### PR TITLE
feat(cli): integrate context usage into input box top border

### DIFF
--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -705,8 +705,6 @@ func (m *cliModel) handleAgentMessage(msg bus.OutboundMessage) {
 		// §11.5 Session reset: clear token usage bar after /new
 		if msg.Metadata != nil && msg.Metadata["session_reset"] == "true" {
 			m.lastTokenUsage = nil
-			m.ctxBarCacheKey = ""
-			m.ctxBarCache = ""
 		}
 
 		// §12 AskUser panel: detect WaitingUser and open interactive panel

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -605,8 +605,6 @@ type cliModel struct {
 	cachedMaxContextTokens int            // max context tokens (from settings/config, cached for View())
 	cachedMaxOutputTokens  int64          // max output tokens (from progress events, cached for View())
 	cachedCompressRatio    float64        // compression threshold ratio, cached for View()
-	ctxBarCache            string         // rendered context bar, invalidated on token data change
-	ctxBarCacheKey         string         // key for cache invalidation (promptTokens + width)
 
 	// === Runner Bridge ===
 	runnerBridge *RunnerBridge

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -88,8 +88,18 @@ func (m *cliModel) renderInputArea(borderColor color.Color) string {
 		}
 	}
 
-	return inputBoxStyle.Render(inputArea)
-}
+	inputRendered := inputBoxStyle.Render(inputArea)
+
+	// Replace top border with context usage progress bar
+	if newTop := m.renderContextTopBorder(borderColor, inputRendered); newTop != "" {
+		_, rest, found := strings.Cut(inputRendered, "\n")
+		if found {
+		return newTop + "\n" + rest
+		}
+	}
+
+	return inputRendered
+	}
 
 // renderReadyStatus builds the "Ready" status bar line with message count,
 // model name, agent session indicator, and right-aligned context usage bar.
@@ -123,10 +133,6 @@ func (m *cliModel) renderReadyStatus() string {
 	}
 	leftParts := strings.Join(readyParts, " · ")
 
-	// Context usage bar (right-aligned)
-	if ctxBar := m.renderContextUsage(); ctxBar != "" {
-		return m.styles.ReadyStatus.Render(padBetween(leftParts, ctxBar, m.width))
-	}
 	return m.styles.ReadyStatus.Render(leftParts)
 }
 
@@ -787,36 +793,13 @@ func (m *cliModel) renderProgressStatus(progressStyle, toolStyle lipgloss.Style)
 		sb.WriteString(formatElapsed(elapsed))
 	}
 
-	// §18 Context usage bar — right-aligned so position stays fixed
-	var ctxBar string
-	if ctxHint := m.renderContextUsage(); ctxHint != "" {
-		ctxBar = ctxHint
-	} else if m.progress != nil && m.progress.TokenUsage != nil && m.progress.TokenUsage.TotalTokens > 0 {
-		// Fallback: raw token count when context bar data is not yet available
-		tu := m.progress.TokenUsage
-		ctxBar = s.TokenUsage.Render(formatTokenCount(tu))
-	}
-
 	// Queue indicator (persistent during typing, not just temp status)
 	if len(m.messageQueue) > 0 {
 		sb.WriteString(" · ")
 		fmt.Fprintf(&sb, m.locale.QueuePending, len(m.messageQueue))
 	}
 
-	leftText := sb.String()
-	if ctxBar != "" {
-		return padBetween(leftText, ctxBar, m.width)
-	}
-	return leftText
-}
-
-// formatTokenCount formats token usage for the fallback status line (when context bar is unavailable).
-// Shows prompt tokens (context fill) as the primary metric.
-func formatTokenCount(tu *CLITokenUsage) string {
-	if tu.PromptTokens < 1000 {
-		return fmt.Sprintf("ctx: %d tokens", tu.PromptTokens)
-	}
-	return fmt.Sprintf("ctx: %s", formatTokenCompact(tu.PromptTokens))
+	return sb.String()
 }
 
 // Pre-created styles for context bar (avoid per-frame allocation).
@@ -844,15 +827,14 @@ var ctxBarStyles = struct {
 	pctRed:     lipgloss.NewStyle().Foreground(lipgloss.Color("#ff6b6b")),
 }
 
-// renderContextUsage returns a context usage bar for the status bar.
-// Uses cached rendering — only recomputes when token data or terminal width changes.
+// renderContextTopBorder replaces the input box top border with a context
+// usage progress bar. The border corners (╭╮) stay in the original border color,
+// while the inner line becomes a segmented progress bar using thin line characters:
 //
