### PR TITLE
feat(cli): TUI experience overhaul — command palette v2, categories, external commands, responsive layout

### DIFF
--- a/agent/engine_run.go
+++ b/agent/engine_run.go
@@ -402,6 +402,23 @@ func (s *runState) updateTokenUsage() {
 	}
 }
 
+// updateTokenUsageEstimate updates TokenUsage with a local estimate after compression.
+// After ResetAfterCompress(), the tracker has zero values — we use the estimate from
+// the compression pipeline so the CLI context bar shows the reduced token count
+// immediately instead of disappearing until the next API call.
+func (s *runState) updateTokenUsageEstimate(estimatedTokens int64) {
+	if s.structuredProgress == nil {
+		return
+	}
+	s.structuredProgress.TokenUsage = &TokenUsageSnapshot{
+		PromptTokens:     estimatedTokens,
+		CompletionTokens: 0,
+		TotalTokens:      estimatedTokens,
+		CacheHitTokens:   0,
+		MaxOutputTokens:  int64(s.cfg.MaxOutputTokens),
+	}
+}
+
 // callLLM invokes the LLM with the current messages, handling per-tenant
 // concurrency semaphore and input-too-long errors with forced compression.
 func (s *runState) callLLM(ctx context.Context, retryNotifyCtx context.Context) (*llm.LLMResponse, error) {
@@ -476,6 +493,8 @@ func (s *runState) handleInputTooLong(ctx context.Context, retryNotifyCtx contex
 		return nil, compressErr
 	}
 	s.messages = pipelineResult.NewMessages
+	// Update token estimate so CLI shows reduced context immediately
+	s.updateTokenUsageEstimate(pipelineResult.NewTokenCount)
 	if s.autoNotify {
 		s.progressLines = append(s.progressLines, fmt.Sprintf("> ✅ 强制压缩完成 → %d tokens (estimated)", pipelineResult.NewTokenCount))
 		s.notifyProgress("")
@@ -608,6 +627,8 @@ func (s *runState) handleFinalResponse(ctx context.Context, response *llm.LLMRes
 				} else {
 					s.messages = pipelineResult.NewMessages
 					s.validateInvariantsAt(ctx, "post_compress_window_exceeded")
+					// Update token estimate so CLI shows reduced context immediately
+					s.updateTokenUsageEstimate(pipelineResult.NewTokenCount)
 					log.Ctx(ctx).WithFields(log.Fields{
 						"new_msg_count": len(s.messages),
 						"retry":         s.compressRetryCount,
@@ -837,6 +858,10 @@ func (s *runState) runCompression(ctx context.Context, cm ContextManager, totalT
 	s.messages = pipelineResult.NewMessages
 	s.lastCompressIter = s.compressAttempts
 	s.validateInvariantsAt(ctx, "post_compress")
+	// Update token usage estimate so progress events show reduced tokens
+	// immediately instead of showing 0 (from ResetAfterCompress) or stale
+	// pre-compress values until the next LLM API call.
+	s.updateTokenUsageEstimate(pipelineResult.NewTokenCount)
 
 	oldTokenCount := totalTokens
 
@@ -937,6 +962,10 @@ func (s *runState) aggressiveTruncate(ctx context.Context) bool {
 	if s.tokenTracker != nil {
 		s.tokenTracker.ResetAfterCompress()
 	}
+
+	// Update token estimate from local count so CLI shows reduced context
+	estimatedTokens, _ := llm.CountMessagesTokens(newMessages, s.cfg.Model)
+	s.updateTokenUsageEstimate(int64(estimatedTokens))
 
 	// Persist the truncated history
 	if s.persistence != nil {

--- a/agent/engine_run.go
+++ b/agent/engine_run.go
@@ -56,14 +56,14 @@ type runState struct {
 	tokenTracker *TokenTracker
 
 	// Loop state
-	toolsUsed            []string
-	waitingUser          bool
-	waitingQuestion      string
-	waitingMetadata      map[string]string
-	lastContent          string
-	disableCompressRetry bool
-	compressAttempts     int
-	lastCompressIter     int
+	toolsUsed          []string
+	waitingUser        bool
+	waitingQuestion    string
+	waitingMetadata    map[string]string
+	lastContent        string
+	compressRetryCount int
+	compressAttempts   int
+	lastCompressIter   int
 
 	// Metrics (local counters for this Run)
 	localIterCount    int
@@ -578,14 +578,18 @@ func (s *runState) handleFinalResponse(ctx context.Context, response *llm.LLMRes
 	if !response.HasToolCalls() {
 		// context_window_exceeded: force compress and retry
 		if response.FinishReason == llm.FinishReasonContextWindowExceeded {
+			const maxCompressRetries = 3
 			log.Ctx(ctx).WithFields(log.Fields{
 				"msg_count":          len(s.messages),
 				"last_prompt_tokens": s.tokenTracker.PromptTokens(),
 				"finish_reason":      response.FinishReason,
+				"compress_retry":     s.compressRetryCount,
 			}).Warn("Model context window exceeded, forcing compression and retry")
+
+			// Phase 1: Try LLM-based compression (up to maxCompressRetries times)
 			cm := s.cfg.ContextManager
-			if cm != nil && !s.disableCompressRetry {
-				s.disableCompressRetry = true
+			if cm != nil && s.compressRetryCount < maxCompressRetries {
+				s.compressRetryCount++
 				if s.cfg.MemoryToolDefs != nil && s.cfg.MemoryToolExec != nil {
 					cm.SetMemoryTools(s.cfg.MemoryToolDefs, s.cfg.MemoryToolExec)
 				}
@@ -598,17 +602,29 @@ func (s *runState) handleFinalResponse(ctx context.Context, response *llm.LLMRes
 					Persistence:     s.persistence,
 					AccumulateUsage: s.accumulateCompressUsage,
 					SyncMessages:    s.syncMessages,
-					// No OffloadStore/MaskStore cleaning for context_window_exceeded
 				})
 				if compressErr != nil {
-					log.Ctx(ctx).WithError(compressErr).Warn("Forced compression failed after context_window_exceeded")
+					log.Ctx(ctx).WithError(compressErr).Warn("Compression failed after context_window_exceeded, trying aggressive truncation")
 				} else {
 					s.messages = pipelineResult.NewMessages
 					s.validateInvariantsAt(ctx, "post_compress_window_exceeded")
-					log.Ctx(ctx).Info("Forced compression completed after context_window_exceeded, retrying")
+					log.Ctx(ctx).WithFields(log.Fields{
+						"new_msg_count": len(s.messages),
+						"retry":         s.compressRetryCount,
+					}).Info("Compression completed after context_window_exceeded, retrying")
 					return nil, true // retry loop iteration
 				}
 			}
+
+			// Phase 2: Aggressive truncation — keep system messages + last N messages
+			if truncated := s.aggressiveTruncate(ctx); truncated {
+				log.Ctx(ctx).WithFields(log.Fields{
+					"new_msg_count": len(s.messages),
+				}).Warn("Applied aggressive truncation after compression retries exhausted, retrying")
+				return nil, true // retry loop iteration
+			}
+
+			// Phase 3: All recovery attempts failed
 			out := s.buildOutput(&bus.OutboundMessage{
 				Channel:   s.cfg.Channel,
 				ChatID:    s.cfg.ChatID,
@@ -872,6 +888,70 @@ func (s *runState) runCompression(ctx context.Context, cm ContextManager, totalT
 	if hook := cm.SessionHook(); hook != nil {
 		hook.AfterPersist(ctx, s.cfg.Session, pipelineResult.CompressOutput)
 	}
+}
+
+// aggressiveTruncate performs emergency context truncation when all compression
+// retries have failed. It keeps system messages + the last few conversation
+// turns, discarding everything in between. Returns true if truncation was applied.
+func (s *runState) aggressiveTruncate(ctx context.Context) bool {
+	const keepTailMessages = 6 // keep last 6 messages (~3 turns)
+	msgs := s.messages
+	if len(msgs) <= keepTailMessages+1 {
+		// Already too few messages to truncate further
+		return false
+	}
+
+	// Separate system messages from conversation
+	var systemMsgs []llm.ChatMessage
+	var conversationMsgs []llm.ChatMessage
+	for _, m := range msgs {
+		if m.Role == "system" {
+			systemMsgs = append(systemMsgs, m)
+		} else {
+			conversationMsgs = append(conversationMsgs, m)
+		}
+	}
+
+	if len(conversationMsgs) <= keepTailMessages {
+		return false // nothing to truncate
+	}
+
+	// Keep: system messages + last keepTailMessages conversation messages
+	tailMsgs := conversationMsgs[len(conversationMsgs)-keepTailMessages:]
+	newMessages := make([]llm.ChatMessage, 0, len(systemMsgs)+1+len(tailMsgs))
+	newMessages = append(newMessages, systemMsgs...)
+
+	// Insert a notice about the truncation so the model knows context was lost
+	newMessages = append(newMessages, llm.ChatMessage{
+		Role: "system",
+		Content: "[System notice: Earlier conversation history was truncated due to context " +
+			"window limits. Some earlier context may be lost. Continue from the " +
+			"remaining conversation below.]",
+	})
+	newMessages = append(newMessages, tailMsgs...)
+
+	oldCount := len(msgs)
+	s.messages = s.syncMessages(newMessages)
+
+	// Reset token tracker so the next iteration gets fresh data from the API
+	if s.tokenTracker != nil {
+		s.tokenTracker.ResetAfterCompress()
+	}
+
+	// Persist the truncated history
+	if s.persistence != nil {
+		s.persistence.RewriteAfterCompress(
+			newMessages, len(newMessages),
+		)
+	}
+
+	log.Ctx(ctx).WithFields(log.Fields{
+		"old_msg_count": oldCount,
+		"new_msg_count": len(s.messages),
+		"kept_tail":     keepTailMessages,
+	}).Warn("Aggressive truncation applied")
+
+	return true
 }
 
 // executeToolCalls runs all tool calls from the LLM response.

--- a/channel/cli.go
+++ b/channel/cli.go
@@ -721,6 +721,9 @@ func (c *CLIChannel) updateBgTaskCountFn() {
 	if c.config.IsAdminFn != nil {
 		c.model.isAdminFn = c.config.IsAdminFn
 	}
+	if c.config.PaletteContributor != nil {
+		c.model.paletteContributor = c.config.PaletteContributor
+	}
 }
 
 // CheckUpdateAsync starts a background goroutine to check for updates.

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -557,12 +557,14 @@ type cliModel struct {
 	llmSubscriber            LLMSubscriber       // injected by CLIChannel
 
 	// --- §23 Command Palette (Ctrl+K) ---
-	paletteOpen     bool             // true = command palette overlay is active
-	paletteInput    textinput.Model  // filter input
-	paletteItems    []paletteCommand // all available commands
-	paletteFiltered []paletteCommand // commands after fuzzy filter
-	paletteCursor   int              // selected index in filtered list
-	paletteScrollY  int              // scroll offset for visible items
+	paletteOpen           bool               // true = command palette overlay is active
+	paletteInput          textinput.Model    // filter input
+	paletteItems          []paletteCommand   // all available commands
+	paletteFiltered       []paletteCommand   // commands after fuzzy filter
+	paletteCursor         int                // selected index in filtered list
+	paletteScrollY        int                // scroll offset for visible items
+	paletteActiveCategory PaletteCategory    // active category tab (empty = all)
+	paletteContributor    PaletteContributor // external command provider (plugins/skills/agents)
 
 	// --- §16 Subscription generation guard ---
 	// subGeneration increments every time the active subscription actually changes.

--- a/channel/cli_palette.go
+++ b/channel/cli_palette.go
@@ -28,12 +28,47 @@ const (
 	paletteActionQuit                              // quits the application
 )
 
+// PaletteCategory groups commands into tabs in the command palette.
+type PaletteCategory string
+
+const (
+	PaletteCategorySystem  PaletteCategory = "System"
+	PaletteCategoryUser    PaletteCategory = "User"
+	PaletteCategoryPlugins PaletteCategory = "Plugins"
+	PaletteCategorySkills  PaletteCategory = "Skills"
+	PaletteCategoryAgents  PaletteCategory = "Agents"
+)
+
+// paletteCategories is the ordered list of visible categories.
+var paletteCategories = []PaletteCategory{
+	PaletteCategorySystem,
+	PaletteCategoryUser,
+	PaletteCategoryPlugins,
+	PaletteCategorySkills,
+	PaletteCategoryAgents,
+}
+
+// PaletteExternalCommand represents a command contributed by an external source
+// (plugin, skill, user custom command).
+type PaletteExternalCommand struct {
+	Title       string
+	Description string
+	Category    PaletteCategory
+	Content     string // content to insert or send
+	Send        bool   // true = send immediately, false = insert into textarea
+}
+
+// PaletteContributor provides external commands for the command palette.
+// Injected by the application layer to supply plugin/skill/agent/custom commands.
+type PaletteContributor func() []PaletteExternalCommand
+
 // paletteCommand represents a single item in the command palette.
 type paletteCommand struct {
 	ID          string
 	Title       string
 	Description string
 	Shortcut    string
+	Category    PaletteCategory
 	ActionKind  paletteActionKind
 	ActionData  string
 }
@@ -47,95 +82,105 @@ func (p paletteFilterable) String(i int) string { return p[i].Title + " " + p[i]
 const paletteMaxVisible = 12
 
 // buildPaletteCommands returns all available commands for the palette.
-// Commands are grouped logically but presented as a flat searchable list.
+// Commands are grouped by category (tab-switchable) and presented as a flat searchable list.
 func (m *cliModel) buildPaletteCommands() []paletteCommand {
 	var cmds []paletteCommand
 
-	// --- Navigation ---
+	// --- System ---
 	cmds = append(cmds, paletteCommand{
 		ID: "sessions", Title: "Open Sessions", Description: "switch between chat sessions",
-		Shortcut: "Ctrl+T", ActionKind: paletteActionOpenPanel, ActionData: "sessions",
+		Shortcut: "Ctrl+T", Category: PaletteCategorySystem, ActionKind: paletteActionOpenPanel, ActionData: "sessions",
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "switch_sub", Title: "Switch Subscription", Description: "change LLM subscription",
-		Shortcut: "Ctrl+P", ActionKind: paletteActionOpenQuickSwitch, ActionData: "subscription",
+		Shortcut: "Ctrl+P", Category: PaletteCategorySystem, ActionKind: paletteActionOpenQuickSwitch, ActionData: "subscription",
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "cycle_model", Title: "Cycle Model", Description: "switch to next model in list",
-		Shortcut: "Ctrl+N", ActionKind: paletteActionCycleModel, ActionData: "",
+		Shortcut: "Ctrl+N", Category: PaletteCategorySystem, ActionKind: paletteActionCycleModel,
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "bgtasks", Title: "Background Tasks", Description: "view running background tasks and agents",
-		Shortcut: "^", ActionKind: paletteActionOpenPanel, ActionData: "bgtasks",
+		Shortcut: "^", Category: PaletteCategorySystem, ActionKind: paletteActionOpenPanel, ActionData: "bgtasks",
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "runner", Title: "Runner Panel", Description: "connect to remote runner",
-		Shortcut: "", ActionKind: paletteActionOpenPanel, ActionData: "runner",
+		Category: PaletteCategorySystem, ActionKind: paletteActionOpenPanel, ActionData: "runner",
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "channel", Title: "Channel Config", Description: "configure web/feishu/QQ channels",
-		Shortcut: "", ActionKind: paletteActionOpenPanel, ActionData: "channel",
+		Category: PaletteCategorySystem, ActionKind: paletteActionOpenPanel, ActionData: "channel",
 	})
-
-	// --- Chat ---
 	cmds = append(cmds, paletteCommand{
 		ID: "clear", Title: "Clear Chat", Description: "start a fresh conversation",
-		Shortcut: "/clear", ActionKind: paletteActionSendText, ActionData: "/clear",
+		Shortcut: "/clear", Category: PaletteCategorySystem, ActionKind: paletteActionSendText, ActionData: "/clear",
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "compact", Title: "Compact Context", Description: "compress conversation history",
-		Shortcut: "/compact", ActionKind: paletteActionSendText, ActionData: "/compact",
+		Shortcut: "/compact", Category: PaletteCategorySystem, ActionKind: paletteActionSendText, ActionData: "/compact",
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "search", Title: "Search Messages", Description: "find text in conversation history",
-		Shortcut: "", ActionKind: paletteActionInsertText, ActionData: "/search ",
+		Category: PaletteCategorySystem, ActionKind: paletteActionInsertText, ActionData: "/search ",
 	})
-
-	// --- Toggles ---
 	cmds = append(cmds, paletteCommand{
 		ID: "tool_detail", Title: "Toggle Tool Details", Description: "expand or collapse tool output",
-		Shortcut: "Ctrl+O", ActionKind: paletteActionToggle, ActionData: "tool_summary",
+		Shortcut: "Ctrl+O", Category: PaletteCategorySystem, ActionKind: paletteActionToggle, ActionData: "tool_summary",
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "msg_fold", Title: "Toggle Message Fold", Description: "expand or collapse long messages",
-		Shortcut: "Ctrl+E", ActionKind: paletteActionToggle, ActionData: "msg_fold",
+		Shortcut: "Ctrl+E", Category: PaletteCategorySystem, ActionKind: paletteActionToggle, ActionData: "msg_fold",
 	})
-
-	// --- Settings ---
 	cmds = append(cmds, paletteCommand{
 		ID: "settings", Title: "Open Settings", Description: "configure LLM, sandbox, memory, etc.",
-		Shortcut: "", ActionKind: paletteActionSendText, ActionData: "/settings",
+		Category: PaletteCategorySystem, ActionKind: paletteActionSendText, ActionData: "/settings",
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "danger", Title: "Danger Zone", Description: "clear session, memory, history",
-		Shortcut: "", ActionKind: paletteActionOpenPanel, ActionData: "danger",
+		Category: PaletteCategorySystem, ActionKind: paletteActionOpenPanel, ActionData: "danger",
 	})
-
-	// --- Plugins ---
 	cmds = append(cmds, paletteCommand{
 		ID: "reload_plugins", Title: "Reload Plugins", Description: "refresh all plugin widgets",
-		Shortcut: "", ActionKind: paletteActionSendText, ActionData: "/plugin reload",
+		Category: PaletteCategorySystem, ActionKind: paletteActionSendText, ActionData: "/plugin reload",
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "install_plugin", Title: "Install Plugin", Description: "install a plugin from URL or path",
-		Shortcut: "", ActionKind: paletteActionInsertText, ActionData: "/plugin install ",
+		Category: PaletteCategorySystem, ActionKind: paletteActionInsertText, ActionData: "/plugin install ",
 	})
-
-	// --- Help & Info ---
 	cmds = append(cmds, paletteCommand{
 		ID: "help", Title: "Help", Description: "show available slash commands and shortcuts",
-		Shortcut: "/help", ActionKind: paletteActionSendText, ActionData: "/help",
+		Shortcut: "/help", Category: PaletteCategorySystem, ActionKind: paletteActionSendText, ActionData: "/help",
 	})
 	cmds = append(cmds, paletteCommand{
 		ID: "update", Title: "Check Update", Description: "check for new xbot versions",
-		Shortcut: "/update", ActionKind: paletteActionSendText, ActionData: "/update",
+		Shortcut: "/update", Category: PaletteCategorySystem, ActionKind: paletteActionSendText, ActionData: "/update",
 	})
-
-	// --- Quit ---
 	cmds = append(cmds, paletteCommand{
 		ID: "quit", Title: "Quit", Description: "exit xbot",
-		Shortcut: "Ctrl+Z", ActionKind: paletteActionQuit, ActionData: "",
+		Shortcut: "Ctrl+Z", Category: PaletteCategorySystem, ActionKind: paletteActionQuit,
 	})
+
+	// --- External contributions (plugins, skills, agents, custom commands) ---
+	if m.paletteContributor != nil {
+		for _, ext := range m.paletteContributor() {
+			kind := paletteActionInsertText
+			if ext.Send {
+				kind = paletteActionSendText
+			}
+			cat := ext.Category
+			if cat == "" {
+				cat = PaletteCategoryPlugins
+			}
+			cmds = append(cmds, paletteCommand{
+				ID:          "ext:" + ext.Title,
+				Title:       ext.Title,
+				Description: ext.Description,
+				Category:    cat,
+				ActionKind:  kind,
+				ActionData:  ext.Content,
+			})
+		}
+	}
 
 	return cmds
 }
@@ -146,11 +191,16 @@ func (m *cliModel) openCommandPalette() {
 		m.closeCommandPalette()
 		return
 	}
+	// Sync external contributor from channel (may change at runtime)
+	if m.channel != nil && m.channel.PaletteContributor != nil {
+		m.paletteContributor = m.channel.PaletteContributor
+	}
 	m.paletteOpen = true
 	m.paletteItems = m.buildPaletteCommands()
 	m.paletteFiltered = m.paletteItems
 	m.paletteCursor = 0
 	m.paletteScrollY = 0
+	m.paletteActiveCategory = "" // show all categories by default
 
 	ti := textinput.New()
 	ti.Placeholder = "Type to filter commands…"
@@ -175,17 +225,32 @@ func (m *cliModel) closeCommandPalette() {
 }
 
 // filterPaletteCommands filters commands by the current input query using fuzzy matching.
+// Respects the active category tab — only shows commands in the current category.
 func (m *cliModel) filterPaletteCommands() {
 	query := m.paletteInput.Value()
+	active := m.paletteActiveCategory
+
+	source := m.paletteItems
+	// Filter by active category (unless "all")
+	if active != "" {
+		filtered := make([]paletteCommand, 0, len(source))
+		for _, cmd := range source {
+			if cmd.Category == active {
+				filtered = append(filtered, cmd)
+			}
+		}
+		source = filtered
+	}
+
 	if query == "" {
-		m.paletteFiltered = m.paletteItems
+		m.paletteFiltered = source
 		return
 	}
-	source := paletteFilterable(m.paletteItems)
-	matches := fuzzy.FindFrom(query, source)
+	fuzzySource := paletteFilterable(source)
+	matches := fuzzy.FindFrom(query, fuzzySource)
 	m.paletteFiltered = make([]paletteCommand, 0, len(matches))
 	for _, match := range matches {
-		m.paletteFiltered = append(m.paletteFiltered, m.paletteItems[match.Index])
+		m.paletteFiltered = append(m.paletteFiltered, source[match.Index])
 	}
 }
 
@@ -237,6 +302,45 @@ func (m *cliModel) applyPaletteCommand() {
 	}
 }
 
+// cyclePaletteCategory moves to the next/previous category tab.
+func (m *cliModel) cyclePaletteCategory(dir int) {
+	// Build list of non-empty categories
+	nonEmpty := make(map[PaletteCategory]bool)
+	for _, cmd := range m.paletteItems {
+		nonEmpty[cmd.Category] = true
+	}
+	var visible []PaletteCategory
+	for _, cat := range paletteCategories {
+		if nonEmpty[cat] {
+			visible = append(visible, cat)
+		}
+	}
+	if len(visible) == 0 {
+		return
+	}
+
+	// Find current index
+	curIdx := -1
+	for i, cat := range visible {
+		if cat == m.paletteActiveCategory {
+			curIdx = i
+			break
+		}
+	}
+
+	// Move to next/prev (wrap around)
+	nextIdx := curIdx + dir
+	if nextIdx < 0 {
+		nextIdx = len(visible) - 1
+	} else if nextIdx >= len(visible) {
+		nextIdx = 0
+	}
+	m.paletteActiveCategory = visible[nextIdx]
+	m.paletteCursor = 0
+	m.paletteScrollY = 0
+	m.filterPaletteCommands()
+}
+
 // handlePaletteKey handles key events when the command palette is open.
 // Returns (handled, cmd). When open, always returns handled=true to block all keys.
 func (m *cliModel) handlePaletteKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
@@ -271,8 +375,13 @@ func (m *cliModel) handlePaletteKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 	}
 	// Non-Code key checks (Tab, Shift+Tab, etc.)
 	switch msg.String() {
-	case "tab", "shift+tab":
-		// Reserved for category switching (future)
+	case "tab":
+		// Cycle to next category
+		m.cyclePaletteCategory(1)
+		return true, nil
+	case "shift+tab":
+		// Cycle to previous category
+		m.cyclePaletteCategory(-1)
 		return true, nil
 	}
 
@@ -314,6 +423,29 @@ func (m *cliModel) viewCommandPalette(width, height int) string {
 
 	// Title
 	lines = append(lines, m.styles.PanelHeader.Render(" Command Palette"))
+
+	// Category tabs
+	nonEmpty := make(map[PaletteCategory]bool)
+	for _, cmd := range m.paletteItems {
+		nonEmpty[cmd.Category] = true
+	}
+	var tabParts []string
+	for _, cat := range paletteCategories {
+		if !nonEmpty[cat] {
+			continue
+		}
+		label := string(cat)
+		if cat == m.paletteActiveCategory {
+			label = m.styles.Accent.Bold(true).Render(label)
+		} else {
+			label = m.styles.TextMutedSt.Render(label)
+		}
+		tabParts = append(tabParts, label)
+	}
+	if len(tabParts) > 1 {
+		tabLine := " " + strings.Join(tabParts, "  ")
+		lines = append(lines, tabLine)
+	}
 
 	// Search input
 	lines = append(lines, m.paletteInput.View())
@@ -379,7 +511,7 @@ func (m *cliModel) viewCommandPalette(width, height int) string {
 	}
 
 	// Footer hints
-	lines = append(lines, m.styles.TextMutedSt.Render(" ↑↓ Navigate · Enter Select · Esc Close"))
+	lines = append(lines, m.styles.TextMutedSt.Render(" ↑↓ Navigate · Enter Select · Tab Category · Esc Close"))
 
 	// Build bordered panel
 	content := strings.Join(lines, "\n")

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -609,7 +609,7 @@ func (m *cliModel) updateBgTasksPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 	case msg.Code == tea.KeyEsc || msg.String() == "ctrl+c":
 		return m.closePanelAndResume()
 
-	case msg.Code == tea.KeyUp || msg.String() == "ctrl+k":
+	case msg.Code == tea.KeyUp:
 		if m.panelBgCursor > 0 {
 			m.panelBgCursor--
 			m.ensureBgCursorVisible()

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -598,6 +598,7 @@ type CLIChannelConfig struct {
 	ListWebUsersFn       func() ([]map[string]any, error)                                                                               // 列出所有 Web 用户
 	DeleteWebUserFn      func(username string) error                                                                                    // 删除 Web 用户（admin only）
 	IsAdminFn            func() bool                                                                                                    // 检查当前用户是否 admin
+	PaletteContributor   PaletteContributor                                                                                             // supplies external commands for command palette
 }
 
 type AgentPanelEntry struct {
@@ -661,9 +662,10 @@ type CLIChannel struct {
 	asyncCh    chan tea.Msg // unified async send channel (buffered)
 
 	// Services (injected by Agent or main)
-	settingsSvc SettingsService // interface for GetSettings/SetSetting
-	configMu    sync.RWMutex    // protects runner LLM fields (llmClient, modelList, llmProvider)
-	modelLister ModelLister     // provides available model names for combo
+	settingsSvc        SettingsService    // interface for GetSettings/SetSetting
+	configMu           sync.RWMutex       // protects runner LLM fields (llmClient, modelList, llmProvider)
+	modelLister        ModelLister        // provides available model names for combo
+	PaletteContributor PaletteContributor // supplies external commands (plugins/skills/agents/custom)
 
 	// Multi-subscription management
 	subscriptionMgr SubscriptionManager // manages LLM subscriptions

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -76,8 +76,8 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 		return m, nil, true
 
 	case msg.String() == "ctrl+k":
-		// §23 Ctrl+K: Command Palette
-		if m.panelMode == "" && m.quickSwitchMode == "" && !m.paletteOpen {
+		// §23 Ctrl+K: Command Palette — always available, even in panels
+		if !m.paletteOpen {
 			m.openCommandPalette()
 			return m, nil, true
 		}

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -800,7 +800,7 @@ func (m *cliModel) renderFooter() string {
 	} else {
 		// 就绪态：显示核心快捷键
 		if m.textarea.Value() == "" {
-			hints = append(hints, m.ctrlKey("k", m.locale.FooterDelete), m.keyHint("/", m.locale.FooterCommands), m.keyHint("tab", m.locale.FooterComplete), m.ctrlKey("e", m.locale.FooterFold))
+			hints = append(hints, m.ctrlKey("k", m.locale.FooterPalette), m.keyHint("tab", m.locale.FooterComplete), m.ctrlKey("e", m.locale.FooterFold))
 			if m.subscriptionMgr != nil {
 				hints = append(hints, m.ctrlKey("p", "Subs"))
 			}
@@ -809,7 +809,7 @@ func (m *cliModel) renderFooter() string {
 				hints = append(hints, m.keyHint("^", m.locale.FooterBgTasks))
 			}
 		} else {
-			hints = append(hints, m.ctrlKey("j", m.locale.FooterNewline), m.keyHint("tab", m.locale.FooterComplete), m.ctrlKey("k", m.locale.FooterDelete))
+			hints = append(hints, m.ctrlKey("j", m.locale.FooterNewline), m.keyHint("tab", m.locale.FooterComplete), m.ctrlKey("k", m.locale.FooterPalette))
 		}
 	}
 

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -28,6 +28,9 @@ func appendStatusHint(status, hint string) string {
 // isCompact returns true when terminal width < 80 — compact layout for narrow windows.
 func (m *cliModel) isCompact() bool { return m.width < 80 }
 
+// isNarrow returns true when terminal width < 60 — minimal layout.
+func (m *cliModel) isNarrow() bool { return m.width < 60 }
+
 // renderTitleBar builds the top title bar with gradient wordmark, diagonal fill,
 // mode label, hints, runner status, and user identity indicator.
 // In compact mode (<80 cols), extras (runner, user) are hidden.
@@ -55,6 +58,10 @@ func (m *cliModel) renderTitleBar() string {
 		}
 	}
 
+	// Narrow: hide /help hint to save space
+	if m.isNarrow() {
+		titleRight = ""
+	}
 	titlePad := m.width - lipgloss.Width(titleLeft) - lipgloss.Width(titleRight)
 	if titlePad < 3 {
 		titlePad = 3
@@ -135,10 +142,14 @@ func (m *cliModel) renderReadyStatus() string {
 	// Model name (cached, avoids per-frame lookup)
 	if m.cachedModelName != "" {
 		modelHint := m.cachedModelName
-		if m.modelCount > 1 {
+		if m.modelCount > 1 && !m.isCompact() {
 			modelHint += " [Ctrl+N]"
 		}
 		readyParts = append(readyParts, modelHint)
+	}
+	// Narrow screen: drop msg count to save space
+	if m.isNarrow() && len(readyParts) > 2 {
+		readyParts = readyParts[:2]
 	}
 	leftParts := strings.Join(readyParts, " · ")
 
@@ -800,16 +811,28 @@ func (m *cliModel) renderFooter() string {
 	} else {
 		// 就绪态：显示核心快捷键
 		if m.textarea.Value() == "" {
-			hints = append(hints, m.ctrlKey("k", m.locale.FooterPalette), m.keyHint("tab", m.locale.FooterComplete), m.ctrlKey("e", m.locale.FooterFold))
-			if m.subscriptionMgr != nil {
+			hints = append(hints, m.ctrlKey("k", m.locale.FooterPalette))
+			if !m.isNarrow() {
+				hints = append(hints, m.keyHint("tab", m.locale.FooterComplete))
+			}
+			if !m.isCompact() {
+				hints = append(hints, m.ctrlKey("e", m.locale.FooterFold))
+			}
+			if m.subscriptionMgr != nil && !m.isNarrow() {
 				hints = append(hints, m.ctrlKey("p", "Subs"))
 			}
-			hints = append(hints, m.ctrlKey("t", "Sessions"))
-			if m.bgTaskCount > 0 {
+			if !m.isNarrow() {
+				hints = append(hints, m.ctrlKey("t", "Sessions"))
+			}
+			if m.bgTaskCount > 0 && !m.isCompact() {
 				hints = append(hints, m.keyHint("^", m.locale.FooterBgTasks))
 			}
 		} else {
-			hints = append(hints, m.ctrlKey("j", m.locale.FooterNewline), m.keyHint("tab", m.locale.FooterComplete), m.ctrlKey("k", m.locale.FooterPalette))
+			hints = append(hints, m.ctrlKey("j", m.locale.FooterNewline))
+			if !m.isNarrow() {
+				hints = append(hints, m.keyHint("tab", m.locale.FooterComplete))
+			}
+			hints = append(hints, m.ctrlKey("k", m.locale.FooterPalette))
 		}
 	}
 

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -105,7 +105,7 @@ type UILocale struct {
 	FooterKill     string // "kill"
 	FooterClose    string // "close"
 	FooterCancel   string // "cancel"
-	FooterDelete   string // "delete"
+	FooterPalette  string // "palette"
 	FooterCommands string // "commands"
 	FooterComplete string // "complete"
 	FooterBgTasks  string // "bg tasks"
@@ -325,7 +325,7 @@ func localeZH() *UILocale {
 		FooterKill:     "终止",
 		FooterClose:    "关闭",
 		FooterCancel:   "取消",
-		FooterDelete:   "删除",
+		FooterPalette:  "命令面板",
 		FooterCommands: "命令",
 		FooterComplete: "补全",
 		FooterBgTasks:  "任务/代理",
@@ -706,7 +706,7 @@ func localeEN() *UILocale {
 		FooterKill:     "kill",
 		FooterClose:    "close",
 		FooterCancel:   "cancel",
-		FooterDelete:   "delete",
+		FooterPalette:  "palette",
 		FooterCommands: "commands",
 		FooterComplete: "complete",
 		FooterBgTasks:  "tasks/agents",
@@ -1087,7 +1087,7 @@ func localeJA() *UILocale {
 		FooterKill:     "終了",
 		FooterClose:    "閉じる",
 		FooterCancel:   "キャンセル",
-		FooterDelete:   "削除",
+		FooterPalette:  "パレット",
 		FooterCommands: "コマンド",
 		FooterComplete: "補完",
 		FooterBgTasks:  "タスク/エージェント",

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -100,24 +100,6 @@ func (app *cliApp) refreshRemoteValuesCache() {
 		}
 		return "flat"
 	}()
-	vals["max_iterations"] = func() string {
-		if app.cfg.Agent.MaxIterations > 0 {
-			return fmt.Sprintf("%d", app.cfg.Agent.MaxIterations)
-		}
-		return "30"
-	}()
-	vals["max_concurrency"] = func() string {
-		if app.cfg.Agent.MaxConcurrency > 0 {
-			return fmt.Sprintf("%d", app.cfg.Agent.MaxConcurrency)
-		}
-		return "3"
-	}()
-	vals["max_context_tokens"] = func() string {
-		if app.cfg.Agent.MaxContextTokens > 0 {
-			return fmt.Sprintf("%d", app.cfg.Agent.MaxContextTokens)
-		}
-		return "200000"
-	}()
 	vals["compression_threshold"] = func() string {
 		if app.cfg.Agent.CompressionThreshold > 0 {
 			return fmt.Sprintf("%g", app.cfg.Agent.CompressionThreshold)
@@ -125,6 +107,33 @@ func (app *cliApp) refreshRemoteValuesCache() {
 		return "0.9"
 	}()
 	vals["tavily_api_key"] = app.cfg.TavilyAPIKey
+	// ScopeUser keys (max_iterations, max_concurrency, max_context_tokens):
+	// Primary source is the user_settings DB (written by /set). Only fallback
+	// to config.json when DB has no value (first-run or never changed).
+	if _, ok := vals["max_iterations"]; !ok {
+		vals["max_iterations"] = func() string {
+			if app.cfg.Agent.MaxIterations > 0 {
+				return fmt.Sprintf("%d", app.cfg.Agent.MaxIterations)
+			}
+			return "30"
+		}()
+	}
+	if _, ok := vals["max_concurrency"]; !ok {
+		vals["max_concurrency"] = func() string {
+			if app.cfg.Agent.MaxConcurrency > 0 {
+				return fmt.Sprintf("%d", app.cfg.Agent.MaxConcurrency)
+			}
+			return "3"
+		}()
+	}
+	if _, ok := vals["max_context_tokens"]; !ok {
+		vals["max_context_tokens"] = func() string {
+			if app.cfg.Agent.MaxContextTokens > 0 {
+				return fmt.Sprintf("%d", app.cfg.Agent.MaxContextTokens)
+			}
+			return "200000"
+		}()
+	}
 	app.valuesCacheMu.Lock()
 	app.valuesCache = vals
 	app.valuesCacheMu.Unlock()

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -545,6 +545,94 @@ func isLocalServer(serverURL string) bool {
 // newCLIApp 执行公共初始化：加载配置、创建 Backend。
 // If serverURL is non-empty, creates a RemoteBackend (agent runs on server).
 // Otherwise creates a LocalBackend (agent runs in-process).
+// buildPaletteExternalCommands collects commands from skills, plugins, and user
+// custom commands (~/.xbot/commands/*.md). Called each time the palette opens.
+func (a *cliApp) buildPaletteExternalCommands() []channel.PaletteExternalCommand {
+	var cmds []channel.PaletteExternalCommand
+	home, _ := os.UserHomeDir()
+	xbotDir := home + "/.xbot"
+
+	// 1. Skills from ~/.xbot/skills/
+	if entries, err := os.ReadDir(xbotDir + "/skills"); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if strings.HasPrefix(name, ".") || name == "skill-creator" {
+				continue
+			}
+			cmds = append(cmds, channel.PaletteExternalCommand{
+				Title:       "Skill: " + name,
+				Description: "activate /" + name + " skill",
+				Category:    channel.PaletteCategorySkills,
+				Content:     "/" + name + " ",
+			})
+		}
+	}
+
+	// 2. Plugin commands from loaded plugins
+	if a.backend != nil {
+		if pm := a.backend.PluginManager(); pm != nil {
+			for _, p := range pm.ListPlugins() {
+				if p.Manifest == nil || p.Manifest.Contributes == nil {
+					continue
+				}
+				for _, cmd := range p.Manifest.Contributes.Commands {
+					cmds = append(cmds, channel.PaletteExternalCommand{
+						Title:       p.Manifest.Name + ": " + cmd.Name,
+						Description: cmd.Description,
+						Category:    channel.PaletteCategoryPlugins,
+						Content:     cmd.Name + " ",
+					})
+				}
+			}
+		}
+	}
+
+	// 3. User custom commands from ~/.xbot/commands/*.md (crush-style)
+	if entries, err := os.ReadDir(xbotDir + "/commands"); err == nil {
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".md") {
+				continue
+			}
+			name := strings.TrimSuffix(e.Name(), filepath.Ext(e.Name()))
+			content, err := os.ReadFile(xbotDir + "/commands/" + e.Name())
+			if err != nil {
+				continue
+			}
+			cmds = append(cmds, channel.PaletteExternalCommand{
+				Title:       name,
+				Description: "custom command",
+				Category:    channel.PaletteCategoryUser,
+				Content:     string(content),
+				Send:        true,
+			})
+		}
+	}
+
+	// 4. SubAgent roles from ~/.xbot/agents/
+	if entries, err := os.ReadDir(xbotDir + "/agents"); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if strings.HasPrefix(name, ".") {
+				continue
+			}
+			cmds = append(cmds, channel.PaletteExternalCommand{
+				Title:       "Agent: " + name,
+				Description: "spawn " + name + " SubAgent",
+				Category:    channel.PaletteCategoryAgents,
+				Content:     "/agent " + name + " ",
+			})
+		}
+	}
+
+	return cmds
+}
+
 func newCLIApp(serverURL, token string, forceLocal bool) *cliApp {
 	cfg := config.Load()
 
@@ -1312,6 +1400,9 @@ func main() {
 		},
 		IsAdminFn: func() bool {
 			return true // standalone mode: CLI user is always admin
+		},
+		PaletteContributor: func() []channel.PaletteExternalCommand {
+			return app.buildPaletteExternalCommands()
 		},
 	}
 


### PR DESCRIPTION
# TUI Experience Overhaul

## Command Palette v2
- **Category tabs**: System / User / Plugins / Skills / Agents
- **Tab / Shift+Tab** cycle categories
- **External command injection** via \`PaletteContributor\` interface
- Auto-loads commands from:
  - \`~/.xbot/skills/*\` → Skill: name
  - \`~/.xbot/agents/*\` → Agent: name
  - \`~/.xbot/commands/*.md\` → crush-style custom commands (sent as prompt)
  - Plugin \`contributes.commands\` from \`plugin.json\`
- Exported \`PaletteCategory\`, \`PaletteExternalCommand\`, \`PaletteContributor\` types

## Fixes
- Footer Ctrl+K shows 'palette' not 'delete' (3 locales)
- Ctrl+K works in panels (removed conflicting panel nav binding)
- Settings panel Ctrl+K no longer navigates up, opens palette instead

## Planned (in progress)
- Responsive layout for small screens
- Layout optimization for large screens
- Plugin-configurable layout contributions

## Validation
- \`go build ./...\` ✅
- \`golangci-lint run ./...\` ✅ 0 issues
- \`go test ./...\` ✅ all pass
- Pre-commit hooks ✅