### PR TITLE
fix: subscription setup — auto-default, model selector, edit, remove gpt-4o hardcode

### DIFF
--- a/channel/feishu.go
+++ b/channel/feishu.go
@@ -75,6 +75,7 @@ type SettingsCallbacks struct {
 	LLMListSubscriptions      func(senderID string) ([]Subscription, error)  // list all user subscriptions
 	LLMGetDefaultSubscription func(senderID string) (*Subscription, error)   // get active subscription
 	LLMAddSubscription        func(senderID string, sub *Subscription) error // add a new subscription
+	LLMUpdateSubscription     func(id string, sub *Subscription) error       // update an existing subscription
 	LLMRemoveSubscription     func(id string) error                          // remove by subscription ID
 	LLMSetDefaultSubscription func(id string) error                          // set as active subscription
 	LLMRenameSubscription     func(id, name string) error                    // rename subscription

--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -317,6 +317,39 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 		}
 		return f.BuildSettingsCard(ctx, senderID, chatID, "model")
 
+	case "settings_edit_subscription":
+		subID := parsed["subscription_id"]
+		if subID == "" {
+			return nil, fmt.Errorf("missing subscription_id")
+		}
+		return f.buildEditSubscriptionCard(senderID, subID)
+
+	case "settings_submit_edit_subscription":
+		subID := parsed["subscription_id"]
+		provider := formStr(actionData, "provider")
+		baseURL := formStr(actionData, "base_url")
+		apiKey := formStr(actionData, "api_key")
+		model := formStr(actionData, "model")
+		name := formStr(actionData, "name")
+		if name == "" {
+			name = provider + " " + model
+		}
+		if provider == "" || baseURL == "" {
+			return nil, fmt.Errorf("请填写完整配置（Provider、API 地址）")
+		}
+		if f.settingsCallbacks.LLMUpdateSubscription != nil {
+			if err := f.settingsCallbacks.LLMUpdateSubscription(subID, &Subscription{
+				Name:     name,
+				Provider: provider,
+				BaseURL:  baseURL,
+				APIKey:   apiKey,
+				Model:    model,
+			}); err != nil {
+				return nil, fmt.Errorf("更新订阅失败: %v", err)
+			}
+		}
+		return f.BuildSettingsCard(ctx, senderID, chatID, "model")
+
 	case "settings_delete_subscription":
 		subID := parsed["subscription_id"]
 		if subID == "" {
@@ -1039,6 +1072,24 @@ func (f *FeishuChannel) buildGeneralTabContent(senderID string, o SettingsCardOp
 
 // buildModelTabContent builds the model configuration tab.
 func (f *FeishuChannel) buildAddSubscriptionCard(senderID string) (map[string]any, error) {
+	// Fetch available models for the model selector dropdown
+	var modelOptions []map[string]any
+	if f.settingsCallbacks.LLMList != nil {
+		models, _ := f.settingsCallbacks.LLMList(senderID)
+		for _, m := range models {
+			modelOptions = append(modelOptions, map[string]any{
+				"text":  map[string]any{"tag": "plain_text", "content": m},
+				"value": m,
+			})
+		}
+	}
+	if len(modelOptions) == 0 {
+		modelOptions = append(modelOptions, map[string]any{
+			"text":  map[string]any{"tag": "plain_text", "content": "暂无可用模型（保存后可切换）"},
+			"value": "",
+		})
+	}
+
 	formElements := []map[string]any{
 		{
 			"tag":  "input",
@@ -1089,16 +1140,13 @@ func (f *FeishuChannel) buildAddSubscriptionCard(senderID string) (map[string]an
 			},
 		},
 		{
-			"tag":  "input",
+			"tag":  "select_static",
 			"name": "model",
-			"label": map[string]any{
-				"tag":     "plain_text",
-				"content": "模型名称（可选，保存后可切换）",
-			},
 			"placeholder": map[string]any{
 				"tag":     "plain_text",
-				"content": "gpt-4o",
+				"content": "选择模型（可选，保存后可切换）",
 			},
+			"options": modelOptions,
 		},
 		{
 			"tag":         "button",
@@ -1134,6 +1182,159 @@ func (f *FeishuChannel) buildAddSubscriptionCard(senderID string) (map[string]an
 				{
 					"tag":      "form",
 					"name":     "add_subscription_form",
+					"elements": formElements,
+				},
+			},
+		},
+	}, nil
+}
+
+// buildEditSubscriptionCard builds the edit subscription form with current values.
+func (f *FeishuChannel) buildEditSubscriptionCard(senderID, subID string) (map[string]any, error) {
+	// Get current subscription data
+	var currentName, currentProvider, currentBaseURL, currentModel string
+	if f.settingsCallbacks.LLMListSubscriptions != nil {
+		subs, _ := f.settingsCallbacks.LLMListSubscriptions(senderID)
+		for _, s := range subs {
+			if s.ID == subID {
+				currentName = s.Name
+				currentProvider = s.Provider
+				currentBaseURL = s.BaseURL
+				currentModel = s.Model
+				break
+			}
+		}
+	}
+
+	// Fetch available models for the dropdown
+	var modelOptions []map[string]any
+	if f.settingsCallbacks.LLMList != nil {
+		models, _ := f.settingsCallbacks.LLMList(senderID)
+		for _, m := range models {
+			modelOptions = append(modelOptions, map[string]any{
+				"text":  map[string]any{"tag": "plain_text", "content": m},
+				"value": m,
+			})
+		}
+	}
+	// Always include current model
+	found := false
+	for _, opt := range modelOptions {
+		if opt["value"] == currentModel {
+			found = true
+			break
+		}
+	}
+	if !found && currentModel != "" {
+		modelOptions = append([]map[string]any{{
+			"text":  map[string]any{"tag": "plain_text", "content": currentModel},
+			"value": currentModel,
+		}}, modelOptions...)
+	}
+	if len(modelOptions) == 0 {
+		modelOptions = append(modelOptions, map[string]any{
+			"text":  map[string]any{"tag": "plain_text", "content": "暂无可用模型"},
+			"value": "",
+		})
+	}
+
+	formElements := []map[string]any{
+		{
+			"tag":  "input",
+			"name": "name",
+			"label": map[string]any{
+				"tag":     "plain_text",
+				"content": "订阅名称",
+			},
+			"placeholder": map[string]any{
+				"tag":     "plain_text",
+				"content": "例如：工作账号、个人测试",
+			},
+			"default_value": currentName,
+		},
+		{
+			"tag":  "select_static",
+			"name": "provider",
+			"placeholder": map[string]any{
+				"tag":     "plain_text",
+				"content": "选择 Provider",
+			},
+			"initial_option": currentProvider,
+			"options": []map[string]any{
+				{"text": map[string]any{"tag": "plain_text", "content": "OpenAI（含兼容 API）"}, "value": "openai"},
+				{"text": map[string]any{"tag": "plain_text", "content": "Anthropic"}, "value": "anthropic"},
+			},
+		},
+		{
+			"tag":  "input",
+			"name": "base_url",
+			"label": map[string]any{
+				"tag":     "plain_text",
+				"content": "API 地址",
+			},
+			"placeholder": map[string]any{
+				"tag":     "plain_text",
+				"content": "https://api.openai.com/v1",
+			},
+			"default_value": currentBaseURL,
+		},
+		{
+			"tag":  "input",
+			"name": "api_key",
+			"label": map[string]any{
+				"tag":     "plain_text",
+				"content": "API Key（留空则保持不变）",
+			},
+			"placeholder": map[string]any{
+				"tag":     "plain_text",
+				"content": "sk-...",
+			},
+		},
+		{
+			"tag":  "select_static",
+			"name": "model",
+			"placeholder": map[string]any{
+				"tag":     "plain_text",
+				"content": "选择模型",
+			},
+			"initial_option": currentModel,
+			"options":        modelOptions,
+		},
+		{
+			"tag":         "button",
+			"name":        "sub_edit_submit",
+			"text":        map[string]any{"tag": "plain_text", "content": "保存修改"},
+			"type":        "primary",
+			"action_type": "form_submit",
+			"value": map[string]string{
+				"action_data": mustMapToJSON(map[string]string{
+					"action":          "settings_submit_edit_subscription",
+					"subscription_id": subID,
+				}),
+			},
+		},
+	}
+
+	return map[string]any{
+		"schema": "2.0",
+		"config": map[string]any{
+			"wide_screen_mode": true,
+		},
+		"header": map[string]any{
+			"title": map[string]any{
+				"tag":     "plain_text",
+				"content": "✏️ 编辑订阅",
+			},
+		},
+		"body": map[string]any{
+			"elements": []map[string]any{
+				{
+					"tag":     "markdown",
+					"content": "修改订阅配置。API Key 留空则保持原值不变。",
+				},
+				{
+					"tag":      "form",
+					"name":     "edit_subscription_form",
 					"elements": formElements,
 				},
 			},
@@ -1456,6 +1657,17 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 						},
 					})
 				}
+				btns = append(btns, map[string]any{
+					"tag":  "button",
+					"text": map[string]any{"tag": "plain_text", "content": "编辑"},
+					"type": "default",
+					"value": map[string]string{
+						"action_data": mustMapToJSON(map[string]string{
+							"action":          "settings_edit_subscription",
+							"subscription_id": sub.ID,
+						}),
+					},
+				})
 				btns = append(btns, map[string]any{
 					"tag":  "button",
 					"text": map[string]any{"tag": "plain_text", "content": "删除"},

--- a/config/config.go
+++ b/config/config.go
@@ -781,9 +781,6 @@ func Load() *Config {
 	if cfg.LLM.BaseURL == "" {
 		cfg.LLM.BaseURL = "https://api.openai.com/v1"
 	}
-	if cfg.LLM.Model == "" {
-		cfg.LLM.Model = "gpt-4o"
-	}
 	if cfg.Log.Level == "" {
 		cfg.Log.Level = "info"
 	}

--- a/serverapp/callbacks.go
+++ b/serverapp/callbacks.go
@@ -423,18 +423,24 @@ func buildFeishuSettingsCallbacks(cfg *config.Config, backend agent.AgentBackend
 		},
 		LLMAddSubscription: func(senderID string, sub *channel.Subscription) error {
 			svc := backend.LLMFactory().GetSubscriptionSvc()
-			err := svc.Add(&sqlite.LLMSubscription{
+			newSub := &sqlite.LLMSubscription{
 				SenderID: senderID,
 				Name:     sub.Name,
 				Provider: sub.Provider,
 				BaseURL:  sub.BaseURL,
 				APIKey:   sub.APIKey,
 				Model:    sub.Model,
-			})
-			if err == nil {
-				backend.LLMFactory().Invalidate(senderID)
 			}
-			return err
+			// If user has no default subscription yet, auto-set the first one.
+			existing, _ := svc.List(senderID)
+			if len(existing) == 0 {
+				newSub.IsDefault = true
+			}
+			if err := svc.Add(newSub); err != nil {
+				return err
+			}
+			backend.LLMFactory().Invalidate(senderID)
+			return nil
 		},
 		LLMRemoveSubscription: func(id string) error {
 			svc := backend.LLMFactory().GetSubscriptionSvc()
@@ -461,6 +467,26 @@ func buildFeishuSettingsCallbacks(cfg *config.Config, backend agent.AgentBackend
 		},
 		LLMRenameSubscription: func(id, name string) error {
 			return backend.LLMFactory().GetSubscriptionSvc().Rename(id, name)
+		},
+
+		LLMUpdateSubscription: func(id string, sub *channel.Subscription) error {
+			svc := backend.LLMFactory().GetSubscriptionSvc()
+			existing, err := svc.Get(id)
+			if err != nil {
+				return err
+			}
+			existing.Name = sub.Name
+			existing.Provider = sub.Provider
+			existing.BaseURL = sub.BaseURL
+			if sub.APIKey != "" {
+				existing.APIKey = sub.APIKey
+			}
+			existing.Model = sub.Model
+			if err := svc.Update(existing); err != nil {
+				return err
+			}
+			backend.LLMFactory().Invalidate(existing.SenderID)
+			return nil
 		},
 
 		// Model tier


### PR DESCRIPTION
## Fixes

### 1. 首个订阅自动设为 default
`LLMAddSubscription` now checks if the user has no default subscription. If the newly added subscription is the first one, it's automatically set as default. This eliminates the "两个 default" issue after setup.

### 2. 移除 gpt-4o 硬编码
`config.go` no longer hardcodes `cfg.LLM.Model = "gpt-4o"` as fallback. Users must explicitly configure their model, or use the model selector dropdown in settings.

### 3. 添加订阅表单 model 改为下拉选择
`buildAddSubscriptionCard` now fetches available models from the API and renders a `select_static` dropdown instead of a text input. No more manually typing model names.

### 4. 订阅列表添加编辑功能
- Added "编辑" button next to each subscription
- `buildEditSubscriptionCard` shows current values with a model dropdown
- `LLMUpdateSubscription` callback added to channel interface and server backend
- API Key field left blank by default (keeps existing value if not changed)

## Changes

| File | Change |
|------|--------|
| `config/config.go` | Remove gpt-4o hardcoded default model |
| `serverapp/callbacks.go` | Auto-default first sub + LLMUpdateSubscription impl |
| `channel/feishu.go` | Add LLMUpdateSubscription callback |
| `channel/feishu_settings.go` | Model dropdown + edit button + edit form handler |