### PR TITLE
fix: TUI channel config changes not taking effect

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -95,6 +95,10 @@
 - **Old `ToolHook`/`HookChain` is gone.** Replaced by `agent/hooks/Manager`. Any code referencing `HookChain`, `ToolHook`, `executeWithHooks` is stale.
 - **Manager.Emit() is shared across Agent + SubAgents** (same instance). Must be concurrency-safe.
 - **Decision priority**: `deny > defer > ask > allow`. Low-priority layer deny cannot be overridden by high-priority allow.
+
+### Channel Configuration
+- **TUI channel config changes require live channel restart.** Writing config.json is not enough — Feishu/Web/QQ/NapCat channels are created once at startup via `registerChannels()`. `SetChannelConfig()` now calls `reconfigureFn` (set by server.go) to start/stop the affected channel. Any new channel type must be added to both `channelShouldRun()` and `createChannelInstance()`.
+- **Key naming must be consistent across all channels.** Web used `enable` while Feishu/QQ/NapCat used `enabled` — the RPC handler only checked `enabled`, so web changes were silently ignored. All channels now use `enabled` (with backward compat for `enable`).
 - **Command hooks disabled by default** — requires `enable_command_hooks: true` in config.
 - **Max 10 handlers per event**, total timeout 60s. Excess silently truncated with warning log.
 

