### PR TITLE
fix: macOS TUI rendering chaos + mouse wheel support

### DIFF
--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -366,11 +366,13 @@ func (m *cliModel) View() tea.View {
 	if !m.splashDone {
 		v := tea.NewView(m.renderSplash())
 		v.AltScreen = true
+		v.MouseMode = tea.MouseModeCellMotion
 		return v
 	}
 	if !m.ready {
 		v := tea.NewView("\n  " + m.locale.SplashLoading)
 		v.AltScreen = true
+		v.MouseMode = tea.MouseModeCellMotion
 		return v
 	}
 
@@ -378,6 +380,7 @@ func (m *cliModel) View() tea.View {
 	if m.easterEgg != easterEggNone {
 		v := tea.NewView(m.renderEasterEggOverlay())
 		v.AltScreen = true
+		v.MouseMode = tea.MouseModeCellMotion
 		return v
 	}
 
@@ -385,6 +388,7 @@ func (m *cliModel) View() tea.View {
 	if m.suLoading {
 		v := tea.NewView(m.renderSuLoading())
 		v.AltScreen = true
+		v.MouseMode = tea.MouseModeCellMotion
 		return v
 	}
 
@@ -408,6 +412,7 @@ func (m *cliModel) View() tea.View {
 
 	v := tea.NewView(content)
 	v.AltScreen = true
+	v.MouseMode = tea.MouseModeCellMotion
 
 	// Command palette overlay (highest priority — hides everything)
 	if m.paletteOpen {

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strconv"
@@ -771,26 +772,19 @@ func (app *cliApp) Close() {
 // go-runewidth (used by BubbleTea/ultraviolet renderer) and ansi.StringWidth
 // (used by xbot's hardWrapRunes/truncateToWidth/lipgloss).
 //
-// In CJK locales (LANG=zh_CN.UTF-8, ja_JP.UTF-8, ko_KR.UTF-8), go-runewidth
-// auto-detects EastAsianWidth=true, which makes ambiguous-width characters
-// (box-drawing │├─, block elements ▋, punctuation ·…) treated as 2 columns.
-// But ansi.StringWidth defaults to EastAsianWidth=false (only sets true when
-// RUNEWIDTH_EASTASIAN env var is explicitly set).
+// In CJK locales, go-runewidth auto-detects EastAsianWidth=true, which makes
+// ambiguous-width characters (box-drawing │├─, block elements ▋, punctuation ·…)
+// treated as 2 columns. But ansi.StringWidth defaults to EastAsianWidth=false
+// unless RUNEWIDTH_EASTASIAN=1 is set.
 //
-// This mismatch causes the terminal to render characters at different widths
-// than what the wrapping code expects, leading to CJK text being overwritten
-// during rapid streaming updates (Issue #14).
-//
-// We fix this by re-executing the process with RUNEWIDTH_EASTASIAN=1 when a
-// CJK locale is detected and the env var isn't already set. This ensures
-// both go-runewidth and ansi.StringWidth use EastAsianWidth=true.
+// On macOS, LANG is often empty even when the system language is set to CJK.
+// We also check LC_ALL, LC_CTYPE, and AppleLocale to detect CJK environments.
 func ensureCJKWidth() {
 	if os.Getenv("RUNEWIDTH_EASTASIAN") != "" {
 		return // Already explicitly configured
 	}
 
-	lang := os.Getenv("LANG")
-	if !isCJKLocale(lang) {
+	if !isCJKLocaleEnv() {
 		return
 	}
 
@@ -806,6 +800,25 @@ func ensureCJKWidth() {
 	}
 	syscall.Exec(execPath, os.Args, os.Environ())
 	// If we reach here, exec failed — continue with default behavior.
+}
+
+// isCJKLocaleEnv checks environment variables and macOS-specific locale
+// settings to determine if the current environment is CJK.
+func isCJKLocaleEnv() bool {
+	// Check standard locale environment variables (works on Linux + macOS)
+	for _, env := range []string{"LANG", "LC_ALL", "LC_CTYPE"} {
+		if isCJKLocale(os.Getenv(env)) {
+			return true
+		}
+	}
+	// macOS: check AppleLocale user default (e.g. "zh-Hans-CN" or "zh-Hant-TW")
+	cmd := exec.Command("defaults", "read", "-g", "AppleLocale")
+	if out, err := cmd.Output(); err == nil {
+		if isCJKLocale(strings.TrimSpace(string(out))) {
+			return true
+		}
+	}
+	return false
 }
 
 // isCJKLocale returns true if the given locale string indicates CJK.


### PR DESCRIPTION
## Bug

最新 master 在 macOS（Mac mini + MacBook Air）上 TUI 样式完全错乱：
- 各种对齐不对（title bar、progress panel、tool output 全乱）
- Head 两行渲染错位
- 鼠标滚轮完全无效
- iTerm 和 Terminal.app 都有问题
- **仅 macOS 有这个问题**

## Root Cause

### 1. CJK 宽度检测在 macOS 上失效

`ensureCJKWidth()` 只检查 `LANG` 环境变量。macOS 上 `LANG` 通常为空（即使系统语言设为中文），导致 `RUNEWIDTH_EASTASIAN` 永远不会被设置为 `1`。

`go-runewidth`（BubbleTea/lipgloss 内部用）和 `ansi.StringWidth`（xbot 自己的截断代码用）对 CJK 字符宽度判断不一致 → 所有对齐计算全部出错。

**修复**: 增加检测 `LC_ALL`、`LC_CTYPE` 和 macOS 的 `AppleLocale` (`defaults read -g AppleLocale`)

### 2. Bubble Tea v2 未启用鼠标

Bubble Tea v2 的鼠标模式通过 `View.MouseMode` 设置，不是 v1 的 `ProgramOption`。所有 `View()` 返回都缺少 `MouseMode = tea.MouseModeCellMotion`。

**修复**: 在所有 `View()` 返回处设置 `v.MouseMode = tea.MouseModeCellMotion`

## Changes

| File | Change |
|------|--------|
| `cmd/xbot-cli/main.go` | CJK locale detection: +LC_ALL/LC_CTYPE + AppleLocale check |
| `channel/cli_view.go` | All View() returns: +MouseMode = MouseModeCellMotion |