### PR TITLE
perf(textarea): reduce wrap memoization cache from 10000 to 128

### DIFF
--- a/internal/textarea/textarea.go
+++ b/internal/textarea/textarea.go
@@ -89,6 +89,12 @@ const (
 
 	// XXX: in v2, make max lines dynamic and default max lines configurable.
 	maxLines = 10000
+
+	// wrapCacheCap is the LRU capacity for the soft-wrap memoization cache.
+	// Each entry stores the wrapped result for one (line content, width) pair.
+	// A typical textarea has at most a few dozen logical lines, each at one
+	// width, so 128 is more than sufficient while keeping memory bounded.
+	wrapCacheCap = 128
 )
 
 // Internal messages for clipboard operations.
@@ -429,7 +435,7 @@ func New() Model {
 		MaxWidth:             defaultMaxWidth,
 		Prompt:               lipgloss.ThickBorder().Left + " ",
 		styles:               styles,
-		cache:                memoization.NewMemoCache[line, [][]rune](maxLines),
+		cache:                memoization.NewMemoCache[line, [][]rune](wrapCacheCap),
 		EndOfBufferCharacter: ' ',
 		ShowLineNumbers:      true,
 		useVirtualCursor:     true,
@@ -1386,8 +1392,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.value[m.row] = make([]rune, 0)
 	}
 
-	if m.MaxHeight > 0 && m.MaxHeight != m.cache.Capacity() {
-		m.cache = memoization.NewMemoCache[line, [][]rune](m.MaxHeight)
+	if m.cache == nil {
+		m.cache = memoization.NewMemoCache[line, [][]rune](wrapCacheCap)
 	}
 
 	switch msg := msg.(type) {


### PR DESCRIPTION

## 问题

wrap memoization 缓存容量设为 `maxLines` (10000) 条，但 textarea 通常只有几行到几十行内容。每个 textarea 实例（主输入、panel 编辑器等）都持有独立的 10000 容量缓存，内存浪费严重。

更严重的是，旧代码在 `Update()` 中每次检查 `MaxHeight (99) != cache.Capacity() (10000)`，条件始终为 true，**导致每次按键都重建缓存**，丢失所有已缓存结果。

## 修改

- 新增 `wrapCacheCap = 128` 作为 wrap 缓存的独立 LRU 容量
- 移除 `Update()` 中的缓存重建逻辑（仅在 nil 时创建，防御性检查）
- `maxLines = 10000` 保留给 value slice 容量和行数上限

## 测试

- `go test ./internal/textarea/...` 通过
- 全量 `go test ./...` 通过