-// Shows a segmented progress bar with:
-//   - Filled portion (prompt tokens used) — color-coded by fill ratio
-//   - Output reservation marker (right-side dim segment)
-//   - Compression threshold marker
-//   - Numeric label: "prompt/budget"
-func (m *cliModel) renderContextUsage() string {
+//	─ filled (color-coded) · ─ free (dim) · ┊ threshold (red bold) · ╌ output reservation (dashed dim)
+//
+// Returns empty string when no token data is available (keep original border).
+func (m *cliModel) renderContextTopBorder(borderColor color.Color, renderedBox string) string {
 	if m.lastTokenUsage == nil || m.cachedMaxContextTokens <= 0 {
 		return ""
 	}
@@ -862,10 +844,19 @@ func (m *cliModel) renderContextUsage() string {
 		return ""
 	}
 
-	// Cache key: re-render only when data changes
-	cacheKey := fmt.Sprintf("%d:%d:%d:%d:%g", promptTokens, maxTokens, m.cachedMaxOutputTokens, m.width, m.cachedCompressRatio)
-	if cacheKey == m.ctxBarCacheKey && m.ctxBarCache != "" {
-		return m.ctxBarCache
+	firstLine, _, found := strings.Cut(renderedBox, "\n")
+	if !found {
+		return ""
+	}
+	totalW := lipgloss.Width(firstLine)
+	innerW := totalW - 2 // minus ╭ and ╮
+	if innerW < 6 {
+		return "" // too narrow, keep default
+	}
+
+	pct := float64(promptTokens) / float64(maxTokens)
+	if pct > 1 {
+		pct = 1
 	}
 
 	maxOutputTokens := m.cachedMaxOutputTokens
@@ -877,114 +868,87 @@ func (m *cliModel) renderContextUsage() string {
 		promptBudget = maxTokens / 2
 	}
 
-	// Use cached compression ratio (set during progress events), not GetCurrentValues()
 	compressRatio := m.cachedCompressRatio
 	if compressRatio <= 0 {
 		compressRatio = 0.9
 	}
 	compressThreshold := int64(float64(promptBudget) * compressRatio)
 
-	// Bar width: adapt to terminal width
-	barWidth := 20
-	if m.width > 120 {
-		barWidth = 30
-	}
-	if m.width < 80 {
-		barWidth = 12
+	// Cell counts
+	filledCells := int(float64(innerW) * float64(promptTokens) / float64(maxTokens))
+	if filledCells > innerW {
+		filledCells = innerW
 	}
 
-	promptFill := promptTokens
-	if promptFill > maxTokens {
-		promptFill = maxTokens
-	}
-	filledCells := int(float64(barWidth) * float64(promptFill) / float64(maxTokens))
-	if filledCells > barWidth {
-		filledCells = barWidth
-	}
-
-	outputCells := int(float64(barWidth) * float64(maxOutputTokens) / float64(maxTokens))
+	outputCells := int(float64(innerW) * float64(maxOutputTokens) / float64(maxTokens))
 	if outputCells < 1 {
 		outputCells = 1
 	}
-	if outputCells > barWidth-1 {
-		outputCells = barWidth - 1
+	if outputCells > innerW-1 {
+		outputCells = innerW - 1
 	}
 
-	compressPos := int(float64(barWidth) * float64(compressThreshold) / float64(maxTokens))
+	compressPos := int(float64(innerW) * float64(compressThreshold) / float64(maxTokens))
 	if compressPos < 1 {
 		compressPos = 1
 	}
-	if compressPos >= barWidth {
-		compressPos = barWidth - 1
+	if compressPos >= innerW {
+		compressPos = innerW - 1
 	}
 
-	pct := float64(promptTokens) / float64(maxTokens) * 100
-
-	// Select pre-created style (no allocation)
-	var fillColor, pctStyle lipgloss.Style
+	// Color selection
+	var fillSty lipgloss.Style
 	switch {
-	case pct > 80:
-		fillColor = ctxBarStyles.fillRed
-		pctStyle = ctxBarStyles.pctRed
-	case pct > 50:
-		fillColor = ctxBarStyles.fillYellow
-		pctStyle = ctxBarStyles.pctYellow
+	case pct > 0.8:
+		fillSty = ctxBarStyles.fillRed
+	case pct > 0.5:
+		fillSty = ctxBarStyles.fillYellow
 	default:
-		fillColor = ctxBarStyles.fillGreen
-		pctStyle = ctxBarStyles.pctGreen
+		fillSty = ctxBarStyles.fillGreen
 	}
 
-	// Build bar runes first (single allocation)
-	outputStart := barWidth - outputCells
+	cornerSty := lipgloss.NewStyle().Foreground(borderColor)
+
+	// Build top border
+	var sb strings.Builder
+	sb.WriteString(cornerSty.Render("╭"))
+
+	outputStart := innerW - outputCells
 	if outputStart < filledCells {
 		outputStart = filledCells
 	}
 
-	// Render bar segments as batch strings (3 segments max, not barWidth calls)
-	var barStr strings.Builder
-	// Segment 1: filled area
+	// 1. Filled segment — thin line matching border style
 	if filledCells > 0 {
-		barStr.WriteString(fillColor.Render(strings.Repeat("█", filledCells)))
+		sb.WriteString(fillSty.Render(strings.Repeat("─", filledCells)))
 	}
-	// Segment 2: empty area (may contain threshold marker)
+
+	// 2. Empty segment (may contain threshold marker)
 	emptyStart := filledCells
 	emptyEnd := outputStart
 	if emptyEnd > emptyStart {
 		if compressPos >= emptyStart && compressPos < emptyEnd {
-			// Split empty into two parts around threshold marker
-			before := compressPos - emptyStart
-			after := emptyEnd - compressPos - 1
-			if before > 0 {
-				barStr.WriteString(ctxBarStyles.empty.Render(strings.Repeat("░", before)))
-			}
-			barStr.WriteString(ctxBarStyles.threshold.Render("┊"))
-			if after > 0 {
-				barStr.WriteString(ctxBarStyles.empty.Render(strings.Repeat("░", after)))
-			}
+		before := compressPos - emptyStart
+		after := emptyEnd - compressPos - 1
+		if before > 0 {
+			sb.WriteString(ctxBarStyles.empty.Render(strings.Repeat("─", before)))
+		}
+		sb.WriteString(ctxBarStyles.threshold.Render("┊"))
+		if after > 0 {
+			sb.WriteString(ctxBarStyles.empty.Render(strings.Repeat("─", after)))
+		}
 		} else {
-			barStr.WriteString(ctxBarStyles.empty.Render(strings.Repeat("░", emptyEnd-emptyStart)))
+		sb.WriteString(ctxBarStyles.empty.Render(strings.Repeat("─", emptyEnd-emptyStart)))
 		}
 	}
-	// Segment 3: output reservation
-	if barWidth-outputStart > 0 {
-		barStr.WriteString(ctxBarStyles.dim.Render(strings.Repeat("▒", barWidth-outputStart)))
+
+	// 3. Output reservation — dashed thin line
+	if innerW-outputStart > 0 {
+		sb.WriteString(ctxBarStyles.dim.Render(strings.Repeat("╌", innerW-outputStart)))
 	}
 
-	pctStr := pctStyle.Render(fmt.Sprintf("%.0f%%", pct))
-
-	var result string
-	if m.width < 100 {
-		result = fmt.Sprintf("%s %s", pctStr, barStr.String())
-	} else {
-		usageStr := formatTokenCompact(promptTokens)
-		budgetStr := formatTokenCompact(promptBudget)
-		label := ctxBarStyles.label.Render(fmt.Sprintf("%s/%s", usageStr, budgetStr))
-		result = fmt.Sprintf("%s %s %s", pctStr, barStr.String(), label)
-	}
-
-	m.ctxBarCache = result
-	m.ctxBarCacheKey = cacheKey
-	return result
+	sb.WriteString(cornerSty.Render("╮"))
+	return sb.String()
 }
 
 // formatTokenCompact formats token counts as compact human-readable strings.


### PR DESCRIPTION
## Summary

Replace the standalone context bar/ring with a segmented progress bar embedded in the input box top border line.

## Before / After

**Before**: Context bar floated on status line or as separate ring to the right
**After**: Input box top border IS the progress bar:

```
╭──────────────┊────╌╌╌╌╌╮   ← 顶部边框 = 上下文进度条
│  Type here...         │
╰───────────────────────╯
```

| Segment | Char | Meaning |
|---------|------|---------|
| Filled | `─` (green/yellow/red) | Used prompt tokens |
| Free | `─` (dim gray) | Available space |
| Threshold | `┊` (red bold) | Compression trigger line |
| Output | `╌` (dashed dim) | Output reservation zone |

## Changes

- `cli_view.go`: Delete `renderRing`, `renderContextLine`, `renderContextUsage`, `formatTokenCount`; add `renderContextTopBorder`
- `cli_model.go`: Remove `ctxBarCache`/`ctxBarCacheKey` fields
- `cli_message.go`: Remove cache clearing for deleted fields

Uses thin line characters matching the input box border style throughout.