### PR TITLE
fix(tui): sync message history on /new and context compression

### DIFF
--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -704,9 +704,13 @@ func (m *cliModel) handleAgentMessage(msg bus.OutboundMessage) {
 		m.renderCacheValid = false
 		m.updateViewportContent()
 
-		// §11.5 Session reset: clear token usage bar after /new
+		// §11.5 Session reset: clear messages and token usage bar after /new
 		if msg.Metadata != nil && msg.Metadata["session_reset"] == "true" {
 			m.lastTokenUsage = nil
+			m.messages = make([]cliMessage, 0, cliMsgBufSize)
+			m.streamingMsgIdx = -1
+			m.invalidateAllCache(true)
+			m.viewport.GotoBottom()
 		}
 
 		// §12 AskUser panel: detect WaitingUser and open interactive panel

--- a/channel/cli_test.go
+++ b/channel/cli_test.go
@@ -537,6 +537,39 @@ func TestCLIModelHandleAgentMessageFeishuCardWithElements(t *testing.T) {
 	}
 }
 
+// TestSessionResetClearsMessages verifies that when the agent responds with
+// session_reset=true (after /new), the CLI clears all messages and resets state.
+func TestSessionResetClearsMessages(t *testing.T) {
+	model := newCLIModel()
+	model.handleResize(80, 24)
+
+	// Simulate existing conversation
+	model.messages = []cliMessage{
+		{role: "user", content: "Hello", timestamp: time.Now(), dirty: true},
+		{role: "assistant", content: "Hi there!", timestamp: time.Now(), dirty: true},
+		{role: "user", content: "/new", timestamp: time.Now(), dirty: true},
+	}
+
+	// Agent responds with session_reset metadata
+	msg := bus.OutboundMessage{
+		Content:   "New session started",
+		IsPartial: false,
+		Metadata:  map[string]string{"session_reset": "true"},
+	}
+	model.handleAgentMessage(msg)
+
+	// Verify ALL messages were cleared (including the session_reset response itself)
+	if len(model.messages) != 0 {
+		t.Fatalf("Expected 0 messages after session_reset, got %d", len(model.messages))
+	}
+	if model.streamingMsgIdx != -1 {
+		t.Errorf("Expected streamingMsgIdx -1, got %d", model.streamingMsgIdx)
+	}
+	if model.lastTokenUsage != nil {
+		t.Error("Expected lastTokenUsage to be nil after session_reset")
+	}
+}
+
 func TestCLIModelHandleAgentMessageEmptyContent(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -375,10 +375,15 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 	}
 
 	// HistoryCompacted: context compression replaced the engine's message list.
-	// Rebuild m.messages from session storage to stay in sync.
+	// Clear stale messages immediately so the user doesn't see outdated content
+	// during the async reload, then rebuild from session storage.
 	// Also clear the token usage bar — compressed context has far fewer tokens.
 	if msg.payload != nil && msg.payload.HistoryCompacted {
 		m.lastTokenUsage = nil
+		m.messages = make([]cliMessage, 0, cliMsgBufSize)
+		m.streamingMsgIdx = -1
+		m.invalidateAllCache(true)
+		m.viewport.GotoBottom()
 		m.reloadMessagesFromSession()
 	}
 


### PR DESCRIPTION

## 问题

1. **`/new` 后旧消息残留**：`/new` 命令只清了 `lastTokenUsage`（token 用量条），`m.messages` 中的旧对话仍然显示在 TUI 中，直到用户手动滚动或 resize。
2. **压缩时异步 reload 空窗期**：context compression 后触发 `reloadMessagesFromSession()` 异步重载，但重载完成前旧消息仍然可见。

这两个问题导致用户在 `/new` 或压缩后看到过时内容，体验不一致。

## 修改

### /new (session_reset)
在 `cli_message.go` 的 `handleAgentMessage` 中，检测到 `session_reset=true` 时：
- 清空 `m.messages`
- 重置 `streamingMsgIdx = -1`
- 调用 `invalidateAllCache(true)` 刷新渲染缓存
- `viewport.GotoBottom()` 滚动到底部

### Context Compression (HistoryCompacted)
在 `cli_update_handlers.go` 的 `handleProgressMsg` 中，检测到 `HistoryCompacted` 时：
- 先清空 `m.messages`（立即清除过时内容）
- 再调 `reloadMessagesFromSession()` 异步加载压缩后的消息

### 测试
- 新增 `TestSessionResetClearsMessages` 验证 `/new` 行为
- 全量 `go test ./...` 通过