### PR TITLE
feat: add release channels (stable/beta/nightly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,27 @@ jobs:
       - name: Build
         working-directory: web
         run: yarn build
+
+  # Trigger nightly release after CI passes on master push
+  nightly:
+    name: Nightly Release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [lint, build, test, build-windows, test-windows, frontend]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Trigger nightly release workflow
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yml',
+              ref: 'master',
+              inputs: {
+                channel: 'nightly'
+              }
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,18 +3,56 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*'             # stable: v1.2.3  /  beta: v1.2.3-beta.1
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Release channel (nightly or beta)'
+        required: true
+        default: 'nightly'
+        type: choice
+        options:
+          - nightly
+          - beta
 
 permissions:
   contents: write
 
 env:
-  VERSION: ${{ github.ref_name }}
   COMMIT: ${{ github.sha }}
 
 jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      channel: ${{ steps.meta.outputs.channel }}
+    steps:
+      - id: meta
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            TAG="${{ github.ref_name }}"
+            echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+            if [[ "$TAG" == *"-"* ]]; then
+              echo "channel=beta" >> "$GITHUB_OUTPUT"
+            else
+              echo "channel=stable" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            CH="${{ github.event.inputs.channel }}"
+            DATE=$(date -u +%Y%m%d)
+            if [[ "$CH" == "nightly" ]]; then
+              echo "version=nightly-${DATE}" >> "$GITHUB_OUTPUT"
+            else
+              echo "version=beta-${DATE}" >> "$GITHUB_OUTPUT"
+            fi
+            echo "channel=${CH}" >> "$GITHUB_OUTPUT"
+          fi
+
   frontend:
     name: Frontend
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +77,7 @@ jobs:
 
   build-linux-amd64:
     name: Build linux/amd64
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,10 +85,13 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Build
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: |
           mkdir -p dist
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-            -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X xbot/version.Channel=${CHANNEL}" \
             -o dist/xbot-cli-linux-amd64 ./cmd/xbot-cli
       - uses: actions/upload-artifact@v4
         with:
@@ -58,6 +100,7 @@ jobs:
 
   build-linux-arm64:
     name: Build linux/arm64
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -65,10 +108,13 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Build
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: |
           mkdir -p dist
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
-            -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X xbot/version.Channel=${CHANNEL}" \
             -o dist/xbot-cli-linux-arm64 ./cmd/xbot-cli
       - uses: actions/upload-artifact@v4
         with:
@@ -77,6 +123,7 @@ jobs:
 
   build-darwin-arm64:
     name: Build darwin/arm64
+    needs: prepare
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -84,10 +131,13 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Build
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: |
           mkdir -p dist
           CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build \
-            -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X xbot/version.Channel=${CHANNEL}" \
             -o dist/xbot-cli-darwin-arm64 ./cmd/xbot-cli
       - uses: actions/upload-artifact@v4
         with:
@@ -96,6 +146,7 @@ jobs:
 
   build-windows-amd64:
     name: Build windows/amd64
+    needs: prepare
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -104,10 +155,13 @@ jobs:
           go-version-file: go.mod
       - name: Build
         shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: |
           mkdir -p dist
           CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build \
-            -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X xbot/version.Channel=${CHANNEL}" \
             -o dist/xbot-cli-windows-amd64.exe ./cmd/xbot-cli
       - uses: actions/upload-artifact@v4
         with:
@@ -116,6 +170,7 @@ jobs:
 
   build-windows-arm64:
     name: Build windows/arm64
+    needs: prepare
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -124,10 +179,13 @@ jobs:
           go-version-file: go.mod
       - name: Build
         shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
         run: |
           mkdir -p dist
           CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build \
-            -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X xbot/version.Channel=${CHANNEL}" \
             -o dist/xbot-cli-windows-arm64.exe ./cmd/xbot-cli
       - uses: actions/upload-artifact@v4
         with:
@@ -136,7 +194,7 @@ jobs:
 
   release:
     name: Release
-    needs: [frontend, build-linux-amd64, build-linux-arm64, build-darwin-arm64, build-windows-amd64, build-windows-arm64]
+    needs: [prepare, frontend, build-linux-amd64, build-linux-arm64, build-darwin-arm64, build-windows-amd64, build-windows-arm64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -150,9 +208,21 @@ jobs:
         working-directory: dist
         run: sha256sum * > ../checksums.txt
 
+      - name: Determine prerelease flag
+        id: prerelease
+        run: |
+          CHANNEL="${{ needs.prepare.outputs.channel }}"
+          if [[ "$CHANNEL" == "nightly" || "$CHANNEL" == "beta" ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.prepare.outputs.version }}
+          prerelease: ${{ steps.prerelease.outputs.prerelease }}
           generate_release_notes: true
           files: |
             dist/xbot-cli-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ test:
 	go test -v -race -coverprofile=coverage.out ./...
 
 VERSION := $(shell git describe --tags --always 2>/dev/null || echo dev)
-LDFLAGS := -X xbot/version.Version=$(VERSION) -X xbot/version.Commit=$(shell git rev-parse --short HEAD) -X xbot/version.BuildTime=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+CHANNEL := $(shell git branch --show-current 2>/dev/null | sed 's/master/stable/' | sed 's/.*/stable/' | head -1)
+LDFLAGS := -X xbot/version.Version=$(VERSION) -X xbot/version.Commit=$(shell git rev-parse --short HEAD) -X xbot/version.BuildTime=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) -X xbot/version.Channel=$(CHANNEL)
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) .

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -956,7 +956,11 @@ func (m *cliModel) handleUpdateCheck(msg cliUpdateCheckMsg) {
 		content := fmt.Sprintf(m.locale.UpdateFound, msg.info.Current, msg.info.Latest, msg.info.URL)
 		m.showSystemMsg(content, feedbackInfo)
 	} else {
-		content := fmt.Sprintf(m.locale.UpdateCurrent, msg.info.Current)
+		ch := msg.info.Channel
+		if ch == "" {
+			ch = "dev"
+		}
+		content := fmt.Sprintf(m.locale.UpdateCurrent, msg.info.Current, ch)
 		m.showSystemMsg(content, feedbackInfo)
 	}
 }

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -1195,7 +1195,7 @@ func (m *cliModel) renderSplash() string {
 	lines = append(lines, "")
 
 	// 版本号居中
-	versionText := versionStyle.Render(fmt.Sprintf("xbot %s · %s", version.Version, version.Commit))
+	versionText := versionStyle.Render(fmt.Sprintf("xbot %s · %s · %s", version.Version, version.Channel, version.Commit))
 	vW := lipgloss.Width(versionText)
 	vPad := (screenW - vW) / 2
 	if vPad < 0 {

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -216,8 +216,8 @@ func localeZH() *UILocale {
 		AskCancelled:   "已取消提问",
 		SetupComplete:  "✅ 初始配置完成，可以开始使用了。随时用 /settings 修改配置，/setup 重新引导。",
 		SetupLettaNote: "\n\n[!] letta 记忆模式需要嵌入服务:\n  1. 安装 Ollama: https://ollama.ai\n  2. 拉取嵌入模型: `ollama pull nomic-embed-text`\n  3. 在配置或环境变量中设置嵌入端点",
-		UpdateFound:    "发现新版本: %s → %s\n升级命令: curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash\n%s",
-		UpdateCurrent:  "当前版本 %s 已是最新",
+		UpdateFound:    "发现新版本: %s → %s (stable)\n升级命令: curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash\n%s",
+		UpdateCurrent:  "当前版本 %s (channel: %s) 已是最新",
 		UpdateFailed:   "更新检查失败（网络超时或无法连接 GitHub API）",
 
 		// --- B. Panel text ---
@@ -603,8 +603,8 @@ func localeEN() *UILocale {
 		AskCancelled:   "Question cancelled",
 		SetupComplete:  "✅ Initial setup complete. Use /settings to configure, /setup to re-run.",
 		SetupLettaNote: "\n\n[!] letta memory mode requires embedding service:\n  1. Install Ollama: https://ollama.ai\n  2. Pull embedding model: `ollama pull nomic-embed-text`\n  3. Set embedding endpoint in config or env",
-		UpdateFound:    "New version available: %s → %s\nUpdate command: curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash\n%s",
-		UpdateCurrent:  "Current version %s is up to date",
+		UpdateFound:    "New version available: %s → %s (stable)\nUpdate command: curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash\n%s",
+		UpdateCurrent:  "Current version %s (channel: %s) is up to date",
 		UpdateFailed:   "Update check failed (network timeout or unable to connect to GitHub API)",
 
 		// --- B. Panel text ---
@@ -985,8 +985,8 @@ func localeJA() *UILocale {
 		AskCancelled:   "質問をキャンセルしました",
 		SetupComplete:  "✅ 初期設定が完了しました。/settings で設定変更、/setup で再設定。",
 		SetupLettaNote: "\n\n[!] letta メモリモードには埋め込みサービスが必要です:\n  1. Ollama をインストール: https://ollama.ai\n  2. 埋め込みモデルを取得: `ollama pull nomic-embed-text`\n  3. 設定または環境変数で埋め込みエンドポイントを設定",
-		UpdateFound:    "新しいバージョン: %s → %s\nアップデート: curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash\n%s",
-		UpdateCurrent:  "現在のバージョン %s は最新です",
+		UpdateFound:    "新しいバージョン: %s → %s (stable)\nアップデート: curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash\n%s",
+		UpdateCurrent:  "現在のバージョン %s (channel: %s) は最新です",
 		UpdateFailed:   "アップデート確認に失敗（ネットワークタイムアウトまたは GitHub API に接続できません）",
 
 		// --- B. Panel text ---

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -14,10 +14,14 @@
     Install mode: "standalone" (default) or "server-client".
 .PARAMETER Port
     Server port for server-client mode (default 8082).
+.PARAMETER Channel
+    Release channel: "stable" (default), "beta", or "nightly".
 .EXAMPLE
     irm https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.ps1 | iex
 .EXAMPLE
     .\install.ps1 -Version v0.1.0
+.EXAMPLE
+    .\install.ps1 -Channel nightly
 .EXAMPLE
     .\install.ps1 -Mode server-client -Port 9090
 #>
@@ -26,6 +30,7 @@ param(
     [string]$Version = "",
     [string]$InstallPath = "",
     [string]$Mode = "",
+    [string]$Channel = "",
     [int]$Port = 0,
     [switch]$NonInteractive
 )
@@ -41,6 +46,7 @@ $DEFAULT_PORT = 8082
 # Env var fallback for parameters (GitHub Actions uses env vars)
 if (-not $Mode)    { $Mode = $env:MODE }
 if (-not $Version) { $Version = $env:VERSION }
+if (-not $Channel) { $Channel = $env:CHANNEL }
 
 if (-not $InstallPath) {
     if ($env:INSTALL_PATH) {
@@ -89,16 +95,75 @@ function Get-Platform {
 
 function Get-LatestVersion {
     if ($Version) { return $Version }
-    try {
-        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -Headers @{"User-Agent"="PowerShell"}
-        return $response.tag_name
-    } catch {}
-    try {
-        Write-Warn "No releases found on $REPO, trying fallback $FALLBACK_REPO..."
-        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$FALLBACK_REPO/releases/latest" -Headers @{"User-Agent"="PowerShell"}
-        return $response.tag_name
-    } catch {
-        Write-Err "Failed to determine latest version from both repos. Set -Version explicitly."
+    $ch = if ($Channel) { $Channel.ToLower() } else { "stable" }
+    $headers = @{"User-Agent"="PowerShell"}
+
+    switch ($ch) {
+        "stable" {
+            try {
+                $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -Headers $headers
+                return $response.tag_name
+            } catch {}
+            try {
+                Write-Warn "No releases found on $REPO, trying fallback $FALLBACK_REPO..."
+                $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$FALLBACK_REPO/releases/latest" -Headers $headers
+                return $response.tag_name
+            } catch {
+                Write-Err "Failed to determine latest version from both repos. Set -Version explicitly."
+            }
+        }
+        "nightly" {
+            try {
+                $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases?per_page=20" -Headers $headers
+                $nightly = $releases | Where-Object { $_.tag_name -match '^nightly-' } | Select-Object -First 1
+                if ($nightly) { return $nightly.tag_name }
+            } catch {}
+            try {
+                Write-Warn "No nightly found on $REPO, trying fallback $FALLBACK_REPO..."
+                $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$FALLBACK_REPO/releases?per_page=20" -Headers $headers
+                $nightly = $releases | Where-Object { $_.tag_name -match '^nightly-' } | Select-Object -First 1
+                if ($nightly) { return $nightly.tag_name }
+            } catch {}
+            Write-Err "No nightly release found. Set -Version explicitly."
+        }
+        "beta" {
+            try {
+                $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases?per_page=20" -Headers $headers
+                $beta = $releases | Where-Object { $_.tag_name -match '-beta\.\d+' } | Select-Object -First 1
+                if ($beta) { return $beta.tag_name }
+            } catch {}
+            try {
+                Write-Warn "No beta found on $REPO, trying fallback $FALLBACK_REPO..."
+                $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$FALLBACK_REPO/releases?per_page=20" -Headers $headers
+                $beta = $releases | Where-Object { $_.tag_name -match '-beta\.\d+' } | Select-Object -First 1
+                if ($beta) { return $beta.tag_name }
+            } catch {}
+            Write-Err "No beta release found. Set -Version explicitly."
+        }
+        default {
+            Write-Err "Unknown channel: $ch. Use 'stable', 'beta', or 'nightly'."
+        }
+    }
+}
+
+function Ask-Channel {
+    if ($Channel) {
+        switch ($Channel.ToLower()) {
+            { $_ -in "stable","beta","nightly" } { return }
+            default { Write-Err "Invalid Channel='${Channel}'. Use 'stable', 'beta', or 'nightly'." }
+        }
+        return
+    }
+    Write-Host ""
+    Write-Host "Choose release channel:" -ForegroundColor Cyan
+    Write-Host "  1) stable   - Official releases (recommended)" -ForegroundColor Cyan
+    Write-Host "  2) beta     - Pre-release versions for testing" -ForegroundColor Cyan
+    Write-Host "  3) nightly  - Latest development builds (may be unstable)" -ForegroundColor Cyan
+    $choice = Read-Host "Select [1/2/3] (default 1)"
+    switch ($choice) {
+        "3" { $script:Channel = "nightly" }
+        "2" { $script:Channel = "beta" }
+        default { $script:Channel = "stable" }
     }
 }
 
@@ -446,10 +511,12 @@ Write-Host "  =======================================" -ForegroundColor Cyan
 Write-Host ""
 
 $platform = Get-Platform
+Ask-Channel
 $tag = Get-LatestVersion
 $downloadUrl = "https://github.com/$REPO/releases/download/$tag/xbot-cli-$platform.exe"
 
 Write-Info "Platform:  $platform"
+Write-Info "Channel:   $Channel"
 Write-Info "Version:   $tag"
 Write-Info "URL:       $downloadUrl"
 Write-Info "Install:   $InstallPath\$BINARY"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,6 +10,7 @@ XBOT_HOME="${XBOT_HOME:-$HOME/.xbot}"
 CONFIG_PATH="${CONFIG_PATH:-$XBOT_HOME/config.json}"
 SERVICE_NAME="xbot-server"
 DEFAULT_PORT="${PORT:-8082}"
+CHANNEL="${CHANNEL:-}"  # stable, beta, or nightly
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -41,18 +42,78 @@ detect_platform() {
     echo "${os}-${arch}"
 }
 
+# Resolve version based on channel.
+# For stable: uses /releases/latest (non-prerelease).
+# For nightly: lists releases, finds latest nightly-* tag.
+# For beta: lists releases, finds latest v*-*beta* tag.
 resolve_version() {
     if [ -n "${VERSION:-}" ]; then
         echo "$VERSION"
         return
     fi
+
+    local ch="${CHANNEL:-stable}"
     local tag
-    tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-    if [ -z "$tag" ]; then
-        tag=$(curl -fsSL "https://api.github.com/repos/${FALLBACK_REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-    fi
-    [ -n "$tag" ] || error "Failed to determine latest version. Set VERSION env var explicitly."
+
+    case "$ch" in
+        stable)
+            # /releases/latest returns the latest non-prerelease release
+            tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+            if [ -z "$tag" ]; then
+                tag=$(curl -fsSL "https://api.github.com/repos/${FALLBACK_REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+            fi
+            ;;
+        nightly)
+            tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=20" 2>/dev/null | grep '"tag_name"' | grep -o '"nightly-[^"]*"' | head -1 | tr -d '"')
+            if [ -z "$tag" ]; then
+                tag=$(curl -fsSL "https://api.github.com/repos/${FALLBACK_REPO}/releases?per_page=20" 2>/dev/null | grep '"tag_name"' | grep -o '"nightly-[^"]*"' | head -1 | tr -d '"')
+            fi
+            ;;
+        beta)
+            tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=20" 2>/dev/null | grep '"tag_name"' | grep -o '"v[^"]*-beta\.[0-9]*"' | head -1 | tr -d '"')
+            if [ -z "$tag" ]; then
+                tag=$(curl -fsSL "https://api.github.com/repos/${FALLBACK_REPO}/releases?per_page=20" 2>/dev/null | grep '"tag_name"' | grep -o '"v[^"]*-beta\.[0-9]*"' | head -1 | tr -d '"')
+            fi
+            ;;
+        *)
+            error "Unknown channel: $ch. Use 'stable', 'beta', or 'nightly'."
+            ;;
+    esac
+
+    [ -n "$tag" ] || error "Failed to determine latest version for channel '$ch'. Set VERSION env var explicitly."
     echo "$tag"
+}
+
+# Interactive channel selection menu.
+# Sets CHANNEL variable directly.
+ask_channel() {
+    if [ -n "$CHANNEL" ]; then
+        case "$CHANNEL" in
+            stable|beta|nightly) ;;
+            *) error "Invalid CHANNEL='${CHANNEL}'. Use 'stable', 'beta', or 'nightly'." ;;
+        esac
+        return
+    fi
+    # Non-interactive: default to stable
+    if ! [ -c /dev/tty ] 2>/dev/null || ! [ -r /dev/tty ] 2>/dev/null; then
+        info "Non-interactive mode (no /dev/tty). Defaulting to stable channel."
+        info "Set CHANNEL=nightly or CHANNEL=beta to use a different channel."
+        CHANNEL=stable
+        return
+    fi
+    echo ""
+    echo "Choose release channel:"
+    echo "  1) stable   - Official releases (recommended)"
+    echo "  2) beta     - Pre-release versions for testing"
+    echo "  3) nightly  - Latest development builds (may be unstable)"
+    printf "Select [1/2/3] (default 1): "
+    local choice
+    read -r choice </dev/tty || choice=1
+    case "${choice:-1}" in
+        3) CHANNEL=nightly ;;
+        2) CHANNEL=beta ;;
+        *) CHANNEL=stable ;;
+    esac
 }
 
 # Non-interactive: use MODE env var. Interactive: prompt user.
@@ -391,6 +452,23 @@ enable_linger() {
 }
 
 main() {
+    # Parse --channel argument from command line
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --channel)
+                CHANNEL="$2"
+                shift 2
+                ;;
+            --channel=*)
+                CHANNEL="${1#*=}"
+                shift
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+
     echo ""
     echo "  ╔══════════════════════════════════════╗"
     echo "  ║         xbot-cli Installer           ║"
@@ -399,10 +477,15 @@ main() {
 
     require_cmd curl
     PLATFORM=$(detect_platform)
+
+    # Ask for channel if not specified (interactive menu)
+    ask_channel
+
     VERSION=$(resolve_version)
     DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/xbot-cli-${PLATFORM}"
 
     info "Platform:  ${PLATFORM}"
+    info "Channel:   ${CHANNEL}"
     info "Version:   ${VERSION}"
     info "URL:       ${DOWNLOAD_URL}"
     info "Install:   ${INSTALL_PATH}/${BINARY}"

--- a/version/check.go
+++ b/version/check.go
@@ -12,9 +12,18 @@ import (
 )
 
 const (
-	newRepoAPIURL = "https://api.github.com/repos/ai-pivot/xbot/releases/latest"
-	oldRepoAPIURL = "https://api.github.com/repos/CjiW/xbot/releases/latest"
+	newRepoAPIURL = "https://api.github.com/repos/ai-pivot/xbot"
+	oldRepoAPIURL = "https://api.github.com/repos/CjiW/xbot"
 	checkTimeout  = 10 * time.Second
+)
+
+// ReleaseChannel represents a distribution channel.
+type ReleaseChannel string
+
+const (
+	ChannelStable  ReleaseChannel = "stable"
+	ChannelBeta    ReleaseChannel = "beta"
+	ChannelNightly ReleaseChannel = "nightly"
 )
 
 // githubRelease represents the GitHub API response for a release.
@@ -31,6 +40,7 @@ type UpdateInfo struct {
 	Latest    string // remote latest version
 	URL       string // release page URL
 	HasUpdate bool
+	Channel   ReleaseChannel // which channel was checked
 }
 
 // semverRegex matches semantic versioning patterns like v1.2.3, 1.2.3, v1.2.3-rc1, etc.
@@ -72,21 +82,30 @@ func isNewer(a, b string) bool {
 // with the local build version. Returns nil if the check fails or version is a
 // dev build (in which case the caller should silently ignore).
 //
+// By default, only checks the stable channel. Nightly/beta builds skip the
+// automatic check (they track their own channel manually via install scripts).
+//
 // Migration: tries the new repo (ai-pivot/xbot) first. If the new repo has no
 // releases yet, falls back to the old repo (CjiW/xbot) so existing users don't
 // lose update notifications during the transition.
 func CheckUpdate(ctx context.Context) *UpdateInfo {
-	// Skip if version is completely empty
-	if Version == "" {
+	// Skip if version is completely empty or dev build
+	if Version == "" || Version == "dev" {
+		return nil
+	}
+
+	// Only stable channel checks for updates automatically.
+	// Nightly/beta users manage their own channel via install scripts.
+	if Channel != "" && Channel != string(ChannelStable) {
 		return nil
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, checkTimeout)
 	defer cancel()
 
-	release := fetchLatestRelease(ctx, newRepoAPIURL)
+	release := fetchLatestStable(ctx, newRepoAPIURL)
 	if release == nil {
-		release = fetchLatestRelease(ctx, oldRepoAPIURL)
+		release = fetchLatestStable(ctx, oldRepoAPIURL)
 	}
 	if release == nil || release.TagName == "" {
 		return nil
@@ -98,12 +117,80 @@ func CheckUpdate(ctx context.Context) *UpdateInfo {
 		Latest:    release.TagName,
 		URL:       release.HTMLURL,
 		HasUpdate: hasUpdate,
+		Channel:   ChannelStable,
 	}
 }
 
-// fetchLatestRelease queries a single GitHub repo's latest release API.
-// Returns nil on any error (network, non-200, parse failure).
-func fetchLatestRelease(ctx context.Context, apiURL string) *githubRelease {
+// ResolveChannel determines the release channel from a tag name.
+//   - "v1.2.3"         → stable
+//   - "v1.2.3-beta.1"  → beta
+//   - "nightly-20260515" → nightly
+func ResolveChannel(tag string) ReleaseChannel {
+	if strings.HasPrefix(tag, "nightly-") {
+		return ChannelNightly
+	}
+	if m := semverRegex.FindStringSubmatch(tag); len(m) == 5 && m[4] != "" {
+		// Has prerelease suffix like -beta.1, -rc.2
+		pre := strings.ToLower(m[4])
+		if strings.HasPrefix(pre, "beta") {
+			return ChannelBeta
+		}
+	}
+	return ChannelStable
+}
+
+// fetchLatestStable queries the /releases/latest endpoint which returns the
+// latest non-prerelease, non-draft release — which is exactly the stable channel.
+func fetchLatestStable(ctx context.Context, repoAPIURL string) *githubRelease {
+	apiURL := strings.TrimRight(repoAPIURL, "/") + "/releases/latest"
+	return fetchRelease(ctx, apiURL)
+}
+
+// FetchLatestByChannel returns the latest release for a specific channel.
+// It uses different strategies per channel:
+//   - stable: /releases/latest (non-prerelease)
+//   - beta: lists all releases, finds latest with -beta suffix
+//   - nightly: lists all releases, finds latest nightly- tag
+func FetchLatestByChannel(ctx context.Context, ch ReleaseChannel) *githubRelease {
+	ctx, cancel := context.WithTimeout(ctx, checkTimeout)
+	defer cancel()
+
+	for _, repoURL := range []string{newRepoAPIURL, oldRepoAPIURL} {
+		var release *githubRelease
+		switch ch {
+		case ChannelStable:
+			release = fetchLatestStable(ctx, repoURL)
+		case ChannelBeta, ChannelNightly:
+			release = fetchLatestByTagPrefix(ctx, repoURL, ch)
+		}
+		if release != nil {
+			return release
+		}
+	}
+	return nil
+}
+
+// fetchLatestByTagPrefix lists all releases and finds the latest one matching
+// the channel's tag prefix pattern.
+func fetchLatestByTagPrefix(ctx context.Context, repoAPIURL string, ch ReleaseChannel) *githubRelease {
+	apiURL := strings.TrimRight(repoAPIURL, "/") + "/releases"
+	releases := fetchReleaseList(ctx, apiURL)
+	if releases == nil {
+		return nil
+	}
+
+	for _, r := range releases {
+		tag := r.TagName
+		resolved := ResolveChannel(tag)
+		if resolved == ch {
+			return &r
+		}
+	}
+	return nil
+}
+
+// fetchRelease queries a single release API endpoint.
+func fetchRelease(ctx context.Context, apiURL string) *githubRelease {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil
@@ -132,4 +219,39 @@ func fetchLatestRelease(ctx context.Context, apiURL string) *githubRelease {
 	}
 
 	return &release
+}
+
+// fetchReleaseList queries the releases list API and returns all releases.
+func fetchReleaseList(ctx context.Context, apiURL string) []githubRelease {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "xbot-cli")
+	q := req.URL.Query()
+	q.Set("per_page", "20")
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if err != nil {
+		return nil
+	}
+
+	var releases []githubRelease
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return nil
+	}
+
+	return releases
 }

--- a/version/check_test.go
+++ b/version/check_test.go
@@ -1,0 +1,139 @@
+package version
+
+import (
+	"context"
+	"testing"
+)
+
+func TestResolveChannel(t *testing.T) {
+	tests := []struct {
+		tag      string
+		expected ReleaseChannel
+	}{
+		{"v1.2.3", ChannelStable},
+		{"v0.0.23", ChannelStable},
+		{"v1.0.0-beta.1", ChannelBeta},
+		{"v2.3.4-beta.3", ChannelBeta},
+		{"nightly-20260515", ChannelNightly},
+		{"nightly-20251231", ChannelNightly},
+		{"v1.0.0-rc.1", ChannelStable}, // rc is not beta, treated as stable
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			got := ResolveChannel(tt.tag)
+			if got != tt.expected {
+				t.Errorf("ResolveChannel(%q) = %q, want %q", tt.tag, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		a, b     string
+		expected bool
+	}{
+		{"v1.0.0", "v1.0.1", true},
+		{"v1.0.1", "v1.0.0", false},
+		{"v1.0.0", "v2.0.0", true},
+		{"v1.2.3", "v1.2.3", false},
+		{"v1.2.3", "v1.3.0", true},
+		{"dev", "v1.0.0", true}, // non-semver fallback: a != b
+		{"v1.0.0", "v1.0.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_"+tt.b, func(t *testing.T) {
+			got := isNewer(tt.a, tt.b)
+			if got != tt.expected {
+				t.Errorf("isNewer(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCheckUpdateSkipDevBuild(t *testing.T) {
+	// Save and restore
+	origVersion := Version
+	origChannel := Channel
+	defer func() {
+		Version = origVersion
+		Channel = origChannel
+	}()
+
+	// dev version should skip
+	Version = "dev"
+	Channel = ""
+	result := CheckUpdate(context.TODO())
+	if result != nil {
+		t.Error("CheckUpdate should return nil for dev version")
+	}
+
+	// empty version should skip
+	Version = ""
+	Channel = ""
+	result = CheckUpdate(context.TODO())
+	if result != nil {
+		t.Error("CheckUpdate should return nil for empty version")
+	}
+
+	// non-stable channel should skip
+	Version = "v1.0.0"
+	Channel = "nightly"
+	result = CheckUpdate(context.TODO())
+	if result != nil {
+		t.Error("CheckUpdate should return nil for non-stable channel")
+	}
+}
+
+func TestInfoIncludesChannel(t *testing.T) {
+	origVersion := Version
+	origChannel := Channel
+	origCommit := Commit
+	defer func() {
+		Version = origVersion
+		Channel = origChannel
+		Commit = origCommit
+	}()
+
+	Version = "v1.0.0"
+	Channel = "stable"
+	Commit = "abc123"
+	info := Info()
+	if info == "" {
+		t.Fatal("Info() returned empty string")
+	}
+	// Should contain channel info
+	if !contains(info, "channel: stable") {
+		t.Errorf("Info() = %q, should contain 'channel: stable'", info)
+	}
+	if !contains(info, "v1.0.0") {
+		t.Errorf("Info() = %q, should contain 'v1.0.0'", info)
+	}
+}
+
+func TestInfoDevChannel(t *testing.T) {
+	origVersion := Version
+	origChannel := Channel
+	defer func() {
+		Version = origVersion
+		Channel = origChannel
+	}()
+
+	Version = "v1.0.0"
+	Channel = "" // empty means dev
+	info := Info()
+	if !contains(info, "channel: dev") {
+		t.Errorf("Info() = %q, should contain 'channel: dev' for empty Channel", info)
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/version/version.go
+++ b/version/version.go
@@ -2,16 +2,21 @@ package version
 
 import "fmt"
 
-// Version, Commit, BuildTime are injected via -ldflags at build time.
+// Version, Commit, BuildTime, Channel are injected via -ldflags at build time.
 //
-//	go build -ldflags "-X xbot/version.Version=v1.0.0 -X xbot/version.Commit=$(git rev-parse --short HEAD) -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+//	go build -ldflags "-X xbot/version.Version=v1.0.0 -X xbot/version.Commit=$(git rev-parse --short HEAD) -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X xbot/version.Channel=stable"
 var (
 	Version   = "dev"
 	Commit    = "unknown"
 	BuildTime = "unknown"
+	Channel   = "" // "stable", "beta", "nightly", or "" for dev builds
 )
 
 // Info returns a formatted version string.
 func Info() string {
-	return fmt.Sprintf("xbot %s (commit: %s, built: %s)", Version, Commit, BuildTime)
+	ch := Channel
+	if ch == "" {
+		ch = "dev"
+	}
+	return fmt.Sprintf("xbot %s (channel: %s, commit: %s, built: %s)", Version, ch, Commit, BuildTime)
 }


### PR DESCRIPTION
## Summary

Add three release channels — **stable**, **beta**, and **nightly** — to the xbot distribution system.

### Channel Design

| Channel | Trigger | Tag Format | Prerelease |
|---------|---------|------------|-----------|
| **stable** | Push `v*` tag (no suffix) | `v1.0.0` | ❌ |
| **beta** | Push `v*-beta.*` tag / manual dispatch | `v1.0.0-beta.1` | ✅ |
| **nightly** | Auto on master push (after CI) | `nightly-20260515` | ✅ |

### Changes

**Version package**
- `version.Channel` variable injected via ldflags
- `Info()` now shows channel: `xbot v1.0.0 (channel: stable, commit: abc, built: ...)`
- `ResolveChannel()` infers channel from tag format
- `FetchLatestByChannel()` for per-channel release lookup
- `CheckUpdate()` only auto-checks for stable channel (nightly/beta skip)

**CI/CD**
- `release.yml`: supports `v*` tag push + `workflow_dispatch` (nightly/beta)
- `ci.yml`: new `nightly` job triggers release workflow after CI passes on master
- `prepare` job resolves version and channel from trigger context

**Install scripts**
- `install.sh`: `--channel` param + interactive `ask_channel` menu (1=stable, 2=beta, 3=nightly)
- `install.ps1`: `-Channel` param + `Ask-Channel` interactive menu
- Channel-aware `resolve_version` / `Get-LatestVersion` with fallback repo support

**UI**
- i18n (zh/en/ja): `UpdateFound` shows `(stable)`, `UpdateCurrent` shows channel
- Status bar: `xbot v1.0.0 · stable · abc1234`
- `Makefile` LDFLAGS injects Channel

**Tests**
- `version/check_test.go`: `ResolveChannel`, `isNewer`, `CheckUpdate` skip logic, `Info` format

### User Experience

```bash
# Default: stable channel
curl -fsSL https://.../install.sh | bash

# Specify channel
curl -fsSL https://.../install.sh | bash -s -- --channel nightly

# PowerShell
.\install.ps1 -Channel beta
```

### Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including new `version/check_test.go`)
- [x] `golangci-lint run ./...` passes (0 issues)
- [ ] Merge this PR, verify nightly release triggers automatically
- [ ] Create `v*` tag to verify stable release
- [ ] Manually trigger `workflow_dispatch` with channel=beta
- [ ] Test install scripts with `--channel nightly/beta/stable`
