### PR TITLE
feat(cli): Duration JSON + provider crash fix + base URL auto-fill

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1086,6 +1086,7 @@ func (a *Agent) Close() error {
 	// Close NotifyCh to unblock bgNotifyLoop goroutine
 	if a.bgTaskMgr != nil && a.bgTaskMgr.NotifyCh != nil {
 		close(a.bgTaskMgr.NotifyCh)
+		a.bgTaskMgr.NotifyCh = nil
 	}
 	// 再关闭数据库连接
 	if a.multiSession != nil {

--- a/agent/backend_config.go
+++ b/agent/backend_config.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"path/filepath"
+	"time"
 
 	"xbot/bus"
 	"xbot/config"
@@ -66,16 +67,16 @@ func (bc BackendConfig) AgentConfig() Config {
 		EmbeddingAPIKey:      embAPIKey,
 		EmbeddingModel:       cfg.Embedding.Model,
 		EmbeddingMaxTokens:   cfg.Embedding.MaxTokens,
-		MCPInactivityTimeout: cfg.Agent.MCPInactivityTimeout,
-		MCPCleanupInterval:   cfg.Agent.MCPCleanupInterval,
-		SessionCacheTimeout:  cfg.Agent.SessionCacheTimeout,
+		MCPInactivityTimeout: time.Duration(cfg.Agent.MCPInactivityTimeout),
+		MCPCleanupInterval:   time.Duration(cfg.Agent.MCPCleanupInterval),
+		SessionCacheTimeout:  time.Duration(cfg.Agent.SessionCacheTimeout),
 		EnableAutoCompress:   cfg.Agent.EffectiveEnableAutoCompress(),
 		MaxContextTokens:     cfg.Agent.MaxContextTokens,
 		CompressionThreshold: cfg.Agent.CompressionThreshold,
 		ContextMode:          ContextMode(cfg.Agent.ContextMode),
 		MaxSubAgentDepth:     cfg.Agent.MaxSubAgentDepth,
 		PurgeOldMessages:     cfg.Agent.PurgeOldMessages,
-		SandboxIdleTimeout:   cfg.Sandbox.IdleTimeout,
+		SandboxIdleTimeout:   time.Duration(cfg.Sandbox.IdleTimeout),
 		PersonaIsolation:     bc.PersonaIsolation,
 		OffloadDir:           offloadDir,
 		MaskDir:              maskDir,

--- a/channel/capability.go
+++ b/channel/capability.go
@@ -36,6 +36,28 @@ const (
 	SettingTypePassword SettingType = "password" // password field (masked display)
 )
 
+// ProviderDefaultURLs maps provider identifiers to their default API base URLs.
+// Used by the settings panel to auto-fill llm_base_url when the user selects a provider.
+// Azure and custom are omitted because their URLs are user-specific.
+var ProviderDefaultURLs = map[string]string{
+	"openai":     "https://api.openai.com/v1",
+	"anthropic":  "https://api.anthropic.com",
+	"openrouter": "https://openrouter.ai/api/v1",
+	"ollama":     "http://localhost:11434/v1",
+	"google":     "https://generativelanguage.googleapis.com/v1beta/openai",
+}
+
+// IsProviderDefaultURL checks whether a URL matches any known provider default,
+// indicating it was auto-filled rather than user-customized.
+func IsProviderDefaultURL(url string) bool {
+	for _, v := range ProviderDefaultURLs {
+		if v == url {
+			return true
+		}
+	}
+	return false
+}
+
 // SettingOption defines an option for select-type settings.
 type SettingOption struct {
 	Label string `json:"label"`

--- a/channel/capability_test.go
+++ b/channel/capability_test.go
@@ -63,6 +63,43 @@ func TestBuildTextSettingsUIEmpty(t *testing.T) {
 	}
 }
 
+func TestProviderDefaultURLs(t *testing.T) {
+	// All expected providers should have URLs
+	expected := []string{"openai", "anthropic", "openrouter", "ollama", "google"}
+	for _, p := range expected {
+		if _, ok := ProviderDefaultURLs[p]; !ok {
+			t.Errorf("ProviderDefaultURLs missing %q", p)
+		}
+	}
+	// Azure and custom should NOT be in the map
+	for _, p := range []string{"azure", "custom"} {
+		if _, ok := ProviderDefaultURLs[p]; ok {
+			t.Errorf("ProviderDefaultURLs should not contain %q", p)
+		}
+	}
+}
+
+func TestIsProviderDefaultURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://api.openai.com/v1", true},
+		{"https://api.anthropic.com", true},
+		{"https://openrouter.ai/api/v1", true},
+		{"http://localhost:11434/v1", true},
+		{"https://generativelanguage.googleapis.com/v1beta/openai", true},
+		{"https://custom.api.example.com/v1", false},
+		{"", false},
+		{"https://api.openai.com/v1/chat", false}, // not an exact match
+	}
+	for _, tt := range tests {
+		if got := IsProviderDefaultURL(tt.url); got != tt.want {
+			t.Errorf("IsProviderDefaultURL(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && len(s) >= len(substr) && search(s, substr)
 }

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -501,6 +501,7 @@ type cliModel struct {
 	approvalDenyInput    textinput.Model                 // deny reason input
 	approvalEnteringDeny bool                            // true when editing deny reason
 	panelValues          map[string]string               // settings panel: current values
+	panelPrevProvider    string                          // previous llm_provider value for base_url auto-fill
 	panelOnSubmit        func(values map[string]string)  // callback on settings submit
 	panelOnAnswer        func(answers map[string]string) // callback on askuser answers (key=index, value=answer)
 	panelOnCancel        func()                          // callback on cancel

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -71,6 +71,16 @@ func (m *cliModel) openSettingsPanel(schema []SettingDefinition, values map[stri
 	}
 	m.panelOnSubmit = onSubmit
 	m.panelOnCancel = nil
+	// Auto-fill base_url on panel open if provider has a known default
+	// and base_url is currently empty (typical for setup wizard).
+	if provider := m.panelValues["llm_provider"]; provider != "" {
+		if m.panelValues["llm_base_url"] == "" {
+			if url, ok := ProviderDefaultURLs[provider]; ok {
+				m.panelValues["llm_base_url"] = url
+			}
+		}
+		m.panelPrevProvider = provider
+	}
 	// Pre-create textarea for editing
 	ta := textarea.New()
 	ta.Placeholder = m.locale.PanelEditPlaceholder
@@ -78,6 +88,26 @@ func (m *cliModel) openSettingsPanel(schema []SettingDefinition, values map[stri
 	ta.SetHeight(1)
 	ta.CharLimit = 200
 	m.panelEditTA = ta
+}
+
+// autoFillBaseURL sets llm_base_url to the provider's default URL when the
+// current base_url is empty or matches a known provider default (i.e., was
+// previously auto-filled). Never overwrites a user's custom URL.
+func (m *cliModel) autoFillBaseURL(provider string) {
+	defaultURL, ok := ProviderDefaultURLs[provider]
+	if !ok {
+		// Provider has no known default (azure, custom) — clear base_url only
+		// if it currently holds a previous provider's auto-filled URL.
+		cur := m.panelValues["llm_base_url"]
+		if cur != "" && IsProviderDefaultURL(cur) {
+			m.panelValues["llm_base_url"] = ""
+		}
+		return
+	}
+	cur := m.panelValues["llm_base_url"]
+	if cur == "" || IsProviderDefaultURL(cur) {
+		m.panelValues["llm_base_url"] = defaultURL
+	}
 }
 
 // openSetupPanel opens the first-run setup wizard as a settings-style panel.
@@ -195,6 +225,7 @@ func (m *cliModel) closePanel() {
 	m.panelCombo = false
 	m.panelSchema = nil
 	m.panelValues = nil
+	m.panelPrevProvider = ""
 	m.panelOnSubmit = nil
 	m.panelItems = nil
 	m.panelTab = 0
@@ -1300,6 +1331,11 @@ func (m *cliModel) updateSettingsPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 					m.panelValues[def.Key] = opts[m.panelComboIdx].Value
 				}
 				m.panelCombo = false
+				// Auto-fill llm_base_url when llm_provider changes via combo
+				if def.Key == "llm_provider" && m.panelValues["llm_provider"] != m.panelPrevProvider {
+					m.autoFillBaseURL(m.panelValues["llm_provider"])
+					m.panelPrevProvider = m.panelValues["llm_provider"]
+				}
 				return true, m, nil
 			case tea.KeySpace:
 				m.panelCombo = false
@@ -1401,6 +1437,11 @@ func (m *cliModel) updateSettingsPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 					m.panelValues[def.Key] = def.Options[idx+1].Value
 				} else if len(def.Options) > 0 {
 					m.panelValues[def.Key] = def.Options[0].Value
+				}
+				// Auto-fill llm_base_url when llm_provider changes via select cycling
+				if def.Key == "llm_provider" && m.panelValues["llm_provider"] != m.panelPrevProvider {
+					m.autoFillBaseURL(m.panelValues["llm_provider"])
+					m.panelPrevProvider = m.panelValues["llm_provider"]
 				}
 				return true, m, nil
 			case SettingTypeCombo:

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -1438,11 +1438,6 @@ func (m *cliModel) updateSettingsPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 				} else if len(def.Options) > 0 {
 					m.panelValues[def.Key] = def.Options[0].Value
 				}
-				// Auto-fill llm_base_url when llm_provider changes via select cycling
-				if def.Key == "llm_provider" && m.panelValues["llm_provider"] != m.panelPrevProvider {
-					m.autoFillBaseURL(m.panelValues["llm_provider"])
-					m.panelPrevProvider = m.panelValues["llm_provider"]
-				}
 				return true, m, nil
 			case SettingTypeCombo:
 				// Open combo dropdown if options available, otherwise edit

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -394,7 +394,7 @@ func localeZH() *UILocale {
 
 			{
 				Key: "llm_provider", Label: "LLM 供应商", Description: "大模型服务提供商",
-				Type: SettingTypeSelect, Category: "LLM", DefaultValue: "openai",
+				Type: SettingTypeCombo, Category: "LLM", DefaultValue: "openai",
 				Options: []SettingOption{
 					{Label: "OpenAI", Value: "openai"},
 					{Label: "Anthropic", Value: "anthropic"},
@@ -414,7 +414,7 @@ func localeZH() *UILocale {
 				Type: SettingTypeText, Category: "LLM",
 			},
 			{
-				Key: "llm_base_url", Label: "Base URL", Description: "API 端点地址（自定义供应商时填写）",
+				Key: "llm_base_url", Label: "Base URL", Description: "API 端点地址（选择供应商时自动填充，也可自定义）",
 				Type: SettingTypeText, Category: "LLM",
 			},
 			{
@@ -775,7 +775,7 @@ func localeEN() *UILocale {
 
 			{
 				Key: "llm_provider", Label: "LLM Provider", Description: "Large language model service provider",
-				Type: SettingTypeSelect, Category: "LLM", DefaultValue: "openai",
+				Type: SettingTypeCombo, Category: "LLM", DefaultValue: "openai",
 				Options: []SettingOption{
 					{Label: "OpenAI", Value: "openai"},
 					{Label: "Anthropic", Value: "anthropic"},
@@ -795,7 +795,7 @@ func localeEN() *UILocale {
 				Type: SettingTypeText, Category: "LLM",
 			},
 			{
-				Key: "llm_base_url", Label: "Base URL", Description: "API endpoint URL (for custom providers)",
+				Key: "llm_base_url", Label: "Base URL", Description: "API endpoint URL (auto-filled on provider selection, or custom)",
 				Type: SettingTypeText, Category: "LLM",
 			},
 			{
@@ -1156,7 +1156,7 @@ func localeJA() *UILocale {
 
 			{
 				Key: "llm_provider", Label: "LLM プロバイダー", Description: "大規模言語モデルサービスプロバイダー",
-				Type: SettingTypeSelect, Category: "LLM", DefaultValue: "openai",
+				Type: SettingTypeCombo, Category: "LLM", DefaultValue: "openai",
 				Options: []SettingOption{
 					{Label: "OpenAI", Value: "openai"},
 					{Label: "Anthropic", Value: "anthropic"},
@@ -1176,7 +1176,7 @@ func localeJA() *UILocale {
 				Type: SettingTypeText, Category: "LLM",
 			},
 			{
-				Key: "llm_base_url", Label: "Base URL", Description: "APIエンドポイントURL（カスタムプロバイダー用）",
+				Key: "llm_base_url", Label: "Base URL", Description: "APIエンドポイントURL（プロバイダー選択時に自動入力、またはカスタム）",
 				Type: SettingTypeText, Category: "LLM",
 			},
 			{

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -2214,10 +2214,10 @@ func createLLM(cfg config.LLMConfig, retryCfg llm.RetryConfig) (llm.LLM, error) 
 		// All other providers (custom, openrouter, ollama, azure, google, deepseek, etc.)
 		// use OpenAI-compatible API — same as LLMFactory.createClient.
 		inner = llm.NewOpenAILLM(llm.OpenAIConfig{
-			BaseURL:        cfg.BaseURL,
-			APIKey:         cfg.APIKey,
-			DefaultModel:   cfg.Model,
-			MaxTokens:      cfg.MaxOutputTokens,
+			BaseURL:      cfg.BaseURL,
+			APIKey:       cfg.APIKey,
+			DefaultModel: cfg.Model,
+			MaxTokens:    cfg.MaxOutputTokens,
 			OnModelsLoadError: func(err error) {
 				select {
 				case channel.ModelsLoadErrorCh() <- err:

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -574,9 +574,9 @@ func newCLIApp(serverURL, token string, forceLocal bool) *cliApp {
 
 	llmClient, err := createLLM(cfg.LLM, llm.RetryConfig{
 		Attempts: uint(cfg.Agent.LLMRetryAttempts),
-		Delay:    cfg.Agent.LLMRetryDelay,
-		MaxDelay: cfg.Agent.LLMRetryMaxDelay,
-		Timeout:  cfg.Agent.LLMRetryTimeout,
+		Delay:    time.Duration(cfg.Agent.LLMRetryDelay),
+		MaxDelay: time.Duration(cfg.Agent.LLMRetryMaxDelay),
+		Timeout:  time.Duration(cfg.Agent.LLMRetryTimeout),
 	})
 	if err != nil {
 		log.WithError(err).Fatal("Failed to create LLM client")
@@ -616,9 +616,9 @@ func newCLIApp(serverURL, token string, forceLocal bool) *cliApp {
 		backend.LLMFactory().SetModelTiers(cfg.LLM)
 		backend.LLMFactory().SetRetryConfig(llm.RetryConfig{
 			Attempts: uint(cfg.Agent.LLMRetryAttempts),
-			Delay:    cfg.Agent.LLMRetryDelay,
-			MaxDelay: cfg.Agent.LLMRetryMaxDelay,
-			Timeout:  cfg.Agent.LLMRetryTimeout,
+			Delay:    time.Duration(cfg.Agent.LLMRetryDelay),
+			MaxDelay: time.Duration(cfg.Agent.LLMRetryMaxDelay),
+			Timeout:  time.Duration(cfg.Agent.LLMRetryTimeout),
 		})
 	}
 
@@ -2211,7 +2211,20 @@ func createLLM(cfg config.LLMConfig, retryCfg llm.RetryConfig) (llm.LLM, error) 
 			MaxTokens:    cfg.MaxOutputTokens,
 		})
 	default:
-		return nil, fmt.Errorf("unsupported LLM provider: %s", cfg.Provider)
+		// All other providers (custom, openrouter, ollama, azure, google, deepseek, etc.)
+		// use OpenAI-compatible API — same as LLMFactory.createClient.
+		inner = llm.NewOpenAILLM(llm.OpenAIConfig{
+			BaseURL:        cfg.BaseURL,
+			APIKey:         cfg.APIKey,
+			DefaultModel:   cfg.Model,
+			MaxTokens:      cfg.MaxOutputTokens,
+			OnModelsLoadError: func(err error) {
+				select {
+				case channel.ModelsLoadErrorCh() <- err:
+				default:
+				}
+			},
+		})
 	}
 	return llm.NewRetryLLM(inner, retryCfg), nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -72,14 +72,14 @@ type OAuthConfig struct {
 
 // SandboxConfig 沙箱配置
 type SandboxConfig struct {
-	Mode        string        `json:"mode"`
-	RemoteMode  string        `json:"remote_mode"`
-	DockerImage string        `json:"docker_image"`
-	HostWorkDir string        `json:"host_work_dir"`
+	Mode        string   `json:"mode"`
+	RemoteMode  string   `json:"remote_mode"`
+	DockerImage string   `json:"docker_image"`
+	HostWorkDir string   `json:"host_work_dir"`
 	IdleTimeout Duration `json:"idle_timeout"`
-	WSPort      int           `json:"ws_port"`
-	AuthToken   string        `json:"auth_token"`
-	PublicURL   string        `json:"public_url"`
+	WSPort      int      `json:"ws_port"`
+	AuthToken   string   `json:"auth_token"`
+	PublicURL   string   `json:"public_url"`
 }
 
 // QQConfig QQ 机器人渠道配置
@@ -218,7 +218,7 @@ type AgentConfig struct {
 
 	MaxSubAgentDepth int `json:"max_sub_agent_depth"`
 
-	LLMRetryAttempts int           `json:"llm_retry_attempts"`
+	LLMRetryAttempts int      `json:"llm_retry_attempts"`
 	LLMRetryDelay    Duration `json:"llm_retry_delay"`
 	LLMRetryMaxDelay Duration `json:"llm_retry_max_delay"`
 	LLMRetryTimeout  Duration `json:"llm_retry_timeout"`
@@ -226,8 +226,8 @@ type AgentConfig struct {
 
 // ServerConfig 服务器配置
 type ServerConfig struct {
-	Host         string        `json:"host"`
-	Port         int           `json:"port"`
+	Host         string   `json:"host"`
+	Port         int      `json:"port"`
 	ReadTimeout  Duration `json:"read_timeout"`
 	WriteTimeout Duration `json:"write_timeout"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,49 @@ func init() {
 	}
 }
 
+// Duration is like time.Duration but serializes to human-readable strings in JSON
+// (e.g. "30m0s" instead of 1800000000000). It accepts both string and number
+// formats when deserializing for backward compatibility with old config files.
+type Duration time.Duration
+
+// Duration constants for use in config defaults and comparisons.
+const (
+	Nanosecond  Duration = 1
+	Microsecond          = 1000 * Nanosecond
+	Millisecond          = 1000 * Microsecond
+	Second               = 1000 * Millisecond
+	Minute               = 60 * Second
+	Hour                 = 60 * Minute
+)
+
+// MarshalJSON implements json.Marshaler.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler. Accepts both human-readable strings
+// ("30m", "1h30m") and legacy nanosecond numbers (1800000000000).
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		dur, err := time.ParseDuration(s)
+		if err != nil {
+			return fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		*d = Duration(dur)
+		return nil
+	}
+	var ns int64
+	if err := json.Unmarshal(b, &ns); err != nil {
+		return fmt.Errorf("duration must be a string like \"30m\" or a number (nanoseconds)")
+	}
+	*d = Duration(ns)
+	return nil
+}
+
 // OAuthConfig OAuth 配置
 type OAuthConfig struct {
 	Enable  bool   `json:"enable"`
@@ -33,7 +76,7 @@ type SandboxConfig struct {
 	RemoteMode  string        `json:"remote_mode"`
 	DockerImage string        `json:"docker_image"`
 	HostWorkDir string        `json:"host_work_dir"`
-	IdleTimeout time.Duration `json:"idle_timeout"`
+	IdleTimeout Duration `json:"idle_timeout"`
 	WSPort      int           `json:"ws_port"`
 	AuthToken   string        `json:"auth_token"`
 	PublicURL   string        `json:"public_url"`
@@ -160,9 +203,9 @@ type AgentConfig struct {
 	PromptFile     string `json:"prompt_file"`
 	SingleUser     bool   `json:"single_user"` // Deprecated: no longer used, kept for config file compatibility
 
-	MCPInactivityTimeout time.Duration `json:"mcp_inactivity_timeout"`
-	MCPCleanupInterval   time.Duration `json:"mcp_cleanup_interval"`
-	SessionCacheTimeout  time.Duration `json:"session_cache_timeout"`
+	MCPInactivityTimeout Duration `json:"mcp_inactivity_timeout"`
+	MCPCleanupInterval   Duration `json:"mcp_cleanup_interval"`
+	SessionCacheTimeout  Duration `json:"session_cache_timeout"`
 
 	ContextMode string `json:"context_mode"`
 	// EnableAutoCompress 为 nil 表示 JSON 未写该字段，Load 后与未设置 AGENT_ENABLE_AUTO_COMPRESS 一致，默认启用压缩。
@@ -176,17 +219,17 @@ type AgentConfig struct {
 	MaxSubAgentDepth int `json:"max_sub_agent_depth"`
 
 	LLMRetryAttempts int           `json:"llm_retry_attempts"`
-	LLMRetryDelay    time.Duration `json:"llm_retry_delay"`
-	LLMRetryMaxDelay time.Duration `json:"llm_retry_max_delay"`
-	LLMRetryTimeout  time.Duration `json:"llm_retry_timeout"`
+	LLMRetryDelay    Duration `json:"llm_retry_delay"`
+	LLMRetryMaxDelay Duration `json:"llm_retry_max_delay"`
+	LLMRetryTimeout  Duration `json:"llm_retry_timeout"`
 }
 
 // ServerConfig 服务器配置
 type ServerConfig struct {
 	Host         string        `json:"host"`
 	Port         int           `json:"port"`
-	ReadTimeout  time.Duration `json:"read_timeout"`
-	WriteTimeout time.Duration `json:"write_timeout"`
+	ReadTimeout  Duration `json:"read_timeout"`
+	WriteTimeout Duration `json:"write_timeout"`
 }
 
 // LLMConfig LLM 配置
@@ -376,18 +419,18 @@ func splitCommaTrim(s string) []string {
 	return out
 }
 
-func setDurationEnv(key string, dst *time.Duration) {
+func setDurationEnv(key string, dst *Duration) {
 	if v := os.Getenv(key); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
-			*dst = d
+			*dst = Duration(d)
 		}
 	}
 }
 
-func setSecondsEnv(key string, dst *time.Duration) {
+func setSecondsEnv(key string, dst *Duration) {
 	if v := os.Getenv(key); v != "" {
 		if sec, err := strconv.Atoi(v); err == nil {
-			*dst = time.Duration(sec) * time.Second
+			*dst = Duration(sec) * Second
 		}
 	}
 }
@@ -522,7 +565,7 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v := os.Getenv("SANDBOX_IDLE_TIMEOUT_MINUTES"); v != "" {
 		if min, err := strconv.Atoi(v); err == nil {
-			cfg.Sandbox.IdleTimeout = time.Duration(min) * time.Minute
+			cfg.Sandbox.IdleTimeout = Duration(min) * Minute
 		}
 	}
 	if v := os.Getenv("SANDBOX_WS_PORT"); v != "" {
@@ -743,31 +786,31 @@ func Load() *Config {
 		cfg.Agent.MaxConcurrency = 3
 	}
 	if cfg.Agent.MCPInactivityTimeout == 0 {
-		cfg.Agent.MCPInactivityTimeout = 30 * time.Minute
+		cfg.Agent.MCPInactivityTimeout = 30 * Minute
 	}
 	if cfg.Agent.MCPCleanupInterval == 0 {
-		cfg.Agent.MCPCleanupInterval = 5 * time.Minute
+		cfg.Agent.MCPCleanupInterval = 5 * Minute
 	}
 	if cfg.Agent.SessionCacheTimeout == 0 {
-		cfg.Agent.SessionCacheTimeout = 24 * time.Hour
+		cfg.Agent.SessionCacheTimeout = 24 * Hour
 	}
 	if cfg.Agent.LLMRetryAttempts == 0 {
 		cfg.Agent.LLMRetryAttempts = 5
 	}
 	if cfg.Agent.LLMRetryDelay == 0 {
-		cfg.Agent.LLMRetryDelay = 1 * time.Second
+		cfg.Agent.LLMRetryDelay = 1 * Second
 	}
 	if cfg.Agent.LLMRetryMaxDelay == 0 {
-		cfg.Agent.LLMRetryMaxDelay = 30 * time.Second
+		cfg.Agent.LLMRetryMaxDelay = 30 * Second
 	}
 	if cfg.Agent.LLMRetryTimeout == 0 {
-		cfg.Agent.LLMRetryTimeout = 120 * time.Second
+		cfg.Agent.LLMRetryTimeout = 120 * Second
 	}
 	if cfg.Sandbox.Mode == "" {
 		cfg.Sandbox.Mode = "none"
 	}
 	if cfg.Sandbox.IdleTimeout == 0 {
-		cfg.Sandbox.IdleTimeout = 30 * time.Minute
+		cfg.Sandbox.IdleTimeout = 30 * Minute
 	}
 	if cfg.Sandbox.DockerImage == "" {
 		cfg.Sandbox.DockerImage = "ubuntu:22.04"
@@ -833,10 +876,10 @@ func Load() *Config {
 		cfg.Server.Port = cfg.Web.Port // 8082
 	}
 	if cfg.Server.ReadTimeout == 0 {
-		cfg.Server.ReadTimeout = 30 * time.Second
+		cfg.Server.ReadTimeout = 30 * Second
 	}
 	if cfg.Server.WriteTimeout == 0 {
-		cfg.Server.WriteTimeout = 120 * time.Second
+		cfg.Server.WriteTimeout = 120 * Second
 	}
 	if cfg.Admin.ChatID == "" {
 		cfg.Admin.ChatID = getAdminChatID()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSubscriptionConfigRoundtrip(t *testing.T) {
@@ -298,5 +299,164 @@ func TestSaveToFileLoadSaveRoundtrip(t *testing.T) {
 	}
 	if cfg3.Feishu.AppID != "test-app" {
 		t.Errorf("feishu app_id lost: got %q", cfg3.Feishu.AppID)
+	}
+}
+
+func TestDurationMarshalJSON(t *testing.T) {
+	tests := []struct {
+		d    Duration
+		want string
+	}{
+		{1 * Second, `"1s"`},
+		{30 * Minute, `"30m0s"`},
+		{24 * Hour, `"24h0m0s"`},
+		{1500 * Millisecond, `"1.5s"`},
+		{0, `"0s"`},
+	}
+	for _, tt := range tests {
+		data, err := tt.d.MarshalJSON()
+		if err != nil {
+			t.Errorf("MarshalJSON(%v): %v", tt.d, err)
+			continue
+		}
+		if string(data) != tt.want {
+			t.Errorf("MarshalJSON(%v) = %s, want %s", tt.d, string(data), tt.want)
+		}
+	}
+}
+
+func TestDurationUnmarshalJSON_String(t *testing.T) {
+	tests := []struct {
+		input string
+		want  Duration
+	}{
+		{`"1s"`, 1 * Second},
+		{`"30m0s"`, 30 * Minute},
+		{`"30m"`, 30 * Minute},
+		{`"2h"`, 2 * Hour},
+		{`"0s"`, 0},
+	}
+	for _, tt := range tests {
+		var d Duration
+		if err := d.UnmarshalJSON([]byte(tt.input)); err != nil {
+			t.Errorf("UnmarshalJSON(%s): %v", tt.input, err)
+			continue
+		}
+		if d != tt.want {
+			t.Errorf("UnmarshalJSON(%s) = %v, want %v", tt.input, time.Duration(d), time.Duration(tt.want))
+		}
+	}
+}
+
+func TestDurationUnmarshalJSON_Number(t *testing.T) {
+	// Old config files store durations as nanoseconds (backward compat)
+	tests := []struct {
+		input string
+		want  Duration
+	}{
+		{"0", 0},
+		{`1000000000`, 1 * Second},
+		{`1800000000000`, 30 * Minute},
+	}
+	for _, tt := range tests {
+		var d Duration
+		if err := d.UnmarshalJSON([]byte(tt.input)); err != nil {
+			t.Errorf("UnmarshalJSON(%s): %v", tt.input, err)
+			continue
+		}
+		if d != tt.want {
+			t.Errorf("UnmarshalJSON(%s) = %v, want %v", tt.input, time.Duration(d), time.Duration(tt.want))
+		}
+	}
+}
+
+func TestDurationUnmarshalJSON_Invalid(t *testing.T) {
+	var d Duration
+	if err := d.UnmarshalJSON([]byte(`"xyz"`)); err == nil {
+		t.Error("expected error for invalid duration string")
+	}
+	if err := d.UnmarshalJSON([]byte(`true`)); err == nil {
+		t.Error("expected error for boolean")
+	}
+}
+
+func TestConfigDurationRoundtrip(t *testing.T) {
+	// Verify Duration fields serialize as strings and deserialize correctly
+	cfg := &Config{
+		Sandbox: SandboxConfig{
+			Mode:        "docker",
+			IdleTimeout: 30 * Minute,
+		},
+		Agent: AgentConfig{
+			MCPInactivityTimeout: 30 * Minute,
+			MCPCleanupInterval:   5 * Minute,
+			LLMRetryDelay:        1 * Second,
+		},
+		Server: ServerConfig{
+			ReadTimeout:  30 * Second,
+			WriteTimeout: 120 * Second,
+		},
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	content := string(data)
+
+	// Verify human-readable strings in JSON output
+	for _, want := range []string{
+		`"idle_timeout": "30m0s"`,
+		`"mcp_inactivity_timeout": "30m0s"`,
+		`"mcp_cleanup_interval": "5m0s"`,
+		`"llm_retry_delay": "1s"`,
+		`"read_timeout": "30s"`,
+		`"write_timeout": "2m0s"`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("JSON output missing %s:\n%s", want, content)
+		}
+	}
+
+	// Verify round-trip deserialization
+	var cfg2 Config
+	if err := json.Unmarshal(data, &cfg2); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if cfg2.Sandbox.IdleTimeout != 30*Minute {
+		t.Errorf("IdleTimeout roundtrip: got %v, want 30m", time.Duration(cfg2.Sandbox.IdleTimeout))
+	}
+	if cfg2.Agent.LLMRetryDelay != 1*Second {
+		t.Errorf("LLMRetryDelay roundtrip: got %v, want 1s", time.Duration(cfg2.Agent.LLMRetryDelay))
+	}
+	if cfg2.Server.ReadTimeout != 30*Second {
+		t.Errorf("ReadTimeout roundtrip: got %v, want 30s", time.Duration(cfg2.Server.ReadTimeout))
+	}
+}
+
+func TestConfigDurationBackwardCompat(t *testing.T) {
+	// Old config files with nanosecond numbers must still parse
+	oldJSON := `{
+  "sandbox": {
+    "idle_timeout": 1800000000000
+  },
+  "agent": {
+    "mcp_inactivity_timeout": 1800000000000,
+    "llm_retry_delay": 1000000000
+  },
+  "server": {
+    "read_timeout": 30000000000,
+    "write_timeout": 120000000000
+  }
+}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(oldJSON), &cfg); err != nil {
+		t.Fatalf("Unmarshal old format: %v", err)
+	}
+	if cfg.Sandbox.IdleTimeout != 30*Minute {
+		t.Errorf("IdleTimeout: got %v, want 30m", time.Duration(cfg.Sandbox.IdleTimeout))
+	}
+	if cfg.Agent.LLMRetryDelay != 1*Second {
+		t.Errorf("LLMRetryDelay: got %v, want 1s", time.Duration(cfg.Agent.LLMRetryDelay))
 	}
 }

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -160,6 +160,9 @@ func createAdminLLM(cfg *config.Config) (llm_pkg.LLM, error) {
 			APIKey:       cfg.LLM.APIKey,
 			DefaultModel: cfg.LLM.Model,
 			MaxTokens:    cfg.LLM.MaxOutputTokens,
+			OnModelsLoadError: func(err error) {
+				log.WithError(err).Warn("Failed to load models list (admin LLM)")
+			},
 		}), nil
 	}
 }
@@ -816,6 +819,9 @@ func createLLM(cfg config.LLMConfig, retryCfg llm_pkg.RetryConfig) (llm_pkg.LLM,
 			BaseURL:      cfg.BaseURL,
 			APIKey:       cfg.APIKey,
 			DefaultModel: cfg.Model,
+			OnModelsLoadError: func(err error) {
+				log.WithError(err).Warn("Failed to load models list")
+			},
 		})
 	}
 

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -153,14 +153,14 @@ func createAdminLLM(cfg *config.Config) (llm_pkg.LLM, error) {
 			MaxTokens:    cfg.LLM.MaxOutputTokens,
 		}), nil
 	default:
-			// All other providers (custom, openrouter, ollama, azure, google, deepseek, etc.)
-			// use OpenAI-compatible API — same as LLMFactory.createClient.
-			return llm_pkg.NewOpenAILLM(llm_pkg.OpenAIConfig{
-				BaseURL:      cfg.LLM.BaseURL,
-				APIKey:       cfg.LLM.APIKey,
-				DefaultModel: cfg.LLM.Model,
-				MaxTokens:    cfg.LLM.MaxOutputTokens,
-			}), nil
+		// All other providers (custom, openrouter, ollama, azure, google, deepseek, etc.)
+		// use OpenAI-compatible API — same as LLMFactory.createClient.
+		return llm_pkg.NewOpenAILLM(llm_pkg.OpenAIConfig{
+			BaseURL:      cfg.LLM.BaseURL,
+			APIKey:       cfg.LLM.APIKey,
+			DefaultModel: cfg.LLM.Model,
+			MaxTokens:    cfg.LLM.MaxOutputTokens,
+		}), nil
 	}
 }
 

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -97,9 +97,9 @@ func setupLogging(cfg *config.Config) {
 func setupLLM(cfg *config.Config) (llm_pkg.LLM, error) {
 	return createLLM(cfg.LLM, llm_pkg.RetryConfig{
 		Attempts: uint(cfg.Agent.LLMRetryAttempts),
-		Delay:    cfg.Agent.LLMRetryDelay,
-		MaxDelay: cfg.Agent.LLMRetryMaxDelay,
-		Timeout:  cfg.Agent.LLMRetryTimeout,
+		Delay:    time.Duration(cfg.Agent.LLMRetryDelay),
+		MaxDelay: time.Duration(cfg.Agent.LLMRetryMaxDelay),
+		Timeout:  time.Duration(cfg.Agent.LLMRetryTimeout),
 	})
 }
 
@@ -153,7 +153,14 @@ func createAdminLLM(cfg *config.Config) (llm_pkg.LLM, error) {
 			MaxTokens:    cfg.LLM.MaxOutputTokens,
 		}), nil
 	default:
-		return nil, fmt.Errorf("unsupported LLM provider: %s", cfg.LLM.Provider)
+			// All other providers (custom, openrouter, ollama, azure, google, deepseek, etc.)
+			// use OpenAI-compatible API — same as LLMFactory.createClient.
+			return llm_pkg.NewOpenAILLM(llm_pkg.OpenAIConfig{
+				BaseURL:      cfg.LLM.BaseURL,
+				APIKey:       cfg.LLM.APIKey,
+				DefaultModel: cfg.LLM.Model,
+				MaxTokens:    cfg.LLM.MaxOutputTokens,
+			}), nil
 	}
 }
 
@@ -545,9 +552,9 @@ func Run(args []string) error {
 	backend.LLMFactory().SetModelTiers(cfg.LLM)
 	backend.LLMFactory().SetRetryConfig(llm_pkg.RetryConfig{
 		Attempts: uint(cfg.Agent.LLMRetryAttempts),
-		Delay:    cfg.Agent.LLMRetryDelay,
-		MaxDelay: cfg.Agent.LLMRetryMaxDelay,
-		Timeout:  cfg.Agent.LLMRetryTimeout,
+		Delay:    time.Duration(cfg.Agent.LLMRetryDelay),
+		MaxDelay: time.Duration(cfg.Agent.LLMRetryMaxDelay),
+		Timeout:  time.Duration(cfg.Agent.LLMRetryTimeout),
 	})
 
 	tokenDB, err := sqlite.Open(dbPath)
@@ -803,7 +810,13 @@ func createLLM(cfg config.LLMConfig, retryCfg llm_pkg.RetryConfig) (llm_pkg.LLM,
 			DefaultModel: cfg.Model,
 		})
 	default:
-		return nil, fmt.Errorf("unknown LLM provider: %s", cfg.Provider)
+		// All other providers (custom, openrouter, ollama, azure, google, deepseek, etc.)
+		// use OpenAI-compatible API — same as LLMFactory.createClient.
+		inner = llm_pkg.NewOpenAILLM(llm_pkg.OpenAIConfig{
+			BaseURL:      cfg.BaseURL,
+			APIKey:       cfg.APIKey,
+			DefaultModel: cfg.Model,
+		})
 	}
 
 	return llm_pkg.NewRetryLLM(inner, retryCfg), nil


### PR DESCRIPTION
## Summary
- **config.Duration**: Custom type that serializes `time.Duration` as human-readable strings (`"30m0s"`) in config.json, with backward-compatible nanosecond number deserialization. Makes config.json readable and safe to edit manually.
- **Provider crash fix**: `createLLM` and `createAdminLLM` now use OpenAI-compatible fallback for all non-anthropic providers (openrouter, ollama, azure, deepseek, custom, etc.) instead of fatal exit on unknown provider — matching the runtime `LLMFactory.createClient` path.
- **Agent.Close() double-close fix**: Prevent "close of closed channel" panic by nil-ing `NotifyCh` after close.
- **Base URL auto-fill**: Setup wizard auto-populates `llm_base_url` with provider defaults (OpenAI, Anthropic, OpenRouter, Ollama, Google). Custom URLs are preserved — only auto-filled defaults get overwritten on provider switch.
- **Provider selector UX**: Changed from cycling `SettingTypeSelect` to dropdown `SettingTypeCombo` for the 7-option provider list.

## Test plan
- [ ] `make build` and `make test` pass
- [ ] Run `xbot-cli`, enter setup wizard, verify base URL auto-fills for OpenAI default
- [ ] Switch provider via dropdown — verify base URL updates (OpenAI → Anthropic → Ollama etc.)
- [ ] Switch to Azure/Custom — verify auto-filled URL clears, custom URL preserved
- [ ] Manually edit base_url to a custom URL, then switch provider — verify custom URL not overwritten
- [ ] Verify config.json Duration fields are human-readable strings after save
- [ ] Verify old config.json with nanosecond number durations still loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)