### PR TITLE
fix(agent): follow symlinks when scanning skill directories

### DIFF
--- a/agent/skills.go
+++ b/agent/skills.go
@@ -117,10 +117,12 @@ func (s *SkillStore) refreshSkills(ctx context.Context, senderID string) ([]Skil
 		}
 
 		for _, e := range entries {
-			if !e.IsDir() {
+			skillDir := filepath.Join(dir, e.Name())
+			// Use os.Stat (not e.IsDir) to follow symlinks.
+			info, err := os.Stat(skillDir)
+			if err != nil || !info.IsDir() {
 				continue
 			}
-			skillDir := filepath.Join(dir, e.Name())
 			skillFile := filepath.Join(skillDir, "SKILL.md")
 			if _, err := os.Stat(skillFile); err != nil {
 				continue
@@ -248,10 +250,12 @@ func (s *SkillStore) scanUserSkills(ctx context.Context, senderID string, merged
 			return // directory doesn't exist or unreadable — not an error
 		}
 		for _, e := range entries {
-			if !e.IsDir() {
+			skillDir := filepath.Join(userDir, e.Name())
+			// Use os.Stat (not e.IsDir) to follow symlinks.
+			info, err := os.Stat(skillDir)
+			if err != nil || !info.IsDir() {
 				continue
 			}
-			skillDir := filepath.Join(userDir, e.Name())
 			skillFile := filepath.Join(skillDir, "SKILL.md")
 			if _, err := os.Stat(skillFile); err != nil {
 				continue


### PR DESCRIPTION
## Summary
Fix skill directory scanning to correctly follow symbolic links.

`fs.DirEntry.IsDir()` does not follow symlinks — it reports a symlink to a directory as a regular file. This caused symlinked skill directories to be silently skipped during scan.

Switch to `os.Stat()` + `info.IsDir()` in both:
- `refreshSkills()` (system skills path)
- `scanUserSkills()` (user skills path)

## Change
- `agent/skills.go`: replace `!e.IsDir()` checks with `os.Stat` calls that follow symlinks before checking `IsDir()`.