### PR TITLE
fix(test): make TestChatHistoryStore_EvictOldest platform-independent

### DIFF
--- a/tools/chat_history_test.go
+++ b/tools/chat_history_test.go
@@ -173,10 +173,22 @@ func TestChatHistoryStore_EvictOldest(t *testing.T) {
 		t.Error("expected messages in recently added channel after eviction")
 	}
 
-	// Some early channels should have been evicted
-	msgsEarly := s.Get("feishu", "chat_evict_0", 0)
-	if msgsEarly != nil {
-		t.Error("expected earliest channel to be evicted")
+	// After adding defaultMaxChannels+100 channels, eviction should have
+	// reduced the map to at most defaultMaxChannels. We can't assert which
+	// specific channel was evicted because time.Now() precision varies
+	// across platforms (Windows ~15ms, Linux ~1µs) and eviction is time-based.
+	// Instead, verify the size invariant holds.
+	s.mu.RLock()
+	count := len(s.history)
+	s.mu.RUnlock()
+	if count > defaultMaxChannels {
+		t.Errorf("expected at most %d channels after eviction, got %d", defaultMaxChannels, count)
+	}
+
+	// Some channels should have been evicted — not all 10100 can fit
+	evicted := (defaultMaxChannels + 100) - count
+	if evicted < 1 {
+		t.Error("expected at least 1 channel to be evicted")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix flaky Windows CI failure in `TestChatHistoryStore_EvictOldest`.

## Root Cause

The test asserted that `chat_evict_0` was evicted based on `time.Now()` ordering. On Windows, `time.Now()` has ~15ms precision, so all 10000+ channels created in <1s get identical timestamps. `evictOldestLocked()` picks a random one among equals, making the assertion non-deterministic.

## Fix

Replace time-order assertion with size invariant check:
- Map size must be `<= defaultMaxChannels` after eviction
- At least 1 channel must have been evicted

## Test

- [x] 5 consecutive runs pass on Linux
- [x] golangci-lint clean
- [ ] Windows CI (pending)