### PR TITLE
fix(cli): restore glamour WordWrap to fix markdown table rendering

### DIFF
--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -236,11 +236,12 @@ func newGlamourRenderer(wrapWidth int) *glamour.TermRenderer {
 
 	r, _ := glamour.NewTermRenderer(
 		glamour.WithStyles(style),
-		// Word wrap disabled: glamour breaks English words at spaces and
-		// doesn't understand CJK boundaries, producing ugly splits like
-		// "Adolf\nHitler". All wrapping is handled by hardWrapRunes which
-		// knows about CJK break rules.
-		glamour.WithWordWrap(0),
+		// Glamour handles table column sizing and paragraph wrapping.
+		// hardWrapRunes serves as a safety net for lines that still exceed
+		// viewport width (e.g. long URLs) but should not be the primary
+		// wrapping mechanism — it doesn't understand table structure and
+		// would break separator/alignment lines.
+		glamour.WithWordWrap(wrapWidth),
 	)
 	return r
 }


### PR DESCRIPTION
## Problem

Commit `e8b1fa0d` set `glamour.WithWordWrap(0)` to avoid CJK-aware space breaks in mixed text. This disabled glamour's word wrap entirely, which also removed its table column sizing — tables now render at their natural content width (148+ columns).

When the viewport is narrower than the table, `hardWrapRunes` in `setViewportContent` breaks separator lines (`─────┼──────`) at arbitrary column boundaries and adds `┊` guide prefix on continuation lines, destroying table alignment:

```
┊  目录                                   │ 内容
┊
┊ ────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────
┊ ────────────────────────────────────────   ← separator broken, ┊ prefix misaligned
┊   data/executable/                      │  robocraft-runtime-g1-0.5.1-test  (主二进制)
```

## Fix

Restore `glamour.WithWordWrap(wrapWidth)` so glamour handles table column sizing and paragraph wrapping correctly. `hardWrapRunes` remains as a safety net for lines that still exceed viewport width (e.g. long URLs).

With `WordWrap(80)`, glamour wraps table cells with proper alignment:
```
 目录                                 │ 内容                                   
──────────────────────────────────────┼───────────────────────────────────────
 data/executable/                     │ robocraft-runtime-g1-0.5.1-test        
                                      │ (主二进制)                             
```

## Test

- `go build ./...` ✅
- `go test ./...` — full suite, zero failures ✅
- Pre-commit hooks (gofmt → golangci-lint → build → test) ✅

## Trade-off

Restoring `WordWrap(wrapWidth)` means glamour will break at spaces in narrow viewports (e.g. `Adolf\nHitler`). This is a minor cosmetic issue compared to completely broken table rendering.
