### PR TITLE
fix: bg task injection fails silently in remote TUI mode

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1126,7 +1126,7 @@ func (a *Agent) resetSessionState(key string) {
 
 // injectCLIUserMessage sends a user message to the CLI channel if available.
 // Used by background notification handlers to display messages in the CLI UI.
-func (a *Agent) injectCLIUserMessage(channelName, content string) {
+func (a *Agent) injectCLIUserMessage(channelName, chatID, content string) {
 	if a.channelFinder == nil {
 		return
 	}
@@ -1134,8 +1134,11 @@ func (a *Agent) injectCLIUserMessage(channelName, content string) {
 	if !ok {
 		return
 	}
-	if cliCh, ok := ch.(*channel.CLIChannel); ok {
-		cliCh.InjectUserMessage(content)
+	switch c := ch.(type) {
+	case *channel.CLIChannel:
+		c.InjectUserMessage(content)
+	case *channel.RemoteCLIChannel:
+		c.InjectUserMessage(chatID, content)
 	}
 }
 
@@ -2164,7 +2167,7 @@ func (a *Agent) processBgNotification(task *tools.BackgroundTask) {
 		"chat_id": chatID,
 	}).Info("Bg task notification: injecting as user message")
 
-	a.injectCLIUserMessage(channelName, content)
+	a.injectCLIUserMessage(channelName, chatID, content)
 	a.injectInbound(channelName, chatID, "user", content)
 }
 
@@ -2197,13 +2200,7 @@ func (a *Agent) processSubAgentBgNotification(n *tools.SubAgentBgNotify) {
 		"channel":  channelName,
 	}).Info("Bg subagent notification: injecting as user message")
 
-	if a.channelFinder != nil {
-		if ch, ok := a.channelFinder(channelName); ok {
-			if cliCh, ok := ch.(*channel.CLIChannel); ok {
-				cliCh.InjectUserMessage(content)
-			}
-		}
-	}
+	a.injectCLIUserMessage(channelName, chatID, content)
 
 	a.injectInbound(channelName, chatID, "user", content)
 }

--- a/agent/backend.go
+++ b/agent/backend.go
@@ -58,6 +58,11 @@ type AgentBackend interface {
 	// CLIProgressPayload and calls the callback.
 	OnProgress(callback func(*channel.CLIProgressPayload))
 
+	// OnInjectUserMessage registers a callback for injected user messages from the server.
+	// LocalBackend: no-op (injected messages flow through CLIChannel directly).
+	// RemoteBackend: converts WS inject_user messages and calls the callback.
+	OnInjectUserMessage(callback func(content string))
+
 	// --- Runtime management (used by CLI settings panel, dispatchers, etc.) ---
 
 	// LLMFactory returns the LLM factory for model management.

--- a/agent/backend_local.go
+++ b/agent/backend_local.go
@@ -139,6 +139,8 @@ func (b *LocalBackend) GetActiveProgress(ch, chatID string) *channel.CLIProgress
 // Dispatcher → CLIChannel.SendProgress path directly.
 func (b *LocalBackend) OnProgress(_ func(*channel.CLIProgressPayload)) {}
 
+func (b *LocalBackend) OnInjectUserMessage(_ func(content string)) {}
+
 func (b *LocalBackend) LLMFactory() *LLMFactory {
 	return b.agent.LLMFactory()
 }

--- a/agent/backend_remote.go
+++ b/agent/backend_remote.go
@@ -78,6 +78,9 @@ type RemoteBackend struct {
 	connState     string // "connected" | "disconnected" | "reconnecting"
 	onConnStateCb func(state string)
 
+	// Injected user message callback (for bg task notifications from server)
+	injectUserCb func(content string)
+
 	// RPC pending calls: requestID → response channel
 	rpcMu      sync.Mutex
 	pending    map[string]chan *rpcResponse
@@ -274,6 +277,13 @@ func (b *RemoteBackend) OnReconnect(callback func()) {
 // Used by CLI to update the header bar connection indicator in real-time.
 func (b *RemoteBackend) OnConnStateChange(callback func(state string)) {
 	b.onConnStateCb = callback
+}
+
+// OnInjectUserMessage registers a callback invoked when the server injects a user
+// message into the CLI (e.g. background task completion notification in remote mode).
+// The CLI displays it as a user message and starts the agent turn display.
+func (b *RemoteBackend) OnInjectUserMessage(callback func(content string)) {
+	b.injectUserCb = callback
 }
 
 // ConnState returns the current connection state string.
@@ -528,6 +538,19 @@ func (b *RemoteBackend) readPump(ctx context.Context) {
 						log.Warn("Received ask_user but no outbound callback registered")
 					}
 				}
+			}
+		case "inject_user":
+			if b.injectUserCb != nil && msg.Content != "" {
+				log.WithField("content_len", len(msg.Content)).Info("RemoteBackend: dispatching inject_user")
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							clipanic.Report("agent.RemoteBackend.OnInjectUserMessage", msg.Content, r)
+							log.WithField("panic", r).Warn("RemoteBackend inject_user callback panicked")
+						}
+					}()
+					b.injectUserCb(msg.Content)
+				}()
 			}
 		}
 	}

