### PR TITLE
fix(llm): decouple reasoning_content round-trip from thinkingMode config

### DIFF
--- a/llm/openai.go
+++ b/llm/openai.go
@@ -349,13 +349,17 @@ func hasAssistantReasoningHistory(messages []ChatMessage) bool {
 }
 
 // toOpenAIMessages 将业务消息转换为 OpenAI 消息格式。
-// 显式开启 thinking mode 时，所有 assistant 消息都会包含 reasoning_content 字段。
-// 在 auto 模式下，只要历史里已经出现过 assistant reasoning，也会为所有 assistant
-// 消息补齐该字段（缺失时传空字符串），以满足 DeepSeek/OpenAI reasoning provider
-// 对历史消息形状的一致性要求。
+//
+// reasoning_content 处理规则：
+//
+//	只要历史中出现过 assistant reasoning（无论来源模型），
+//	所有 assistant 消息都会包含 reasoning_content 字段。
+//	这是 API 的数据完整性要求（DeepSeek thinking 模式硬性要求回传），
+//	不依赖 thinkingMode 配置——thinkingMode 只控制是否向 API 请求 thinking，
+//	不应影响历史消息的 round-trip 完整性。
 func toOpenAIMessages(messages []ChatMessage, thinkingMode string) []openai.ChatCompletionMessageParamUnion {
 	thinkingEnabled := thinkingMode != "" && thinkingMode != "disabled"
-	reasoningHistoryObserved := thinkingMode != "disabled" && hasAssistantReasoningHistory(messages)
+	reasoningHistoryObserved := hasAssistantReasoningHistory(messages)
 	result := make([]openai.ChatCompletionMessageParamUnion, 0, len(messages))
 	for _, msg := range messages {
 		switch msg.Role {


### PR DESCRIPTION
## Problem

DeepSeek v4-pro (always-thinking model) 在多轮 tool_calls 对话中报 400：

```
The reasoning_content in the thinking mode must be passed back to the API
```

用户场景：DeepSeek thinking 模式 + 调用 SubAgent + 中途取消 → 100% 复现。

## Root Cause

`toOpenAIMessages` 中 `reasoningHistoryObserved` 被 `thinkingMode != "disabled"` 门控：

```go
reasoningHistoryObserved := thinkingMode != "disabled" && hasAssistantReasoningHistory(messages)
```

`reasoningHistoryObserved` 本质是数据完整性判断（"历史中有没有 reasoning 数据"），不应受 `thinkingMode` 配置控制。`thinkingMode` 应该只控制**是否向 API 请求 thinking**（`buildThinkingOptions`），不应影响**历史消息的序列化**。

## Fix

移除 `thinkingMode` 前提条件：

```go
reasoningHistoryObserved := hasAssistantReasoningHistory(messages)
```

一行改动，不需要新增函数或模型检测逻辑。

## Experiment

用 DeepSeek v4-pro API 做了 7 组实验，确认 API 行为：

| content | tool_calls | reasoning_content | 结果 |
|---------|-----------|-------------------|------|
| `null` | ✅ | ✅ | ✅ 200 |
| `null` | ✅ | ❌ 缺失 | ❌ 400 "reasoning_content must be passed back" |
| `""` | ✅ | ✅ | ✅ 200 |
| `""` | ✅ | ❌ 缺失 | ❌ 400 "reasoning_content must be passed back" |

结论：DeepSeek v4-pro 要求历史中有 tool_calls 的 assistant 消息必须带 `reasoning_content` 字段，与 `content` 是 null 还是空字符串无关。

## Complementary to #34

#34 修复了流取消时的数据来源问题（stream.go 保留部分内容 + SanitizeMessages Pass 2 清理残缺 tool_calls）。

本 PR 修复的是序列化层问题：即使数据完整，发给 API 时 `reasoning_content` 可能因为 `thinkingMode` 配置而漏传。两个修复互补。

## Test

- `go build ./...` ✅
- `go test ./...` ✅（含 7 个 reasoning 相关测试全部通过）