### PR TITLE
feat: same-directory multi-session in TUI (like Claude Code)

### DIFF
--- a/channel/cli.go
+++ b/channel/cli.go
@@ -149,6 +149,10 @@ func (c *CLIChannel) Start() error {
 	c.model.channelName = "cli"
 	c.model.defaultChatID = c.config.ChatID
 	c.model.chatID = c.config.ChatID
+	c.model.sessionName, _ = ParseChatID(c.config.ChatID)
+	if c.model.sessionName == "" {
+		c.model.sessionName = defaultSessionName
+	}
 
 	// Propagate late-injected services to model (set before Start() when model was nil)
 	if c.subscriptionMgr != nil {

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -437,6 +437,7 @@ type cliModel struct {
 	channelName     string // 当前 channel（默认 "cli"，/su 切换时可能变为 "web"）
 	defaultChatID   string // 默认 chatID（/su 切换回来时恢复）
 	chatID          string // 会话 ID（按工作目录区分）
+	sessionName     string // 当前会话名称（同目录多 session 支持）
 
 	// --- §1 增量渲染 ---
 	renderCacheValid    bool   // 全局缓存是否有效（resize 后置 false）

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -791,11 +791,15 @@ func (m *cliModel) openSessionsPanel() {
 	m.panelMode = "sessions"
 	m.relayoutViewport()
 
+	// Server sessions (from backend)
 	if m.sessionsListFn != nil {
 		m.panelSessionItems = m.sessionsListFn()
 	} else {
 		m.panelSessionItems = nil
 	}
+	// Also include local directory sessions (same-directory multi-session)
+	localSessions := m.listLocalDirSessions()
+	m.panelSessionItems = append(m.panelSessionItems, localSessions...)
 	// Position cursor on the currently active session
 	m.panelSessionCursor = 0
 	for i, entry := range m.panelSessionItems {
@@ -947,6 +951,22 @@ func (m *cliModel) updateSessionsPanel(msg tea.KeyPressMsg) (bool, *cliModel, te
 				m.panelSessionCursor = 0
 			}
 			m.ensureSessionCursorVisible()
+		}
+		return true, m, nil
+
+	// N: create new session in current directory
+	case msg.String() == "n" || msg.String() == "N":
+		if !m.panelSessionViewing {
+			return true, m, m.showSessionCreateDialog()
+		}
+
+	// D: delete selected session (except default)
+	case msg.String() == "d" || msg.String() == "D":
+		if !m.panelSessionViewing && m.panelSessionCursor >= 0 && m.panelSessionCursor < len(m.panelSessionItems) {
+			entry := m.panelSessionItems[m.panelSessionCursor]
+			if entry.Type == "main" && entry.Label != defaultSessionName {
+				m.deleteLocalSession(entry)
+			}
 		}
 		return true, m, nil
 
@@ -3024,4 +3044,66 @@ func (m *cliModel) openChannelSettingsPanel(channel string) {
 			m.showTempStatus(fmt.Sprintf("✅ %s config saved", channel))
 		}
 	})
+}
+
+// ── Session management (same-directory multi-session) ──
+
+// showSessionCreateDialog shows an input dialog for creating a new session.
+func (m *cliModel) showSessionCreateDialog() tea.Cmd {
+	schema := []SettingDefinition{
+		{Key: "session_name", Label: "Session Name", Description: "Name for the new session (e.g. debug, experiment)", Type: SettingTypeText, DefaultValue: ""},
+	}
+	m.panelMode = "" // close sessions panel
+	m.openSettingsPanel(schema, map[string]string{}, func(values map[string]string) {
+		name := strings.TrimSpace(values["session_name"])
+		if name == "" {
+			m.showTempStatus("Session name cannot be empty")
+			return
+		}
+		ds, err := loadDirSessions(m.workDir)
+		if err != nil {
+			m.showTempStatus(fmt.Sprintf("Failed: %v", err))
+			return
+		}
+		chatID, err := ds.addSession(name)
+		if err != nil {
+			m.showTempStatus(fmt.Sprintf("Failed: %v", err))
+			return
+		}
+		m.saveCurrentSession()
+		m.chatID = chatID
+		m.sessionName = name
+		m.messages = nil
+		m.lastTokenUsage = nil
+		m.invalidateAllCache(false)
+		m.restoreSession()
+		m.showTempStatus(fmt.Sprintf("Created session: %s", name))
+	})
+	return nil
+}
+
+// deleteLocalSession deletes the selected session and switches to default if active.
+func (m *cliModel) deleteLocalSession(entry SessionPanelEntry) {
+	ds, err := loadDirSessions(m.workDir)
+	if err != nil {
+		m.showTempStatus(fmt.Sprintf("Failed: %v", err))
+		return
+	}
+	if err := ds.removeSession(entry.Label); err != nil {
+		m.showTempStatus(fmt.Sprintf("Failed: %v", err))
+		return
+	}
+	// If we deleted the active session, switch to default
+	if entry.Active {
+		m.saveCurrentSession()
+		m.chatID = m.defaultChatID
+		m.sessionName = defaultSessionName
+		m.messages = nil
+		m.lastTokenUsage = nil
+		m.invalidateAllCache(false)
+		m.restoreSession()
+	}
+	m.showTempStatus(fmt.Sprintf("Deleted session: %s", entry.Label))
+	// Refresh sessions panel
+	m.openSessionsPanel()
 }

--- a/channel/cli_session.go
+++ b/channel/cli_session.go
@@ -1,0 +1,205 @@
+package channel
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"xbot/config"
+)
+
+// ── Session name utilities ──
+
+const defaultSessionName = "default"
+
+// SessionChatID builds a chatID from workDir and session name.
+// Old format (backward compat): when sessionName is "default", returns just workDir.
+func SessionChatID(workDir, sessionName string) string {
+	if sessionName == "" || sessionName == defaultSessionName {
+		return workDir
+	}
+	return workDir + ":" + sessionName
+}
+
+// ParseChatID extracts the workDir and sessionName from a chatID.
+// Returns (workDir, sessionName). If there's no ":" separator, sessionName is "default".
+func ParseChatID(chatID string) (workDir, sessionName string) {
+	idx := strings.LastIndex(chatID, ":")
+	if idx <= 0 || idx == len(chatID)-1 {
+		return chatID, defaultSessionName
+	}
+	// WorkDir is everything before the last ":", session name after.
+	workDir = chatID[:idx]
+	sessionName = chatID[idx+1:]
+	// Validate: workDir should look like an absolute path
+	if !strings.HasPrefix(workDir, "/") && !strings.HasPrefix(workDir, ".") {
+		return chatID, defaultSessionName
+	}
+	return workDir, sessionName
+}
+
+// ── Per-directory session storage ──
+
+// dirSessions stores the list of sessions for a given directory.
+// Persisted to ~/.xbot/sessions/<hash>.json
+type dirSessions struct {
+	Dir      string       `json:"dir"`
+	Sessions []dirSession `json:"sessions"`
+}
+
+type dirSession struct {
+	Name      string    `json:"name"`
+	ChatID    string    `json:"chat_id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// sessionsDir returns the directory where per-directory session files are stored.
+func sessionsDir() string {
+	return filepath.Join(config.XbotHome(), "sessions")
+}
+
+// loadDirSessions loads the session list for a given work directory.
+func loadDirSessions(workDir string) (*dirSessions, error) {
+	dir := sessionsDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+	hash := sessionDirHash(workDir)
+	path := filepath.Join(dir, hash+".json")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No sessions file yet — return empty list with default session
+			return &dirSessions{
+				Dir: workDir,
+				Sessions: []dirSession{{
+					Name:      defaultSessionName,
+					ChatID:    workDir,
+					CreatedAt: time.Now(),
+				}},
+			}, nil
+		}
+		return nil, err
+	}
+
+	var ds dirSessions
+	if err := json.Unmarshal(data, &ds); err != nil {
+		return nil, fmt.Errorf("parse sessions file: %w", err)
+	}
+	ds.Dir = workDir
+	// Ensure default session always exists
+	if !ds.hasSession(defaultSessionName) {
+		ds.Sessions = append([]dirSession{{
+			Name:      defaultSessionName,
+			ChatID:    workDir,
+			CreatedAt: time.Now(),
+		}}, ds.Sessions...)
+	}
+	return &ds, nil
+}
+
+// saveDirSessions persists the session list to disk.
+func (ds *dirSessions) save() error {
+	dir := sessionsDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	hash := sessionDirHash(ds.Dir)
+	path := filepath.Join(dir, hash+".json")
+	data, err := json.MarshalIndent(ds, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func (ds *dirSessions) hasSession(name string) bool {
+	for _, s := range ds.Sessions {
+		if s.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// addSession adds a new session to the directory.
+func (ds *dirSessions) addSession(name string) (string, error) {
+	if ds.hasSession(name) {
+		return "", fmt.Errorf("session %q already exists", name)
+	}
+	chatID := SessionChatID(ds.Dir, name)
+	ds.Sessions = append(ds.Sessions, dirSession{
+		Name:      name,
+		ChatID:    chatID,
+		CreatedAt: time.Now(),
+	})
+	return chatID, ds.save()
+}
+
+// removeSession removes a session (except "default").
+func (ds *dirSessions) removeSession(name string) error {
+	if name == defaultSessionName {
+		return fmt.Errorf("cannot delete default session")
+	}
+	for i, s := range ds.Sessions {
+		if s.Name == name {
+			ds.Sessions = append(ds.Sessions[:i], ds.Sessions[i+1:]...)
+			return ds.save()
+		}
+	}
+	return fmt.Errorf("session %q not found", name)
+}
+
+// sortedSessions returns sessions sorted by creation time.
+func (ds *dirSessions) sortedSessions() []dirSession {
+	sorted := make([]dirSession, len(ds.Sessions))
+	copy(sorted, ds.Sessions)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].CreatedAt.Before(sorted[j].CreatedAt)
+	})
+	return sorted
+}
+
+// sessionDirHash creates a safe filename hash from a directory path.
+// Uses simple character substitution to avoid collision issues.
+func sessionDirHash(workDir string) string {
+	abs, _ := filepath.Abs(workDir)
+	// Remove trailing separators
+	abs = strings.TrimRight(abs, string(filepath.Separator))
+	// Replace path separators and colons
+	hash := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		":", "_",
+		" ", "_",
+	).Replace(abs)
+	// Remove leading underscore from absolute paths
+	hash = strings.TrimPrefix(hash, "_")
+	return hash
+}
+
+// listLocalDirSessions returns all sessions in the current directory from
+// the local session store (used by the sessions panel).
+func (m *cliModel) listLocalDirSessions() []SessionPanelEntry {
+	ds, err := loadDirSessions(m.workDir)
+	if err != nil {
+		return nil
+	}
+	var entries []SessionPanelEntry
+	for _, s := range ds.sortedSessions() {
+		active := s.ChatID == m.chatID
+		entries = append(entries, SessionPanelEntry{
+			ID:      s.ChatID,
+			Label:   s.Name,
+			Type:    "main",
+			Channel: "cli",
+			Active:  active,
+		})
+	}
+	return entries
+}


### PR DESCRIPTION
## Feature

类似 Claude Code 的同目录多 session 功能。每个工作目录可以有多个命名 session，通过 `/ss` 面板相互切换。

## 使用方式

- **`/ss`** 打开 sessions 面板，显示当前目录所有 session
- **N** — 创建新 session（输入名称）
- **D** — 删除选中的 session（不能删除 default）
- **Enter** — 切换到选中的 session
- **Esc** — 关闭面板

## 设计

- `chatID` 格式：`<workdir>[:<sessionName>]`
- 旧格式（不带 `:name` 后缀）自动映射为 "default" session，**完全向后兼容**
- Session 列表持久化在 `~/.xbot/sessions/<dir_hash>.json`

## Changes

| File | Change |
|------|--------|
| `channel/cli_session.go` | 新文件：session CRUD，chatID 解析，本地文件存储 |
| `channel/cli_model.go` | 加 `sessionName` 字段 |
| `channel/cli.go` | Start() 解析 sessionName |
| `channel/cli_panel.go` | sessions panel 显示本地 session，N/D 键绑定 |