--- a/channel/web.go
+++ b/channel/web.go
@@ -1733,6 +1733,20 @@ func (c *RemoteCLIChannel) Start() error { return nil }
 
 func (c *RemoteCLIChannel) Stop() {}
 
+// InjectUserMessage sends an injected user message (e.g. bg task notification)
+// to the remote CLI runner via WebSocket. The runner will display it as a user
+// message in the TUI and use it to start the agent turn display.
+func (c *RemoteCLIChannel) InjectUserMessage(chatID, content string) {
+	wsMsg := wsMessage{
+		Type:    "inject_user",
+		Content: content,
+		TS:      time.Now().Unix(),
+	}
+	if !c.hub.sendToClient(chatID, wsMsg) {
+		log.WithField("chat_id", chatID).Debug("Remote CLI client offline, inject_user buffered")
+	}
+}
+
 // SendProgress sends structured progress to remote CLI clients via the Hub.
 func (c *RemoteCLIChannel) SendProgress(chatID string, payload *WsProgressPayload) {
 	if payload == nil {

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -1448,6 +1448,11 @@ func main() {
 				defer clipanic.Recover("main.remote.OnProgress", p, false)
 				cliCh.SendProgress("cli:"+cliCfg.ChatID, p)
 			})
+			// Register OnInjectUserMessage callback for bg task notifications
+			app.backend.OnInjectUserMessage(func(content string) {
+				defer clipanic.Recover("main.remote.OnInjectUserMessage", content, false)
+				cliCh.InjectUserMessage(content)
+			})
 			// Inject remote bg task callbacks (BgTaskManager is nil in remote mode)
 			bgSessionKey := "cli:" + cliCfg.ChatID
 			cliCh.SetBgTaskRemoteCallbacks(

--- a/cmd/xbot-cli/main_test.go
+++ b/cmd/xbot-cli/main_test.go
@@ -691,6 +691,7 @@ func (b *fakeAgentBackend) Stop()                                               
 func (b *fakeAgentBackend) SendInbound(bus.InboundMessage) error                         { return nil }
 func (b *fakeAgentBackend) OnOutbound(func(bus.OutboundMessage))                         {}
 func (b *fakeAgentBackend) OnProgress(func(*channel.CLIProgressPayload))                 {}
+func (b *fakeAgentBackend) OnInjectUserMessage(func(string))                             {}
 func (b *fakeAgentBackend) Bus() *bus.MessageBus                                         { return nil }
 func (b *fakeAgentBackend) IsRemote() bool                                               { return false }
 func (b *fakeAgentBackend) IsProcessing(string, string) bool                             { return false }

--- a/serverapp/server_test.go
+++ b/serverapp/server_test.go
@@ -124,6 +124,7 @@ func (b fakeBackend) IsRemote() bool                                            
 func (b fakeBackend) IsProcessing(_, _ string) bool                                      { return false }
 func (b fakeBackend) GetActiveProgress(_, _ string) *channel.CLIProgressPayload          { return nil }
 func (b fakeBackend) OnProgress(_ func(*channel.CLIProgressPayload))                     {}
+func (b fakeBackend) OnInjectUserMessage(_ func(string))                                 {}
 func (b fakeBackend) LLMFactory() *agent.LLMFactory                                      { return b.factory }
 func (b fakeBackend) SettingsService() *agent.SettingsService                            { return b.settingsSvc }
 func (b fakeBackend) MultiSession() *session.MultiTenantSession                          { return nil }


### PR DESCRIPTION
## Bug

In remote TUI mode, when a background task completes while the TUI is idle (not in an iteration), the user never sees:
1. The injected user message (bg task completion notification)
2. The agent message iteration

## Root Cause

`injectCLIUserMessage()` on the server side does a type assertion `ch.(*channel.CLIChannel)`, but in remote mode the server's channel is `*channel.RemoteCLIChannel`. The assertion silently fails → injected user message never reaches the CLI runner. Same bug in `processSubAgentBgNotification()`.

## Fix

| Layer | Change |
|-------|--------|
| `agent/agent.go` | `injectCLIUserMessage`: type switch for both `CLIChannel` + `RemoteCLIChannel`, accept `chatID` param |
| `agent/agent.go` | `processSubAgentBgNotification`: reuse `injectCLIUserMessage` helper |
| `channel/web.go` | `RemoteCLIChannel.InjectUserMessage(chatID, content)`: sends `"inject_user"` WS message |
| `agent/backend.go` | `AgentBackend` interface: add `OnInjectUserMessage` |
| `agent/backend_local.go` | `LocalBackend`: no-op impl |
| `agent/backend_remote.go` | `RemoteBackend`: `injectUserCb`, `OnInjectUserMessage`, handle `"inject_user"` in readPump |
| `cmd/xbot-cli/main.go` | Register `OnInjectUserMessage` callback in remote mode |

## Testing
- `go build ./...` ✅
- `go test ./...` ✅
- Pre-push hooks ✅