--- a/agent/backend.go
+++ b/agent/backend.go
@@ -299,6 +299,10 @@ type AgentBackend interface {
 	// channel: "web", "feishu", "qq", or "napcat".
 	SetChannelConfig(channel string, values map[string]string) error
 
+	// SetChannelReconfigureFn sets a callback to restart a channel after config changes.
+	// In remote mode, channel restart is handled server-side via RPC; this is a no-op.
+	SetChannelReconfigureFn(fn func(channel string))
+
 	// CallRPC sends a raw RPC call to the server (RemoteBackend forwards via WS).
 	// LocalBackend returns an error (not available in standalone mode, but
 	// CLI callbacks use DB directly instead of going through this).

--- a/agent/backend_local.go
+++ b/agent/backend_local.go
@@ -36,8 +36,9 @@ var (
 // Outbound messages flow through the MessageBus as usual — the caller
 // should set up a Dispatcher to route them to channels.
 type LocalBackend struct {
-	agent *Agent
-	bus   *bus.MessageBus
+	agent         *Agent
+	bus           *bus.MessageBus
+	reconfigureFn func(channel string) // called after SetChannelConfig to restart affected channel
 }
 
 // NewLocalBackend creates a LocalBackend with the given agent config.
@@ -717,6 +718,12 @@ func (b *LocalBackend) ResetTokenState() {
 	// /rewind already clears token state via TrimHistory → SetTokenState(0,0).
 }
 
+// SetChannelReconfigureFn sets the function to call after channel config changes
+// to restart the affected live channel.
+func (b *LocalBackend) SetChannelReconfigureFn(fn func(channel string)) {
+	b.reconfigureFn = fn
+}
+
 func (b *LocalBackend) GetChannelConfigs() (map[string]map[string]string, error) {
 	cfg := config.LoadFromFile(config.ConfigFilePath())
 	if cfg == nil {
@@ -724,9 +731,9 @@ func (b *LocalBackend) GetChannelConfigs() (map[string]map[string]string, error)
 	}
 	result := make(map[string]map[string]string)
 	result["web"] = map[string]string{
-		"enable": strconv.FormatBool(cfg.Web.Enable),
-		"host":   cfg.Web.Host,
-		"port":   strconv.Itoa(cfg.Web.Port),
+		"enabled": strconv.FormatBool(cfg.Web.Enable),
+		"host":    cfg.Web.Host,
+		"port":    strconv.Itoa(cfg.Web.Port),
 	}
 	result["feishu"] = map[string]string{
 		"enabled":            strconv.FormatBool(cfg.Feishu.Enabled),
@@ -756,7 +763,10 @@ func (b *LocalBackend) SetChannelConfig(channel string, values map[string]string
 	}
 	switch channel {
 	case "web":
-		if v, ok := values["enable"]; ok {
+		// Accept both "enable" (legacy) and "enabled" (aligned with other channels)
+		if v, ok := values["enabled"]; ok {
+			cfg.Web.Enable, _ = strconv.ParseBool(v)
+		} else if v, ok := values["enable"]; ok {
 			cfg.Web.Enable, _ = strconv.ParseBool(v)
 		}
 		if v, ok := values["host"]; ok {
@@ -807,7 +817,11 @@ func (b *LocalBackend) SetChannelConfig(channel string, values map[string]string
 	default:
 		return fmt.Errorf("unknown channel: %s", channel)
 	}
-	return config.SaveToFile(config.ConfigFilePath(), cfg)
+	err := config.SaveToFile(config.ConfigFilePath(), cfg)
+	if b.reconfigureFn != nil {
+		b.reconfigureFn(channel)
+	}
+	return err
 }
 
 func (b *LocalBackend) Run(ctx context.Context) error {

--- a/agent/backend_remote.go
+++ b/agent/backend_remote.go
@@ -1421,6 +1421,10 @@ func (b *RemoteBackend) SetChannelConfig(channel string, values map[string]strin
 	})
 }
 
+// SetChannelReconfigureFn is a no-op in remote mode: channel restart
+// is handled server-side via the set_channel_config RPC.
+func (b *RemoteBackend) SetChannelReconfigureFn(fn func(channel string)) {}
+
 func (b *RemoteBackend) Run(ctx context.Context) error {
 	<-ctx.Done()
 	return ctx.Err()

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -2952,7 +2952,7 @@ func channelSettingsSchema(channel string) []SettingDefinition {
 	switch channel {
 	case "web":
 		return []SettingDefinition{
-			{Key: "enable", Label: "Enable", Description: "Enable Web channel", Type: SettingTypeToggle, Category: "Web Channel", DefaultValue: "false"},
+			{Key: "enabled", Label: "Enabled", Description: "Enable Web channel", Type: SettingTypeToggle, Category: "Web Channel", DefaultValue: "false"},
 			{Key: "host", Label: "Host", Description: "Listen host (e.g. 0.0.0.0)", Type: SettingTypeText, Category: "Web Channel", DefaultValue: "0.0.0.0"},
 			{Key: "port", Label: "Port", Description: "Listen port (e.g. 8080)", Type: SettingTypeText, Category: "Web Channel", DefaultValue: "8080"},
 		}

--- a/cmd/xbot-cli/main_test.go
+++ b/cmd/xbot-cli/main_test.go
@@ -827,7 +827,8 @@ func (b *fakeAgentBackend) GetChannelConfigs() (map[string]map[string]string, er
 func (b *fakeAgentBackend) SetChannelConfig(channel string, values map[string]string) error {
 	return nil
 }
-func (b *fakeAgentBackend) Close() error { return nil }
+func (b *fakeAgentBackend) SetChannelReconfigureFn(func(string)) {}
+func (b *fakeAgentBackend) Close() error                         { return nil }
 func (b *fakeAgentBackend) CallRPC(string, any) (json.RawMessage, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/serverapp/rpc_table.go
+++ b/serverapp/rpc_table.go
@@ -731,7 +731,12 @@ func registerAdminHandlers(t rpcTable, h *rpcContext) {
 		if err := backend.SetChannelConfig(p.Channel, p.Values); err != nil {
 			return nil, err
 		}
-		if enabledVal, ok := p.Values["enabled"]; ok && disp != nil && msgBus != nil {
+		enabledVal, ok := p.Values["enabled"]
+		if !ok {
+			// Fallback: web channel historically used "enable", not "enabled".
+			enabledVal, ok = p.Values["enable"]
+		}
+		if ok && disp != nil && msgBus != nil {
 			enabled, _ := strconv.ParseBool(enabledVal)
 			_, alreadyRunning := disp.GetChannel(p.Channel)
 			if enabled && !alreadyRunning {

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -220,6 +220,21 @@ func createChannelInstance(name string, cfg *config.Config, msgBus *bus.MessageB
 	}
 }
 
+// channelShouldRun returns true if the given channel should be running
+// based on the current config.
+func channelShouldRun(cfg *config.Config, name string) bool {
+	switch name {
+	case "feishu":
+		return cfg.Feishu.Enabled
+	case "qq":
+		return cfg.QQ.Enabled
+	case "napcat":
+		return cfg.NapCat.Enabled
+	default:
+		return false
+	}
+}
+
 // registerChannels creates and registers all channels.
 func registerChannels(disp *channel.Dispatcher, cfg *config.Config, msgBus *bus.MessageBus, backend agent.AgentBackend, webDB *sql.DB, workDir string) (*channel.FeishuChannel, *channel.WebChannel, error) {
 	var feishuCh *channel.FeishuChannel
@@ -577,6 +592,39 @@ func Run(args []string) error {
 	if err != nil {
 		log.WithError(err).Fatal("Failed to register channels")
 	}
+
+	// Wire channel reconfiguration: when TUI channel config changes, restart
+	// the affected channel so it picks up the new configuration immediately.
+	backend.SetChannelReconfigureFn(func(name string) {
+		if disp == nil || msgBus == nil {
+			return
+		}
+		cfg := config.LoadFromFile(config.ConfigFilePath())
+		if cfg == nil {
+			return
+		}
+		_, running := disp.GetChannel(name)
+		shouldRun := channelShouldRun(cfg, name)
+		if shouldRun && !running {
+			if ch := createChannelInstance(name, cfg, msgBus); ch != nil {
+				disp.Register(ch)
+				go func(n string, c any) {
+					defer func() {
+						if r := recover(); r != nil {
+							log.WithField("channel", n).Error("Dynamic channel start panicked\n" + string(debug.Stack()))
+						}
+					}()
+					if sc, ok := c.(interface{ Start() error }); ok {
+						if err := sc.Start(); err != nil {
+							log.WithError(err).WithField("channel", n).Error("Dynamic channel failed")
+						}
+					}
+				}(ch.Name(), ch)
+			}
+		} else if !shouldRun && running {
+			disp.Unregister(name)
+		}
+	})
 
 	// Build RPC table once at startup; per-request identity is passed via context.
 	rpcTable := buildRPCTable(cfg, backend, disp, msgBus)

--- a/serverapp/server_test.go
+++ b/serverapp/server_test.go
@@ -206,6 +206,7 @@ func (b fakeBackend) TrimHistory(_, _ string, _ time.Time) error                
 func (b fakeBackend) ResetTokenState()                                                   {}
 func (b fakeBackend) GetChannelConfigs() (map[string]map[string]string, error)           { return nil, nil }
 func (b fakeBackend) SetChannelConfig(channel string, values map[string]string) error    { return nil }
+func (b fakeBackend) SetChannelReconfigureFn(func(string))                               {}
 func (b fakeBackend) Close() error                                                       { return nil }
 func (b fakeBackend) CallRPC(string, any) (json.RawMessage, error) {
 	return nil, fmt.Errorf("not implemented")


### PR DESCRIPTION
## Bug

TUI channel 配置面板改了什么都不生效——关闭 Web、开启飞书，完全无效。

## Root Cause

1. **Key 命名不一致**: TUI settings 对 web 用 `enable`，但 RPC handler 检查 `enabled` → web 改动从未被检测到
2. **本地 backend 没有重启 channel**: `SetChannelConfig` 写入了 config.json，但运行中的 channel 实例从未重新配置
3. **RPC handler 缺少 disable 逻辑**: 只能启用 channel，不能禁用它

## Fix

| File | Change |
|------|--------|
| `channel/cli_panel.go` | web key: `enable` → `enabled` |
| `agent/backend_local.go` | 添加 `SetChannelReconfigureFn` + 保存后调用 + key 兼容 |
| `serverapp/server.go` | 注册 reconfiguration callback（启动/停止 channel） |
| `serverapp/rpc_table.go` | 接受 `enable` 作为 web 的向后兼容 key |