### PR TITLE
fix: RegisterPeer assigns correct role (primary/peer) instead of hardcoded 'shared'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
         working-directory: dist
         run: sha256sum * > ../checksums.txt
 
-      - name: Determine prerelease flag
+      - name: Determine prerelease flag and release tag
         id: prerelease
         run: |
           CHANNEL="${{ needs.prepare.outputs.channel }}"
@@ -227,13 +227,25 @@ jobs:
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
+          # Nightly uses a fixed tag so the release is overwritten each run.
+          # Stable/beta keep unique tags (v1.2.3, beta-YYYYMMDD).
+          if [[ "$CHANNEL" == "nightly" ]]; then
+            echo "release_tag=nightly" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_tag=${{ needs.prepare.outputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.prepare.outputs.version }}
+          tag_name: ${{ steps.prerelease.outputs.release_tag }}
           prerelease: ${{ steps.prerelease.outputs.prerelease }}
           generate_release_notes: true
+          body: |
+            ## ${{ needs.prepare.outputs.version }}
+
+            Commit: `${{ env.COMMIT }}`
+            Built: $(date -u +%Y-%m-%dT%H:%M:%SZ)
           files: |
             dist/xbot-cli-linux-amd64
             dist/xbot-cli-linux-arm64

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 
 BINARY_NAME := xbot
 
+# Worktree-safe: go build's VCS stamping fails in git worktrees
+# (it cd's to the main repo which is locked by the worktree).
+# Override with: make install-cli GOFLAGS=
+GOFLAGS ?= -buildvcs=false
+
 fmt:
 	go fmt ./...
 
@@ -16,13 +21,13 @@ CHANNEL := $(shell git branch --show-current 2>/dev/null | sed 's/master/stable/
 LDFLAGS := -X xbot/version.Version=$(VERSION) -X xbot/version.Commit=$(shell git rev-parse --short HEAD) -X xbot/version.BuildTime=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) -X xbot/version.Channel=$(CHANNEL)
 
 build:
-	go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) .
+	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) .
 
 run: build
 	./$(BINARY_NAME)
 
 dev:
-	go run -ldflags "$(LDFLAGS)" .
+	go run $(GOFLAGS) -ldflags "$(LDFLAGS)" .
 
 clean:
 	rm -f $(BINARY_NAME) coverage.out
@@ -45,6 +50,6 @@ web-dev:
 	cd web && yarn dev
 
 install-cli:
-	go build -ldflags "$(LDFLAGS)" -o /tmp/xbot-cli ./cmd/xbot-cli
+	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o /tmp/xbot-cli ./cmd/xbot-cli
 	sudo mv /tmp/xbot-cli /usr/local/bin/
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"xbot/config"
+
 	"xbot/agent/hooks"
 	"xbot/bus"
 	"xbot/channel"
@@ -2281,10 +2283,18 @@ func (a *Agent) buildPrompt(ctx context.Context, msg bus.InboundMessage, tenantS
 	if detectDir == "" {
 		detectDir = workspaceRoot
 	}
-	// Peer awareness: always register this session so other agents can see it.
-	// When auto_worktree is enabled, AutoDetectAndInit handles worktree creation.
-	// When disabled, RegisterPeer provides lightweight session tracking.
-	tools.GlobalWorktreeRegistry.RegisterPeer(sessKey, detectDir)
+	// Peer awareness / auto worktree: register this session for collaboration.
+	// When auto_worktree is enabled, every session gets its own git worktree (no primary).
+	// When disabled, RegisterPeer provides lightweight in-memory session tracking.
+	cfgPath := filepath.Join(a.xbotHome, "config.json")
+	if cfg := config.LoadFromFile(cfgPath); cfg != nil && cfg.Agent.Experimental.AutoWorktree {
+		if entry := tools.AutoDetectAndInit(detectDir, sessKey); entry != nil && entry.WorktreeDir != "" {
+			tenantSession.SetCurrentDir(entry.WorktreeDir)
+			detectDir = entry.WorktreeDir
+		}
+	} else {
+		tools.GlobalWorktreeRegistry.RegisterPeer(sessKey, detectDir)
+	}
 
 	// Fixup: strip trailing unpaired tool_calls left by a cancelled Run.
 	// Both Anthropic and OpenAI APIs reject requests with unpaired tool_calls.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2290,7 +2290,6 @@ func (a *Agent) buildPrompt(ctx context.Context, msg bus.InboundMessage, tenantS
 	if cfg := config.LoadFromFile(cfgPath); cfg != nil && cfg.Agent.Experimental.AutoWorktree {
 		if entry := tools.AutoDetectAndInit(detectDir, sessKey); entry != nil && entry.WorktreeDir != "" {
 			tenantSession.SetCurrentDir(entry.WorktreeDir)
-			detectDir = entry.WorktreeDir
 		}
 	} else {
 		tools.GlobalWorktreeRegistry.RegisterPeer(sessKey, detectDir)

--- a/agent/agent_backend_methods.go
+++ b/agent/agent_backend_methods.go
@@ -20,11 +20,10 @@ func (a *Agent) SetCWD(ch, chatID, dir string) error {
 	if err != nil {
 		return err
 	}
-	// If session already has a persisted CWD (restored from disk), keep it.
-	// Otherwise use the requested directory.
-	if sess.GetCurrentDir() == "" {
-		sess.SetCurrentDir(dir)
-	}
+	// Set CWD — always accept the caller's value. The persisted CWD
+	// (loadPersistedCWD) is only a fallback for channels that never call
+	// SetCWD (e.g. Feishu, Web). CLI callers always sync their terminal CWD.
+	sess.SetCurrentDir(dir)
 	// Always refresh plugin contexts so script plugins see the correct workDir
 	if a.pluginMgr != nil {
 		cwd := sess.GetCurrentDir()

--- a/agent/agent_backend_methods.go
+++ b/agent/agent_backend_methods.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 
 	"xbot/config"
 	"xbot/protocol"
@@ -20,10 +21,16 @@ func (a *Agent) SetCWD(ch, chatID, dir string) error {
 	if err != nil {
 		return err
 	}
-	// Set CWD — always accept the caller's value. The persisted CWD
-	// (loadPersistedCWD) is only a fallback for channels that never call
-	// SetCWD (e.g. Feishu, Web). CLI callers always sync their terminal CWD.
-	sess.SetCurrentDir(dir)
+	// Set CWD — but don't overwrite an existing worktree path.
+	// Worktree CWD is set by AutoDetectAndInit in buildPrompt and persists
+	// across restarts. CLI callers sync their terminal CWD on startup, which
+	// should only take effect when the session has no CWD yet or the existing
+	// CWD is not a worktree path (i.e. the user changed their terminal dir
+	// between invocations of the same non-worktree session).
+	existingCWD := sess.GetCurrentDir()
+	if existingCWD == "" || !strings.Contains(existingCWD, ".xbot-worktrees") {
+		sess.SetCurrentDir(dir)
+	}
 	// Always refresh plugin contexts so script plugins see the correct workDir
 	if a.pluginMgr != nil {
 		cwd := sess.GetCurrentDir()

--- a/agent/setting_runtime.go
+++ b/agent/setting_runtime.go
@@ -161,6 +161,13 @@ var SettingHandlerRegistry = map[string]SettingHandler{
 	"sidebar_sections": {},
 	"chat_max_width":   {},
 	"chat_center":      {},
+
+	// --- Worktree isolation ---
+	"auto_worktree": {
+		ApplyConfig: func(cfg *config.Config, value string) {
+			cfg.Agent.Experimental.AutoWorktree = strings.ToLower(value) == "true"
+		},
+	},
 }
 
 // ApplyRuntimeSetting applies a single setting change to the in-memory config and agent.

--- a/agent/setting_runtime.go
+++ b/agent/setting_runtime.go
@@ -215,6 +215,19 @@ func ApplyRuntimeSettings(cfg *config.Config, ag *Agent, senderID string, values
 	}
 }
 
+// ApplyRuntimeSettingsLocal applies setting changes to the in-memory config only
+// (no agent backend side effects). Used by the CLI process to update its local cfg
+// copy before persisting to config.json.
+func ApplyRuntimeSettingsLocal(cfg *config.Config, values map[string]string) {
+	for k, v := range values {
+		handler, ok := SettingHandlerRegistry[k]
+		if !ok || handler.ApplyConfig == nil {
+			continue
+		}
+		handler.ApplyConfig(cfg, v)
+	}
+}
+
 // MissingSettingHandlerKeys returns keys from channel.CLIRuntimeSettingKeys
 // that are missing from SettingHandlerRegistry.
 func MissingSettingHandlerKeys() []string {

--- a/channel/channel_cli.go
+++ b/channel/channel_cli.go
@@ -151,16 +151,17 @@ func (c *ChannelCliChannel) SendToast(msg string) {
 }
 
 // SendStreamContent pushes a stream content event.
+// Mirrors RemoteCLIChannel.SendStreamContent: the Progress.ChatID carries
+// the "cli:" prefix expected by handleProgressMsg's session filter.
 func (c *ChannelCliChannel) SendStreamContent(chatID, content, reasoning string) {
 	if content == "" && reasoning == "" {
 		return
 	}
 	wsMsg := protocol.WSMessage{
-		Type:   protocol.MsgTypeStreamContent,
-		TS:     time.Now().Unix(),
-		ChatID: chatID,
+		Type: protocol.MsgTypeStreamContent,
+		TS:   time.Now().Unix(),
 		Progress: &protocol.ProgressEvent{
-			ChatID:                 chatID,
+			ChatID:                 "cli:" + chatID,
 			StreamContent:          content,
 			ReasoningStreamContent: reasoning,
 		},

--- a/channel/channel_cli.go
+++ b/channel/channel_cli.go
@@ -73,10 +73,38 @@ func (c *ChannelCliChannel) Send(msg OutboundMsg) (string, error) {
 	}
 	select {
 	case c.eventCh <- wsMsg:
-		return "", nil
 	default:
 		return "", fmt.Errorf("channel cli: event channel full")
 	}
+
+	// AskUser: agent needs user input. Send as separate MsgTypeAskUser
+	// so dispatchWSMessage can route it to the "ask_user" subscriber,
+	// mirroring RemoteCLIChannel.Send() behavior.
+	if msg.WaitingUser {
+		askEv := protocol.AskUserEvent{
+			Channel: msg.Channel,
+			ChatID:  msg.ChatID,
+		}
+		if msg.Metadata != nil {
+			askEv.RequestID = msg.Metadata["request_id"]
+			askEv.Questions = msg.Metadata["ask_questions"]
+		}
+		data, _ := json.Marshal(askEv)
+		askMsg := protocol.WSMessage{
+			Type:    protocol.MsgTypeAskUser,
+			TS:      time.Now().Unix(),
+			ChatID:  msg.ChatID,
+			Content: string(data),
+		}
+		select {
+		case c.eventCh <- askMsg:
+		default:
+			// AskUser is critical — log but don't silently drop
+			return "", fmt.Errorf("channel cli: event channel full, ask_user dropped")
+		}
+	}
+
+	return "", nil
 }
 
 // SendProgress converts a progress event to WSMessage and pushes to the event channel.
@@ -153,21 +181,6 @@ func (c *ChannelCliChannel) InjectUserMessage(chatID, content string) {
 		TS:      time.Now().Unix(),
 		ChatID:  chatID,
 		Content: content,
-	}
-	select {
-	case c.eventCh <- wsMsg:
-	default:
-	}
-}
-
-// SendAskUser pushes an ask_user event.
-func (c *ChannelCliChannel) SendAskUser(chatID string, ev protocol.AskUserEvent) {
-	data, _ := json.Marshal(ev)
-	wsMsg := protocol.WSMessage{
-		Type:    protocol.MsgTypeAskUser,
-		TS:      time.Now().Unix(),
-		ChatID:  chatID,
-		Content: string(data),
 	}
 	select {
 	case c.eventCh <- wsMsg:

--- a/channel/channel_cli.go
+++ b/channel/channel_cli.go
@@ -1,7 +1,6 @@
 package channel
 
 import (
-	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -14,10 +13,9 @@ import (
 // into WSMessage events pushed to an event channel, which ChannelTransport
 // reads and dispatches to subscribers.
 //
-// This replaces the local-mode pattern where Agent directly called
-// cliCh.SendProgress() → progressCh → asyncCh → TUI.
-// Now: Agent → ChannelCliChannel → eventCh → ChannelTransport → baseTransport → Subscribe handler → cliCh → TUI.
-// Same path as remote mode, but with Go channels instead of WebSocket.
+// Message construction is delegated to cliMessageBuilder (cli_msg_builder.go)
+// so the WSMessage format is identical to RemoteCLIChannel — only the
+// transport differs (Go channel vs WebSocket).
 type ChannelCliChannel struct {
 	eventCh      chan<- protocol.WSMessage
 	tuiPendingMu sync.Mutex
@@ -51,7 +49,6 @@ type ProgressSender interface {
 // UserMessageInjector is implemented by channels that support injecting
 // user messages from background sources (cron, bg task notifications).
 // Used by agent's injectCLIUserMessage for type assertion.
-// All three CLI channel types implement this: CLIChannel, RemoteCLIChannel, ChannelCliChannel.
 type UserMessageInjector interface {
 	InjectUserMessage(chatID, content string)
 }
@@ -63,137 +60,68 @@ type SessionStateSender interface {
 	SendSessionState(ev protocol.SessionEvent)
 }
 
-func (c *ChannelCliChannel) Send(msg OutboundMsg) (string, error) {
-	wsMsg := protocol.WSMessage{
-		Type:    protocol.MsgTypeText,
-		TS:      time.Now().Unix(),
-		Content: msg.Content,
-		ChatID:  msg.ChatID,
-		Channel: msg.Channel,
-	}
+// sendMsg pushes a WSMessage to the event channel. Returns error if full.
+func (c *ChannelCliChannel) sendMsg(msg protocol.WSMessage) error {
 	select {
-	case c.eventCh <- wsMsg:
+	case c.eventCh <- msg:
+		return nil
 	default:
-		return "", fmt.Errorf("channel cli: event channel full")
+		return fmt.Errorf("channel cli: event channel full")
 	}
+}
 
-	// AskUser: agent needs user input. Send as separate MsgTypeAskUser
-	// so dispatchWSMessage can route it to the "ask_user" subscriber,
-	// mirroring RemoteCLIChannel.Send() behavior.
-	if msg.WaitingUser {
-		askEv := protocol.AskUserEvent{
-			Channel: msg.Channel,
-			ChatID:  msg.ChatID,
-		}
-		if msg.Metadata != nil {
-			askEv.RequestID = msg.Metadata["request_id"]
-			askEv.Questions = msg.Metadata["ask_questions"]
-		}
-		data, _ := json.Marshal(askEv)
-		askMsg := protocol.WSMessage{
-			Type:    protocol.MsgTypeAskUser,
-			TS:      time.Now().Unix(),
-			ChatID:  msg.ChatID,
-			Content: string(data),
-		}
-		select {
-		case c.eventCh <- askMsg:
-		default:
-			// AskUser is critical — log but don't silently drop
-			return "", fmt.Errorf("channel cli: event channel full, ask_user dropped")
+// sendMsgBestEffort pushes a WSMessage, silently dropping if full.
+func (c *ChannelCliChannel) sendMsgBestEffort(msg protocol.WSMessage) {
+	select {
+	case c.eventCh <- msg:
+	default:
+	}
+}
+
+func (c *ChannelCliChannel) Send(msg OutboundMsg) (string, error) {
+	if err := c.sendMsg(cliMsg.buildTextMsg(msg)); err != nil {
+		return "", err
+	}
+	if askMsg := cliMsg.buildAskUserMsg(msg); askMsg != nil {
+		if err := c.sendMsg(*askMsg); err != nil {
+			return "", err
 		}
 	}
-
 	return "", nil
 }
 
-// SendProgress converts a progress event to WSMessage and pushes to the event channel.
 func (c *ChannelCliChannel) SendProgress(chatID string, payload *protocol.ProgressEvent) {
-	if payload == nil {
-		return
-	}
-	wsMsg := protocol.WSMessage{
-		Type:     protocol.MsgTypeProgress,
-		TS:       time.Now().Unix(),
-		Progress: payload,
-		ChatID:   chatID,
-	}
-	select {
-	case c.eventCh <- wsMsg:
-	default:
+	if msg := cliMsg.buildProgressMsg(chatID, payload); msg != nil {
+		c.sendMsgBestEffort(*msg)
 	}
 }
 
-// SendSessionState pushes a session state change event.
 func (c *ChannelCliChannel) SendSessionState(ev protocol.SessionEvent) {
-	wsMsg := protocol.WSMessage{
-		Type:    protocol.MsgTypeSession,
-		TS:      time.Now().Unix(),
-		Session: &ev,
-	}
-	select {
-	case c.eventCh <- wsMsg:
-	default:
-	}
+	c.sendMsgBestEffort(cliMsg.buildSessionStateMsg(ev))
 }
 
-// SendToast pushes a toast notification event.
 func (c *ChannelCliChannel) SendToast(msg string) {
-	wsMsg := protocol.WSMessage{
+	c.sendMsgBestEffort(protocol.WSMessage{
 		Type:    protocol.MsgTypeText,
 		TS:      time.Now().Unix(),
 		Content: msg,
-	}
-	select {
-	case c.eventCh <- wsMsg:
-	default:
-	}
+	})
 }
 
-// SendStreamContent pushes a stream content event.
-// Mirrors RemoteCLIChannel.SendStreamContent: the Progress.ChatID carries
-// the "cli:" prefix expected by handleProgressMsg's session filter.
 func (c *ChannelCliChannel) SendStreamContent(chatID, content, reasoning string) {
-	if content == "" && reasoning == "" {
-		return
-	}
-	wsMsg := protocol.WSMessage{
-		Type: protocol.MsgTypeStreamContent,
-		TS:   time.Now().Unix(),
-		Progress: &protocol.ProgressEvent{
-			ChatID:                 "cli:" + chatID,
-			StreamContent:          content,
-			ReasoningStreamContent: reasoning,
-		},
-	}
-	select {
-	case c.eventCh <- wsMsg:
-	default:
+	if msg := cliMsg.buildStreamContentMsg(chatID, content, reasoning); msg != nil {
+		c.sendMsgBestEffort(*msg)
 	}
 }
 
-// SetConnState is a no-op for in-process channel — always connected.
 func (c *ChannelCliChannel) SetConnState(string) {}
 
-// InjectUserMessage pushes an inject_user event.
 func (c *ChannelCliChannel) InjectUserMessage(chatID, content string) {
-	wsMsg := protocol.WSMessage{
-		Type:    protocol.MsgTypeInjectUser,
-		TS:      time.Now().Unix(),
-		ChatID:  chatID,
-		Content: content,
-	}
-	select {
-	case c.eventCh <- wsMsg:
-	default:
-	}
+	c.sendMsgBestEffort(cliMsg.buildInjectUserMsg(chatID, content))
 }
 
-// SendTUIControlRequest sends a TUI control request via the event channel
-// and waits for a response, following the same request/response pattern as
-// RemoteCLIChannel.SendTUIControlRequest.
 func (c *ChannelCliChannel) SendTUIControlRequest(chatID string, action string, params map[string]string) (map[string]string, error) {
-	id := fmt.Sprintf("tui-%d", time.Now().UnixNano())
+	id := cliMsg.generateTUIID()
 	ch := make(chan *protocol.TUIControlPayload, 1)
 
 	c.tuiPendingMu.Lock()
@@ -206,19 +134,8 @@ func (c *ChannelCliChannel) SendTUIControlRequest(chatID string, action string, 
 		c.tuiPendingMu.Unlock()
 	}()
 
-	wsMsg := protocol.WSMessage{
-		Type:   protocol.MsgTypeTUIControlReq,
-		ID:     id,
-		ChatID: chatID,
-		TUIControl: &protocol.TUIControlPayload{
-			Action: action,
-			Params: params,
-		},
-	}
-	select {
-	case c.eventCh <- wsMsg:
-	default:
-		return nil, fmt.Errorf("channel cli: event channel full")
+	if err := c.sendMsg(cliMsg.buildTUIControlReqMsg(id, chatID, action, params)); err != nil {
+		return nil, err
 	}
 
 	select {
@@ -227,12 +144,11 @@ func (c *ChannelCliChannel) SendTUIControlRequest(chatID string, action string, 
 			return nil, fmt.Errorf("%s", resp.Error)
 		}
 		return resp.Result, nil
-	case <-time.After(10 * time.Second):
+	case <-time.After(tuiRespTimeout):
 		return nil, fmt.Errorf("tui_control request %s timed out", id)
 	}
 }
 
-// DeliverTUIResponse routes a TUI control response to the pending request channel.
 func (c *ChannelCliChannel) DeliverTUIResponse(id string, payload *protocol.TUIControlPayload) {
 	c.tuiPendingMu.Lock()
 	ch, ok := c.tuiPending[id]

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -1768,10 +1768,17 @@ func (m *cliModel) renderToolContentBelow(tool *protocol.ToolProgress, guide str
 			guideW := lipgloss.Width(g)
 			for _, line := range strings.Split(body, "\n") {
 				// Final safety net: ensure guide + rendered line fits within bodyW.
-				// Tool body renderers (renderGrepBody etc.) truncate to bodyContentW,
-				// but lipgloss.Style.Render() may change effective width.
+				// Tool body renderers (renderShellBody etc.) wrap to bodyContentW,
+				// but lipgloss.Style.Render() may change effective width. Use hardWrapRunes
+				// so overflow lines wrap (preserving content) instead of truncating.
 				if visW := lipgloss.Width(line); guideW+visW > bodyW {
-					line = truncateToWidth(line, bodyW-guideW)
+					wrapped := hardWrapRunes(line, bodyW-guideW)
+					for _, wl := range strings.Split(wrapped, "\n") {
+						sb.WriteString(g)
+						sb.WriteString(wl)
+						sb.WriteString("\n")
+					}
+					continue
 				}
 				sb.WriteString(g)
 				sb.WriteString(line)
@@ -2929,22 +2936,26 @@ func (m *cliModel) renderShellBody(tool protocol.ToolProgress, maxW int, t cliTh
 
 	// Show command
 	if command != "" {
-		command = ansi.Truncate(command, maxW-3, "") + "..."
-		sb.WriteString(lipgloss.NewStyle().Foreground(fgPrompt).Render("$ " + command))
-		sb.WriteString("\n")
+		commandLine := "$ " + ansi.Truncate(command, maxW-5, "") + "..."
+		for _, wl := range strings.Split(hardWrapRunes(commandLine, maxW), "\n") {
+			sb.WriteString(lipgloss.NewStyle().Foreground(fgPrompt).Render(wl))
+			sb.WriteString("\n")
+		}
 	}
 
-	// Show output (truncated)
+	// Show output (wrapped to fit)
 	lines := strings.Split(content, "\n")
 	totalLines := len(lines)
 	displayLines := lines
 	if len(displayLines) > toolBodyMaxLines {
 		displayLines = displayLines[:toolBodyMaxLines]
 	}
+	outputStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextPrimary))
 	for _, line := range displayLines {
-		line = ansi.Truncate(line, maxW, "")
-		sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextPrimary)).Render(line))
-		sb.WriteString("\n")
+		for _, wl := range strings.Split(hardWrapRunes(line, maxW), "\n") {
+			sb.WriteString(outputStyle.Render(wl))
+			sb.WriteString("\n")
+		}
 	}
 	if totalLines > toolBodyMaxLines {
 		hidden := totalLines - toolBodyMaxLines
@@ -2974,10 +2985,12 @@ func (m *cliModel) renderGrepBody(tool protocol.ToolProgress, maxW int, t cliThe
 	}
 
 	var sb strings.Builder
+	grepStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextPrimary))
 	for _, line := range displayLines {
-		line = ansi.Truncate(line, maxW, "")
-		sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextPrimary)).Render(line))
-		sb.WriteString("\n")
+		for _, wl := range strings.Split(hardWrapRunes(line, maxW), "\n") {
+			sb.WriteString(grepStyle.Render(wl))
+			sb.WriteString("\n")
+		}
 	}
 	if totalLines > toolBodyMaxLines {
 		hidden := totalLines - toolBodyMaxLines
@@ -3008,11 +3021,15 @@ func (m *cliModel) renderGlobBody(tool protocol.ToolProgress, maxW int, t cliThe
 	}
 
 	var sb strings.Builder
+	indentStyle := lipgloss.NewStyle().Foreground(fgMeta)
+	fileStyle := lipgloss.NewStyle().Foreground(fgFile)
 	for _, line := range displayLines {
-		line = ansi.Truncate(line, maxW, "")
-		sb.WriteString(lipgloss.NewStyle().Foreground(fgMeta).Render("  "))
-		sb.WriteString(lipgloss.NewStyle().Foreground(fgFile).Render(line))
-		sb.WriteString("\n")
+		// Account for "  " indent: wrap file path to maxW-2, then prepend indent.
+		for _, wl := range strings.Split(hardWrapRunes(line, maxW-2), "\n") {
+			sb.WriteString(indentStyle.Render("  "))
+			sb.WriteString(fileStyle.Render(wl))
+			sb.WriteString("\n")
+		}
 	}
 	if totalLines > toolBodyMaxLines {
 		hidden := totalLines - toolBodyMaxLines

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -2944,6 +2944,11 @@ func (m *cliModel) renderShellBody(tool protocol.ToolProgress, maxW int, t cliTh
 	}
 
 	// Show output (wrapped to fit)
+	// Progress bars (tqdm etc.) use \r to overwrite the same line.
+	// When captured as output, \r-embedded lines confuse the terminal:
+	// \r moves cursor to column 0, overwriting the guide prefix.
+	// Strategy: for each output line, keep only the content after the
+	// last \r (i.e. the final visual state), then wrap normally.
 	lines := strings.Split(content, "\n")
 	totalLines := len(lines)
 	displayLines := lines
@@ -2952,6 +2957,16 @@ func (m *cliModel) renderShellBody(tool protocol.ToolProgress, maxW int, t cliTh
 	}
 	outputStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextPrimary))
 	for _, line := range displayLines {
+		// Strip carriage-return overwrites: keep only the final visual
+		// state (content after the last \r). This handles progress bars
+		// (tqdm etc.) whose output contains multiple \r-separated frames.
+		if idx := strings.LastIndex(line, "\r"); idx >= 0 {
+			line = line[idx+1:]
+		}
+		// Skip empty lines after \r stripping (fully overwritten frames)
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
 		for _, wl := range strings.Split(hardWrapRunes(line, maxW), "\n") {
 			sb.WriteString(outputStyle.Render(wl))
 			sb.WriteString("\n")

--- a/channel/cli_msg_builder.go
+++ b/channel/cli_msg_builder.go
@@ -1,0 +1,124 @@
+package channel
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"xbot/protocol"
+)
+
+// cliMessageBuilder constructs WSMessage payloads for CLI channel operations.
+// Both ChannelCliChannel (local/in-process) and RemoteCLIChannel (WebSocket)
+// use these builders so the message format stays identical — only the
+// transport layer differs.
+type cliMessageBuilder struct{}
+
+var cliMsg = cliMessageBuilder{}
+
+// buildTextMsg creates a text outbound message.
+func (cliMessageBuilder) buildTextMsg(msg OutboundMsg) protocol.WSMessage {
+	return protocol.WSMessage{
+		Type:    protocol.MsgTypeText,
+		TS:      time.Now().Unix(),
+		Content: msg.Content,
+		ChatID:  msg.ChatID,
+		Channel: msg.Channel,
+	}
+}
+
+// buildAskUserMsg creates an ask_user message from an outbound message with
+// WaitingUser=true. Returns nil if WaitingUser is false.
+func (cliMessageBuilder) buildAskUserMsg(msg OutboundMsg) *protocol.WSMessage {
+	if !msg.WaitingUser {
+		return nil
+	}
+	askEv := protocol.AskUserEvent{
+		Channel: msg.Channel,
+		ChatID:  msg.ChatID,
+	}
+	if msg.Metadata != nil {
+		askEv.RequestID = msg.Metadata["request_id"]
+		askEv.Questions = msg.Metadata["ask_questions"]
+	}
+	data, _ := json.Marshal(askEv)
+	return &protocol.WSMessage{
+		Type:    protocol.MsgTypeAskUser,
+		TS:      time.Now().Unix(),
+		ChatID:  msg.ChatID,
+		Content: string(data),
+	}
+}
+
+// buildProgressMsg creates a progress event message.
+// Returns nil if payload is nil.
+func (cliMessageBuilder) buildProgressMsg(chatID string, payload *protocol.ProgressEvent) *protocol.WSMessage {
+	if payload == nil {
+		return nil
+	}
+	return &protocol.WSMessage{
+		Type:     protocol.MsgTypeProgress,
+		TS:       time.Now().Unix(),
+		Progress: payload,
+		ChatID:   chatID,
+	}
+}
+
+// buildStreamContentMsg creates a stream content message.
+// The Progress.ChatID carries the "cli:" prefix expected by
+// handleProgressMsg's session filter. Returns nil if both content and
+// reasoning are empty.
+func (cliMessageBuilder) buildStreamContentMsg(chatID, content, reasoning string) *protocol.WSMessage {
+	if content == "" && reasoning == "" {
+		return nil
+	}
+	return &protocol.WSMessage{
+		Type: protocol.MsgTypeStreamContent,
+		TS:   time.Now().Unix(),
+		Progress: &protocol.ProgressEvent{
+			ChatID:                 "cli:" + chatID,
+			StreamContent:          content,
+			ReasoningStreamContent: reasoning,
+		},
+	}
+}
+
+// buildSessionStateMsg creates a session state change message.
+func (cliMessageBuilder) buildSessionStateMsg(ev protocol.SessionEvent) protocol.WSMessage {
+	return protocol.WSMessage{
+		Type:    protocol.MsgTypeSession,
+		TS:      time.Now().Unix(),
+		Session: &ev,
+	}
+}
+
+// buildInjectUserMsg creates an inject_user message.
+func (cliMessageBuilder) buildInjectUserMsg(chatID, content string) protocol.WSMessage {
+	return protocol.WSMessage{
+		Type:    protocol.MsgTypeInjectUser,
+		TS:      time.Now().Unix(),
+		ChatID:  chatID,
+		Content: content,
+	}
+}
+
+// buildTUIControlReqMsg creates a TUI control request message.
+func (cliMessageBuilder) buildTUIControlReqMsg(id, chatID string, action string, params map[string]string) protocol.WSMessage {
+	return protocol.WSMessage{
+		Type:   protocol.MsgTypeTUIControlReq,
+		ID:     id,
+		ChatID: chatID,
+		TUIControl: &protocol.TUIControlPayload{
+			Action: action,
+			Params: params,
+		},
+	}
+}
+
+// generateTUIID creates a unique ID for TUI control requests.
+func (cliMessageBuilder) generateTUIID() string {
+	return fmt.Sprintf("tui-%d", time.Now().UnixNano())
+}
+
+// tuiRespTimeout is the timeout for waiting on a TUI control response.
+const tuiRespTimeout = 10 * time.Second

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -196,6 +196,15 @@ func hardWrapRunes(line string, maxW int) string {
 	var ansiState strings.Builder // accumulated SGR sequences since last reset
 	haveAnsiState := false
 
+	// Snapshot of ansiState at the lastBreakable position.
+	// When breaking at lastBreakable, rest already contains escape sequences
+	// that came after the break point. If we blindly replay the CURRENT
+	// ansiState (which accumulated more escapes since lastBreakable),
+	// we inject escape sequences into the middle of rest's text,
+	// corrupting the terminal output and causing visible "character loss".
+	var breakAnsiState string
+	breakHaveAnsi := false
+
 	for _, r := range line {
 		if r == '\x1b' {
 			inEscape = true
@@ -229,6 +238,14 @@ func hardWrapRunes(line string, maxW int) string {
 		// Mark breakable positions: after space or after CJK character
 		if r == ' ' || isCJK(r) {
 			lastBreakable = buf.Len() + utf8.RuneLen(r)
+			// Snapshot ANSI state at this breakable position so we can
+			// replay the correct state on the continuation line.
+			if haveAnsiState {
+				breakAnsiState = ansiState.String()
+			} else {
+				breakAnsiState = ""
+			}
+			breakHaveAnsi = haveAnsiState
 		}
 
 		if w+rw > maxW {
@@ -238,8 +255,15 @@ func hardWrapRunes(line string, maxW int) string {
 				rest := buf.String()[lastBreakable:]
 				lines = append(lines, keep)
 				buf.Reset()
+				// Replay ANSI state BEFORE rest so the continuation line
+				// inherits the correct color/style. Without this, the replay
+				// ends up AFTER rest's text, corrupting the terminal output
+				// (ANSI escape injected mid-word causes visible "character loss").
+				if breakHaveAnsi {
+					buf.WriteString(breakAnsiState)
+				}
 				buf.WriteString(rest)
-				w = lipgloss.Width(rest)
+				w = lipgloss.Width(buf.String())
 				lastBreakable = -1
 			} else {
 				// No breakable position found, hard break here
@@ -247,10 +271,12 @@ func hardWrapRunes(line string, maxW int) string {
 				buf.Reset()
 				w = 0
 				lastBreakable = -1
-			}
-			// Replay active ANSI state on continuation line
-			if haveAnsiState {
-				buf.WriteString(ansiState.String())
+				// For hard breaks, the current ansiState is correct —
+				// no escape sequences were accumulated between buf.String()
+				// and this point (the current rune hasn't been written yet).
+				if haveAnsiState {
+					buf.WriteString(ansiState.String())
+				}
 			}
 		}
 		buf.WriteRune(r)

--- a/channel/cli_types_test.go
+++ b/channel/cli_types_test.go
@@ -268,3 +268,103 @@ func TestHardWrapRunes_AnsiResetClearsState(t *testing.T) {
 		t.Errorf("continuation replayed color after reset: %q", lines[1])
 	}
 }
+
+// TestHardWrapRunes_AnsiColorBreakOrder verifies that ANSI state is replayed
+// BEFORE the rest text on continuation lines, not after. This was the root
+// cause of "character loss" during TUI streaming: the escape sequence was
+// injected mid-word, corrupting the terminal output.
+//
+// Before fix: line 1 = "W\x1b[36morld..." (escape after 'W', before 'orld')
+// After fix:  line 1 = "\x1b[36mWorld..." (escape before the text)
+func TestHardWrapRunes_AnsiColorBreakOrder(t *testing.T) {
+	// "Hello" (plain) + "\x1b[36m" (cyan) + " World" (cyan) + "\x1b[0m" (reset) + "ABCDEFGHIJKLMNO"
+	input := "Hello\x1b[36m World\x1b[0mABCDEFGHIJKLMNO"
+	got := hardWrapRunes(input, 7)
+	lines := strings.Split(got, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected >= 3 lines, got %d: %q", len(lines), got)
+	}
+
+	// Verify: no line should have an ANSI escape in the MIDDLE of a word.
+	// Each line should either start with an escape or have plain text.
+	for i, line := range lines {
+		plain := ansi.Strip(line)
+		// Check that the line is not empty
+		if plain == "" {
+			t.Errorf("line %d is empty: %q", i, line)
+		}
+		// Check that the plain text is a substring of the original plain text
+		orig := ansi.Strip(input)
+		if !strings.Contains(orig, plain) && len(plain) > 0 {
+			t.Errorf("line %d: plain %q not found in original %q", i, plain, orig)
+		}
+	}
+
+	// Verify: total plain text reconstruction equals original
+	var recon []string
+	for _, line := range lines {
+		recon = append(recon, ansi.Strip(line))
+	}
+	orig := ansi.Strip(input)
+	reconstructed := strings.Join(recon, "")
+	if orig != reconstructed {
+		t.Errorf("character loss: got %q, want %q", reconstructed, orig)
+	}
+}
+
+// TestHardWrapRunes_AnsiBreakBeforeRest verifies the fix for the streaming
+// character loss bug: when breaking at a breakable position inside styled text,
+// the continuation line must replay the ANSI state BEFORE rest text.
+func TestHardWrapRunes_AnsiBreakBeforeRest(t *testing.T) {
+	// Styled text with a space as break point, followed by more styled text.
+	// The break should produce lines where the ANSI replay is at the START
+	// of the continuation line, not injected into the middle of text.
+	input := "\x1b[36mABCDEF\x1b[0m GHIJKLMNOP"
+	got := hardWrapRunes(input, 6)
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected >= 2 lines, got %d", len(lines))
+	}
+
+	// Line 0 should end the cyan region cleanly
+	line0 := lines[0]
+	if !strings.HasSuffix(line0, "\x1b[0m") && !strings.Contains(line0, "\x1b[0m ") {
+		// Line 0 has the reset, which is fine
+	}
+
+	// Line 1 should NOT have an escape injected between characters of a word.
+	// Before the fix, line 1 could be "G\x1b[0mHIJKL" with escape between G and H.
+	line1 := lines[1]
+	plain1 := ansi.Strip(line1)
+	// The plain text should be a contiguous substring of the original
+	orig := ansi.Strip(input)
+	if !strings.Contains(orig, plain1) {
+		t.Errorf("line 1 plain %q not found in original %q\nfull line: %q", plain1, orig, line1)
+	}
+}
+
+// TestHardWrapRunes_MultipleColorsNoLoss verifies that wrapping text with
+// multiple color changes doesn't lose any characters.
+func TestHardWrapRunes_MultipleColorsNoLoss(t *testing.T) {
+	input := "This is a \x1b[36mcode\x1b[0m block with \x1b[33mmore\x1b[0m text here"
+	for _, maxW := range []int{10, 15, 20, 25} {
+		got := hardWrapRunes(input, maxW)
+		lines := strings.Split(got, "\n")
+		var recon []string
+		for _, l := range lines {
+			recon = append(recon, ansi.Strip(l))
+		}
+		reconstructed := strings.Join(recon, "")
+		orig := ansi.Strip(input)
+		if orig != reconstructed {
+			t.Errorf("maxW=%d: character loss. got %q, want %q", maxW, reconstructed, orig)
+		}
+		// Width constraint
+		for i, l := range lines {
+			w := ansi.StringWidth(l)
+			if w > maxW {
+				t.Errorf("maxW=%d line %d: width %d exceeds maxW: %q", maxW, i, w, l)
+			}
+		}
+	}
+}

--- a/channel/cli_types_test.go
+++ b/channel/cli_types_test.go
@@ -326,11 +326,9 @@ func TestHardWrapRunes_AnsiBreakBeforeRest(t *testing.T) {
 		t.Fatalf("expected >= 2 lines, got %d", len(lines))
 	}
 
-	// Line 0 should end the cyan region cleanly
-	line0 := lines[0]
-	if !strings.HasSuffix(line0, "\x1b[0m") && !strings.Contains(line0, "\x1b[0m ") {
-		// Line 0 has the reset, which is fine
-	}
+	// Line 0 should end the cyan region cleanly — no assertion needed,
+	// as missing reset is acceptable.
+	_ = lines[0]
 
 	// Line 1 should NOT have an escape injected between characters of a word.
 	// Before the fix, line 1 could be "G\x1b[0mHIJKL" with escape between G and H.

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -510,12 +510,10 @@ func (m *cliModel) layoutViewportHeight() int {
 	if len(m.todos) > 0 && !m.sidebarShown() {
 		todoLines = 1 + len(m.todos)
 	}
-	// Info bar: 1 line when bg tasks/agents/queue are active OR widget content exists.
-	// (Widget content may fill the info bar even when no system indicators are active.)
-	infoBarLines := 0
-	if m.bgTaskCount > 0 || m.agentCount > 0 || len(m.messageQueue) > 0 || m.resolveWidgetZone("infoBar") != "" {
-		infoBarLines = 1
-	}
+	// Info bar: always reserve 1 line. renderInfoBar() always produces
+	// output (at minimum the workspace indicator), so the viewport must
+	// account for it.
+	infoBarLines := 1
 	reservedLines := fixedLines + taBorder + m.textarea.Height() + todoLines + infoBarLines
 	// §20b 小终端适配：极小窗口下动态缩减布局
 	if height < 12 {

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -1588,7 +1588,19 @@ func (m *cliModel) handleTickMsg() []tea.Cmd {
 	busy := m.typing || sessionActive
 	needsSpinnerTick := busy || m.sidebarHasBusySessions
 
-	if (m.bgTaskCountFn != nil && m.bgTaskCount > 0) || (m.agentCountFn != nil && m.agentCount > 0) || needsSpinnerTick {
+	// Refresh bg task / agent counts every tick so the infobar and sidebar
+	// stay accurate even when the agent is idle (no progress messages flowing).
+	prevBg := m.bgTaskCount
+	prevAgent := m.agentCount
+	if m.bgTaskCountFn != nil {
+		m.bgTaskCount = m.bgTaskCountFn()
+	}
+	if m.agentCountFn != nil {
+		m.agentCount = m.agentCountFn()
+	}
+	countsChanged := m.bgTaskCount != prevBg || m.agentCount != prevAgent
+
+	if (m.bgTaskCount > 0) || (m.agentCount > 0) || needsSpinnerTick {
 		m.ticker.tick()
 		hasStreamContent := m.progress != nil && m.progress.StreamContent != "" && m.twVisible < len([]rune(m.progress.StreamContent))
 		hasReasoningContent := m.progress != nil && m.progress.ReasoningStreamContent != "" && m.rwVisible < len([]rune(m.progress.ReasoningStreamContent))
@@ -1601,7 +1613,7 @@ func (m *cliModel) handleTickMsg() []tea.Cmd {
 		m.updateViewportContent()
 	} else {
 		m.typewriterTickActive = false
-		if !m.renderCacheValid {
+		if !m.renderCacheValid || countsChanged {
 			m.updateViewportContent()
 		}
 	}

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -917,8 +917,10 @@ func (m *cliModel) allTodosDone() bool {
 
 // renderInfoBar renders a sleek bottom status line below the input box
 // showing background tasks, active subagents, and pending queue —
-// inspired by lazygit's and Warp's status panels.
-// Only renders when there are active items (no "empty" state noise).
+// renderInfoBar builds the info bar below the input box.
+// Always produces output (at minimum the workspace indicator) so the user
+// can see which workspace/session they're in. layoutViewportHeight reserves
+// a matching line via infoBarLines=1.
 func (m *cliModel) renderInfoBar() string {
 	hasTasks := m.bgTaskCount > 0
 	hasAgents := m.agentCount > 0

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -585,6 +585,8 @@ func localeZH() *UILocale {
 			{Key: "privileged_user", Label: "特权用户", Description: "LLM 以此用户执行时需要人工审批。留空则禁止提权。需配置 NOPASSWD sudoers", Type: SettingTypeText, Category: "权限"},
 			// Runner panel entry (display-only, triggers panel switch)
 			{Key: "runner_panel", Label: "🔧 Runner 管理", Type: SettingTypeText, Category: "Runner"},
+			// Experimental features
+			{Key: "auto_worktree", Label: "自动 Worktree 隔离", Description: "每个会话自动创建独立的 git worktree，避免多 agent 同时修改同一文件。需要 git 仓库。", Type: SettingTypeToggle, Category: "实验性", DefaultValue: "false"},
 			// Danger zone entry (display-only, triggers panel switch)
 			{Key: "danger_zone", Label: "⚠️ 危险区 — 清空记忆", Type: SettingTypeText, Category: "危险"},
 		},
@@ -967,6 +969,8 @@ func localeEN() *UILocale {
 			{Key: "privileged_user", Label: "Privileged User", Description: "OS user that requires human approval when used by LLM. Leave empty to block privilege escalation. Requires NOPASSWD sudoers", Type: SettingTypeText, Category: "Permissions"},
 			// Runner panel entry (display-only, triggers panel switch)
 			{Key: "runner_panel", Label: "🔧 Runner Manager", Type: SettingTypeText, Category: "Runner"},
+			// Experimental features
+			{Key: "auto_worktree", Label: "Auto Worktree Isolation", Description: "Automatically create an isolated git worktree for each session, preventing multi-agent file conflicts. Requires a git repository.", Type: SettingTypeToggle, Category: "Experimental", DefaultValue: "false"},
 			// Danger zone entry (display-only, triggers panel switch)
 			{Key: "danger_zone", Label: "⚠️ Danger Zone — Clear Memory", Type: SettingTypeText, Category: "Danger"},
 		},
@@ -1349,6 +1353,8 @@ func localeJA() *UILocale {
 			{Key: "privileged_user", Label: "特権ユーザー", Description: "LLMが使用時に人間の承認が必要なOSユーザー。空の場合は権限昇格を禁止。NOPASSWD sudoersが必要", Type: SettingTypeText, Category: "権限"},
 			// Runner panel entry (display-only, triggers panel switch)
 			{Key: "runner_panel", Label: "🔧 Runner 管理", Type: SettingTypeText, Category: "Runner"},
+			// Experimental features
+			{Key: "auto_worktree", Label: "自動 Worktree 分離", Description: "各セッションに独立した git worktree を自動作成し、マルチエージェントのファイル競合を防止します。git リポジトリが必要です。", Type: SettingTypeToggle, Category: "実験的", DefaultValue: "false"},
 			// Danger zone entry (display-only, triggers panel switch)
 			{Key: "danger_zone", Label: "⚠️ 危険エリア — 記憶クリア", Type: SettingTypeText, Category: "危険"},
 		},

--- a/channel/setting_keys.go
+++ b/channel/setting_keys.go
@@ -97,6 +97,9 @@ var AllSettingDefs = []SettingDef{
 	{Key: "chat_max_width", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermTransient, AIDescription: "Max chat width in columns", ValidValues: "0-200", DefaultValue: "0"},
 	{Key: "chat_center", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermTransient, AIDescription: "Center chat area", ValidValues: "true|false", DefaultValue: "false"},
 
+	// ── Worktree isolation ──
+	{Key: "auto_worktree", Scope: ScopeGlobal, Source: SourceConfigJSON, Runtime: true, Permission: PermPersistent, AIDescription: "Automatically create isolated git worktrees for each session (no shared workspace)", ValidValues: "true|false", DefaultValue: "false"},
+
 	{Key: "language", Scope: ScopeUser, Source: SourceUserDB, Permission: PermTransient, AIDescription: "UI language", ValidValues: "zh|en|ja", DefaultValue: "zh"},
 	{Key: "context_mode", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Context handling: auto or manual", ValidValues: "auto|manual", DefaultValue: "auto"},
 	{Key: "max_iterations", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Max tool iterations per turn", ValidValues: "1-500", DefaultValue: "30"},

--- a/channel/setting_keys.go
+++ b/channel/setting_keys.go
@@ -98,7 +98,7 @@ var AllSettingDefs = []SettingDef{
 	{Key: "chat_center", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermTransient, AIDescription: "Center chat area", ValidValues: "true|false", DefaultValue: "false"},
 
 	// ── Worktree isolation ──
-	{Key: "auto_worktree", Scope: ScopeGlobal, Source: SourceConfigJSON, Runtime: true, Permission: PermPersistent, AIDescription: "Automatically create isolated git worktrees for each session (no shared workspace)", ValidValues: "true|false", DefaultValue: "false"},
+	{Key: "auto_worktree", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Automatically create isolated git worktrees for each session (no shared workspace)", ValidValues: "true|false", DefaultValue: "false"},
 
 	{Key: "language", Scope: ScopeUser, Source: SourceUserDB, Permission: PermTransient, AIDescription: "UI language", ValidValues: "zh|en|ja", DefaultValue: "zh"},
 	{Key: "context_mode", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Context handling: auto or manual", ValidValues: "auto|manual", DefaultValue: "auto"},

--- a/channel/web_remote_cli.go
+++ b/channel/web_remote_cli.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (c *RemoteCLIChannel) SendTUIControlRequest(chatID string, action string, params map[string]string) (map[string]string, error) {
-	id := fmt.Sprintf("tui-%d", time.Now().UnixNano())
+	id := cliMsg.generateTUIID()
 	ch := make(chan *protocol.TUIControlPayload, 1)
 
 	c.tuiPendingMu.Lock()
@@ -27,14 +27,7 @@ func (c *RemoteCLIChannel) SendTUIControlRequest(chatID string, action string, p
 		c.tuiPendingMu.Unlock()
 	}()
 
-	wsMsg := protocol.WSMessage{
-		Type: protocol.MsgTypeTUIControlReq,
-		ID:   id,
-		TUIControl: &protocol.TUIControlPayload{
-			Action: action,
-			Params: params,
-		},
-	}
+	wsMsg := cliMsg.buildTUIControlReqMsg(id, chatID, action, params)
 	if !c.hub.sendToClient(chatID, wsMsg) {
 		return nil, fmt.Errorf("remote CLI client offline for chat %s", chatID)
 	}
@@ -45,7 +38,7 @@ func (c *RemoteCLIChannel) SendTUIControlRequest(chatID string, action string, p
 			return nil, fmt.Errorf("%s", resp.Error)
 		}
 		return resp.Result, nil
-	case <-time.After(10 * time.Second):
+	case <-time.After(tuiRespTimeout):
 		return nil, fmt.Errorf("tui_control request %s timed out", id)
 	}
 }
@@ -99,15 +92,9 @@ func (c *RemoteCLIChannel) Start() error { return nil }
 func (c *RemoteCLIChannel) Stop() {}
 
 // InjectUserMessage sends an injected user message (e.g. bg task notification)
-// to the remote CLI runner via WebSocket. The runner will display it as a user
-// message in the TUI and use it to start the agent turn display.
+// to the remote CLI runner via WebSocket.
 func (c *RemoteCLIChannel) InjectUserMessage(chatID, content string) {
-	wsMsg := protocol.WSMessage{
-		Type:    protocol.MsgTypeInjectUser,
-		Content: content,
-		ChatID:  chatID,
-		TS:      time.Now().Unix(),
-	}
+	wsMsg := cliMsg.buildInjectUserMsg(chatID, content)
 	if !c.hub.sendToClient(chatID, wsMsg) {
 		log.WithField("chat_id", chatID).Debug("Remote CLI client offline, inject_user buffered")
 	}
@@ -115,49 +102,27 @@ func (c *RemoteCLIChannel) InjectUserMessage(chatID, content string) {
 
 // SendProgress sends structured progress to remote CLI clients via the Hub.
 func (c *RemoteCLIChannel) SendProgress(chatID string, payload *protocol.ProgressEvent) {
-	if payload == nil {
-		return
-	}
-	wsMsg := protocol.WSMessage{
-		Type:     protocol.MsgTypeProgress,
-		TS:       time.Now().Unix(),
-		Progress: payload,
-	}
-	if !c.hub.sendToClient(chatID, wsMsg) {
-		log.WithFields(log.Fields{
-			"chat_id": chatID,
-			"phase":   payload.Phase,
-			"iter":    payload.Iteration,
-		}).Info("Hub SendProgress: no online subscriber, event buffered")
+	if msg := cliMsg.buildProgressMsg(chatID, payload); msg != nil {
+		if !c.hub.sendToClient(chatID, *msg) {
+			log.WithFields(log.Fields{
+				"chat_id": chatID,
+				"phase":   payload.Phase,
+				"iter":    payload.Iteration,
+			}).Info("Hub SendProgress: no online subscriber, event buffered")
+		}
 	}
 }
 
 // SendSessionState sends a session state change event to remote CLI clients via the Hub.
 func (c *RemoteCLIChannel) SendSessionState(ev protocol.SessionEvent) {
-	wsMsg := protocol.WSMessage{
-		Type:    protocol.MsgTypeSession,
-		TS:      time.Now().Unix(),
-		Session: &ev,
-	}
-	// Broadcast to all connected clients — session state is global, not per-chat.
-	c.hub.broadcastToAll(wsMsg)
+	c.hub.broadcastToAll(cliMsg.buildSessionStateMsg(ev))
 }
 
 // SendStreamContent sends streaming LLM content to remote CLI clients via the Hub.
 func (c *RemoteCLIChannel) SendStreamContent(chatID, content, reasoning string) {
-	if content == "" && reasoning == "" {
-		return
+	if msg := cliMsg.buildStreamContentMsg(chatID, content, reasoning); msg != nil {
+		_ = c.hub.sendToClient(chatID, *msg) // stream events are ephemeral, safe to drop
 	}
-	wsMsg := protocol.WSMessage{
-		Type: protocol.MsgTypeStreamContent,
-		TS:   time.Now().Unix(),
-		Progress: &protocol.ProgressEvent{
-			ChatID:                 "cli:" + chatID,
-			StreamContent:          content,
-			ReasoningStreamContent: reasoning,
-		},
-	}
-	_ = c.hub.sendToClient(chatID, wsMsg) // stream events are ephemeral, safe to drop
 }
 
 // PushPluginWidgetsPerSession pushes widget zone content to each connected CLI
@@ -235,47 +200,26 @@ func (c *RemoteCLIChannel) Send(msg OutboundMsg) (string, error) {
 
 	targetClientID := msg.ChatID
 
-	wsMsg := protocol.WSMessage{
-		Type:            msgType,
-		ID:              msgID,
-		Content:         content,
-		TS:              time.Now().Unix(),
-		ProgressHistory: msg.Metadata["progress_history"],
-		Channel:         msg.Channel,
-		ChatID:          msg.ChatID,
-	}
+	// Build base text message, then overlay remote-specific fields
+	wsMsg := cliMsg.buildTextMsg(msg)
+	wsMsg.ID = msgID
+	wsMsg.Type = msgType
+	wsMsg.Content = content
+	wsMsg.ProgressHistory = msg.Metadata["progress_history"]
 
 	if !c.hub.sendToClient(targetClientID, wsMsg) {
 		log.WithFields(log.Fields{"chat_id": msg.ChatID, "target_client_id": targetClientID}).Debug("CLI WS client offline, message buffered")
 	}
 
-	// AskUser: agent needs user input
-	if msg.WaitingUser {
-		askPayload := &protocol.ProgressEvent{}
-		if msg.Metadata != nil {
-			askPayload.RequestID = msg.Metadata["request_id"]
-			if qJSON := msg.Metadata["ask_questions"]; qJSON != "" {
-				var qs []protocol.AskUserQuestion
-				if json.Unmarshal([]byte(qJSON), &qs) == nil {
-					askPayload.Questions = qs
-				}
-			}
-		}
+	// AskUser: reuse shared builder
+	if askMsg := cliMsg.buildAskUserMsg(msg); askMsg != nil {
+		askMsg.ID = msgID
 		log.WithFields(log.Fields{
 			"msg_channel":   msg.Channel,
 			"msg_chatid":    msg.ChatID,
 			"target_client": targetClientID,
-			"num_questions": len(askPayload.Questions),
 		}).Info("RemoteCLIChannel.Send: dispatching ask_user")
-		askMsg := protocol.WSMessage{
-			Type:     protocol.MsgTypeAskUser,
-			ID:       msgID,
-			TS:       time.Now().Unix(),
-			Channel:  msg.Channel,
-			ChatID:   msg.ChatID,
-			Progress: askPayload,
-		}
-		c.hub.sendToClient(targetClientID, askMsg)
+		c.hub.sendToClient(targetClientID, *askMsg)
 	}
 
 	return msgID, nil

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -1004,7 +1004,15 @@ func main() {
 	}
 
 	// 用工作目录绝对路径作为 ChatID，不同目录有不同的会话
-	absWorkDir, _ := filepath.Abs(app.workDir)
+	// Prefer os.Getwd() (actual terminal cwd) over config agent.work_dir.
+	// config work_dir may be ~ or some other non-project directory, but the user
+	// typically launches xbot-cli from the project root. Using os.Getwd() ensures
+	// chatID and session workDir match the actual project directory.
+	workDir := app.workDir
+	if cwd, err := os.Getwd(); err == nil && cwd != "" {
+		workDir = cwd
+	}
+	absWorkDir, _ := filepath.Abs(workDir)
 
 	// Restore last active session on startup, unless --new/--new-session is used.
 	// Both local and remote mode use local sessions.json — it's written by

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -1620,18 +1620,18 @@ func main() {
 
 	chatID := initialChatID
 
-	// Auto-set CWD: for remote servers, sync the CLI's actual cwd so the
-	// agent uses the correct directory. Local mode already has the workspace set.
-	if app.client.IsRemote() && isLocalServer(app.cfg.CLI.ServerURL) {
-		if cwd, err := os.Getwd(); err == nil {
-			if err := app.client.SetCWD("cli", chatID, cwd); err != nil {
-				log.WithError(err).WithField("chat_id", chatID).Warn("Failed to sync CWD to server")
-			} else {
-				log.WithFields(log.Fields{
-					"cwd":     cwd,
-					"chat_id": chatID,
-				}).Info("Synced CLI CWD to local server")
-			}
+	// Auto-set CWD: sync the CLI's actual cwd so the agent uses the
+	// correct directory. Both local and remote modes need this — local mode's
+	// cfg.Agent.WorkDir defaults to "." (process root), and sessions may have
+	// a stale persisted CWD from a previous run.
+	if cwd, err := os.Getwd(); err == nil {
+		if err := app.client.SetCWD("cli", chatID, cwd); err != nil {
+			log.WithError(err).WithField("chat_id", chatID).Warn("Failed to sync CWD")
+		} else {
+			log.WithFields(log.Fields{
+				"cwd":     cwd,
+				"chat_id": chatID,
+			}).Info("Synced CLI CWD")
 		}
 	}
 

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -193,6 +193,10 @@ func (app *cliApp) refreshRemoteValuesCache() {
 			return fmt.Sprintf("%d", config.DefaultMaxContextTokens)
 		}()
 	}
+	// Experimental: auto_worktree
+	if _, ok := vals["auto_worktree"]; !ok {
+		vals["auto_worktree"] = strconv.FormatBool(app.cfg.Agent.Experimental.AutoWorktree)
+	}
 	app.valuesCacheMu.Lock()
 	app.valuesCache = vals
 	app.valuesCacheMu.Unlock()

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -193,13 +193,14 @@ func (app *cliApp) refreshRemoteValuesCache() {
 			return fmt.Sprintf("%d", config.DefaultMaxContextTokens)
 		}()
 	}
-	// Experimental: auto_worktree
-	if _, ok := vals["auto_worktree"]; !ok {
-		vals["auto_worktree"] = strconv.FormatBool(app.cfg.Agent.Experimental.AutoWorktree)
-	}
 	app.valuesCacheMu.Lock()
 	app.valuesCache = vals
 	app.valuesCacheMu.Unlock()
+
+	// Sync all DB values back to app.cfg so saveCLIConfig persists them.
+	// This ensures CLI-side config stays in sync with user_settings DB
+	// regardless of which setting was changed.
+	agent.ApplyRuntimeSettingsLocal(app.cfg, vals)
 
 	// Merge layout keys from local config.json if missing (RPC may fail on first call)
 	layoutKeys := []string{"sidebar_width", "sidebar_enabled", "sidebar_position", "chat_max_width", "chat_center", "layout_mode"}

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/qiniu/go-sdk/v7 v7.26.6
 	github.com/rivo/uniseg v0.4.7
 	github.com/sahilm/fuzzy v0.1.1
+	github.com/stretchr/testify v1.11.1
 	github.com/tiktoken-go/tokenizer v0.7.0
 	golang.org/x/crypto v0.49.0
 	modernc.org/sqlite v1.46.1
@@ -54,6 +55,7 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elliotchance/orderedmap/v2 v2.2.0 // indirect
@@ -71,6 +73,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.3 // indirect
@@ -89,6 +92,7 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/fileutil v1.3.40 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/tools/todo.go
+++ b/tools/todo.go
@@ -153,11 +153,13 @@ func (m *TodoManager) GetTodos(sessionKey string) []TodoItem {
 }
 
 // sessionKey helper
-// Uses AgentID to isolate TODOs between main Agent and SubAgents.
-// SubAgent AgentID is "parentID/roleName", main Agent is typically "main".
+// For SubAgents (AgentID contains "/", e.g. "main/explore"), prepends AgentID
+// to isolate their TODOs from the main agent. Main agent (AgentID="main")
+// keeps the original Channel:ChatID key so all readers remain compatible.
 func (m *TodoManager) sessionKey(ctx *ToolContext) string {
 	if ctx.Channel != "" && ctx.ChatID != "" {
-		if ctx.AgentID != "" {
+		// SubAgent AgentID format: "parentID/roleName" (contains "/")
+		if strings.Contains(ctx.AgentID, "/") {
 			return ctx.AgentID + ":" + ctx.Channel + ":" + ctx.ChatID
 		}
 		return ctx.Channel + ":" + ctx.ChatID

--- a/tools/todo_test.go
+++ b/tools/todo_test.go
@@ -78,7 +78,19 @@ func TestTodoManager_SessionKey_BackwardsCompatible(t *testing.T) {
 		t.Errorf("sessionKey without AgentID = %q, want %q", key, "cli:session-1")
 	}
 
-	// 有 AgentID 时应使用 AgentID:Channel:ChatID
+	// 主 Agent AgentID="main"（不含 "/"），保持 Channel:ChatID 不变
+	ctx1b := &ToolContext{
+		Ctx:     context.Background(),
+		AgentID: "main",
+		Channel: "cli",
+		ChatID:  "session-1",
+	}
+	key1b := mgr.sessionKey(ctx1b)
+	if key1b != "cli:session-1" {
+		t.Errorf("sessionKey with main AgentID = %q, want %q", key1b, "cli:session-1")
+	}
+
+	// SubAgent AgentID 含 "/"，使用 AgentID:Channel:ChatID
 	ctx2 := &ToolContext{
 		Ctx:     context.Background(),
 		AgentID: "main/explore",
@@ -87,7 +99,7 @@ func TestTodoManager_SessionKey_BackwardsCompatible(t *testing.T) {
 	}
 	key2 := mgr.sessionKey(ctx2)
 	if key2 != "main/explore:cli:session-1" {
-		t.Errorf("sessionKey with AgentID = %q, want %q", key2, "main/explore:cli:session-1")
+		t.Errorf("sessionKey with SubAgent AgentID = %q, want %q", key2, "main/explore:cli:session-1")
 	}
 
 	// 无 Channel/ChatID 时返回空

--- a/tools/worktree.go
+++ b/tools/worktree.go
@@ -23,8 +23,7 @@ so agents don't conflict on the same files. Also supports listing and cleanup.
 
 ### init
 Create a new git worktree for the current agent. Registers it in the global registry.
-- The first agent in a repo uses the main project directly (role="primary").
-- Subsequent agents get their own worktree (role="peer" or "child").
+- Every session gets its own worktree — all agents are equal peers.
 - Returns the worktree path. You should then Cd to it.
 
 Parameters: {"action": "init", "role": "peer", "instance": "debug", "task": "fix auth bug"}
@@ -92,7 +91,8 @@ func (t *WorktreeTool) executeInit(ctx *ToolContext, params WorktreeParams) (*To
 	if !ctx.AutoWorktreeEnabled {
 		return NewResult(
 			"⚠️ Worktree 是实验性功能，默认关闭。\n" +
-				"如需启用自动 worktree 隔离，请在 config.json 中设置：\n" +
+				"如需启用自动 worktree 隔离，请在 /settings 中设置 `auto_worktree = true`，\n" +
+				"或在 config.json 中设置：\n" +
 				`  "agent": {"experimental": {"auto_worktree": true}}` +
 				"\n\n当前已启用 peer 感知——你可以看到其他 agent 并与之通信。"), nil
 	}
@@ -112,23 +112,7 @@ func (t *WorktreeTool) executeInit(ctx *ToolContext, params WorktreeParams) (*To
 			existing.Role, existing.WorktreeDir, existing.Branch)), nil
 	}
 
-	primary := GlobalWorktreeRegistry.GetPrimary(repoPath)
-	if primary == nil {
-		entry := &WorktreeEntry{
-			SessionKey:  sessionKey,
-			Role:        "primary",
-			RepoPath:    repoPath,
-			WorktreeDir: "",
-			Branch:      "",
-			Status:      "working",
-		}
-		if err := GlobalWorktreeRegistry.Register(entry); err != nil {
-			return nil, fmt.Errorf("worktree init: register primary: %w", err)
-		}
-		return NewResult(fmt.Sprintf("Registered as primary agent for repo %s.\nUsing main project directly (no worktree needed).", repoPath)), nil
-	}
-
-	// Creating a worktree — warn if tree is dirty (worktree starts from HEAD)
+	// All sessions get a worktree — no primary concept.
 	dirty, err := gitIsDirty(repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("worktree init: check dirty: %w", err)

--- a/tools/worktree_registry.go
+++ b/tools/worktree_registry.go
@@ -452,12 +452,11 @@ func removeWorktree(repoPath, worktreePath, branch string) error {
 }
 
 // pruneOrphanWorktrees cleans up worktree metadata for directories that no longer exist.
-// AutoDetectAndInit checks whether the current session needs worktree isolation.
-// It is called automatically at session start (before buildPrompt).
+// AutoDetectAndInit creates an isolated git worktree for the current session.
+// Called automatically at session start when auto_worktree is enabled.
 //
-// - If no other sessions are active in the repo → registers this session as primary (no worktree).
-// - If another session is already primary → creates a worktree for this session.
-// - Returns the worktree entry (primary or peer), or nil if not a git repo.
+// Every session gets its own worktree — no primary concept. All agents are equal peers.
+// Returns the worktree entry, or nil if not a git repo or worktree creation fails.
 func AutoDetectAndInit(workDir, sessionKey string) *WorktreeEntry {
 	// Check if in a git repo
 	repoPath, err := GitRepoRoot(workDir)
@@ -470,23 +469,7 @@ func AutoDetectAndInit(workDir, sessionKey string) *WorktreeEntry {
 		return entry
 	}
 
-	// Is there already a primary?
-	primary := GlobalWorktreeRegistry.GetPrimary(repoPath)
-	if primary == nil {
-		// First session → register as primary
-		entry := &WorktreeEntry{
-			SessionKey: sessionKey,
-			Role:       "primary",
-			RepoPath:   repoPath,
-			Status:     "working",
-		}
-		if err := GlobalWorktreeRegistry.Register(entry); err != nil {
-			return nil
-		}
-		return entry
-	}
-
-	// Another session is primary → create worktree for this session
+	// All sessions get a worktree — no primary concept.
 	branch := generateBranchName("peer", sessionKey, "")
 	branch = strings.ReplaceAll(branch, ":", "-") // sessionKey may contain ":"
 

--- a/tools/worktree_registry.go
+++ b/tools/worktree_registry.go
@@ -200,6 +200,9 @@ func (r *WorktreeRegistry) GetCWD(sessionKey string) string {
 // Used when auto_worktree is disabled. The first session in a repo is registered
 // as "primary"; subsequent sessions are registered as "peer" (sharing the main
 // workspace, no file isolation).
+//
+// Entries created by RegisterPeer are NOT persisted to disk — they are runtime-only
+// peer awareness data that becomes stale across process restarts.
 func (r *WorktreeRegistry) RegisterPeer(sessionKey, workDir string) {
 	if r.GetBySession(sessionKey) != nil {
 		return // already registered
@@ -233,7 +236,8 @@ func (r *WorktreeRegistry) RegisterPeer(sessionKey, workDir string) {
 	}
 	r.bySess[sessionKey] = entry
 	r.byRepo[repoPath] = append(r.byRepo[repoPath], entry)
-	r.saveRepoLocked(repoPath)
+	// Do NOT saveRepoLocked: peer-awareness entries are runtime-only.
+	// Only entries with real worktrees (WorktreeDir != "") need persistence.
 }
 
 // ensureLoadedBySession tries to load persisted data for the repo that
@@ -289,6 +293,10 @@ func (r *WorktreeRegistry) loadRepoLocked(repoPath string) {
 			if _, err := os.Stat(e.WorktreeDir); os.IsNotExist(err) {
 				continue // orphaned worktree dir gone
 			}
+		} else {
+			// Entries without worktrees are runtime-only peer awareness data
+			// from a previous process. Skip them — they become stale on restart.
+			continue
 		}
 		r.bySess[e.SessionKey] = e
 		r.byRepo[e.RepoPath] = append(r.byRepo[e.RepoPath], e)

--- a/tools/worktree_registry.go
+++ b/tools/worktree_registry.go
@@ -197,8 +197,9 @@ func (r *WorktreeRegistry) GetCWD(sessionKey string) string {
 }
 
 // RegisterPeer registers a session for peer awareness without creating a worktree.
-// Used when auto_worktree is disabled. Sessions are registered as "shared"
-// to indicate they share the main workspace and agents must coordinate.
+// Used when auto_worktree is disabled. The first session in a repo is registered
+// as "primary"; subsequent sessions are registered as "peer" (sharing the main
+// workspace, no file isolation).
 func (r *WorktreeRegistry) RegisterPeer(sessionKey, workDir string) {
 	if r.GetBySession(sessionKey) != nil {
 		return // already registered
@@ -213,9 +214,18 @@ func (r *WorktreeRegistry) RegisterPeer(sessionKey, workDir string) {
 	if _, exists := r.bySess[sessionKey]; exists {
 		return
 	}
+	// Determine role: first session → primary, others → peer.
+	// Must check inline (not via GetPrimary) because we already hold mu.Lock.
+	role := "primary"
+	for _, e := range r.byRepo[repoPath] {
+		if e.Role == "primary" {
+			role = "peer"
+			break
+		}
+	}
 	entry := &WorktreeEntry{
 		SessionKey:  sessionKey,
-		Role:        "shared",
+		Role:        role,
 		RepoPath:    repoPath,
 		WorktreeDir: "",
 		Branch:      "",

--- a/tools/worktree_registry.go
+++ b/tools/worktree_registry.go
@@ -329,6 +329,35 @@ func (r *WorktreeRegistry) saveRepoLocked(repoPath string) {
 
 // --- Worktree helper functions ---
 
+// gitEnvBlocklist contains GIT_* variables that must be stripped from
+// subprocess environments so that git commands operate on the intended
+// directory instead of the parent repo (e.g. during pre-commit hooks).
+var gitEnvBlocklist = []string{
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+}
+
+// cleanGitEnv returns os.Environ() with git plumbing variables removed.
+func cleanGitEnv() []string {
+	var env []string
+	for _, e := range os.Environ() {
+		strip := false
+		for _, prefix := range gitEnvBlocklist {
+			if strings.HasPrefix(e, prefix+"=") {
+				strip = true
+				break
+			}
+		}
+		if !strip {
+			env = append(env, e)
+		}
+	}
+	return env
+}
+
 // GitRepoRoot returns the absolute root of the git repo containing dir.
 // Works correctly in both regular repos and git worktrees (uses git-common-dir).
 func GitRepoRoot(dir string) (string, error) {
@@ -348,6 +377,7 @@ func GitRepoRoot(dir string) (string, error) {
 
 	// Regular directory: use git rev-parse
 	cmd := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel")
+	cmd.Env = cleanGitEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("not a git repository: %w", err)

--- a/tools/worktree_registry_test.go
+++ b/tools/worktree_registry_test.go
@@ -122,33 +122,30 @@ func TestRegisterPeer_DifferentRepos(t *testing.T) {
 	assert.Equal(t, "primary", e2.Role, "first session in repo2 should be primary")
 }
 
-func TestRegisterPeer_PersistenceAndReload(t *testing.T) {
+func TestRegisterPeer_NotPersistedToDisk(t *testing.T) {
 	repoPath := newTestGitRepo(t)
 	reg := newTestRegistry()
 
 	reg.RegisterPeer("cli:repo:session-1", repoPath)
 	reg.RegisterPeer("cli:repo:session-2", repoPath)
 
-	// Verify persistence file was created
+	// RegisterPeer entries are runtime-only — no persistence file should be created.
 	persistPath := registryPath(repoPath)
-	data, err := os.ReadFile(persistPath)
-	require.NoError(t, err, "registry should be persisted to disk")
-	t.Logf("persisted: %s", data)
+	_, err := os.ReadFile(persistPath)
+	assert.True(t, os.IsNotExist(err), "RegisterPeer entries should NOT be persisted to disk")
 
-	// Load into a fresh registry
+	// A fresh registry should NOT see the old entries via loadRepoLocked.
 	reg2 := newTestRegistry()
-	reg2.RegisterPeer("cli:repo:session-3", repoPath) // triggers loadRepoLocked
+	reg2.RegisterPeer("cli:repo:session-3", repoPath) // triggers loadRepoLocked internally
 
-	// All 3 sessions should be visible
-	e1 := reg2.GetBySession("cli:repo:session-1")
-	e2 := reg2.GetBySession("cli:repo:session-2")
+	// Old entries from reg1 are NOT visible — they were runtime-only.
+	assert.Nil(t, reg2.GetBySession("cli:repo:session-1"), "old runtime entries should not survive reload")
+	assert.Nil(t, reg2.GetBySession("cli:repo:session-2"), "old runtime entries should not survive reload")
+
+	// New entry IS visible (in memory).
 	e3 := reg2.GetBySession("cli:repo:session-3")
-	require.NotNil(t, e1)
-	require.NotNil(t, e2)
 	require.NotNil(t, e3)
-	assert.Equal(t, "primary", e1.Role)
-	assert.Equal(t, "peer", e2.Role)
-	assert.Equal(t, "peer", e3.Role, "third session after reload should also be peer")
+	assert.Equal(t, "primary", e3.Role, "fresh registry should assign primary to first session")
 }
 
 func TestRegisterPeer_GetPrimary(t *testing.T) {

--- a/tools/worktree_registry_test.go
+++ b/tools/worktree_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,8 @@ import (
 )
 
 // newTestGitRepo creates a temporary git repo and returns its path.
+// The returned path is normalized via git rev-parse to ensure consistent
+// formatting across platforms (e.g. Windows 8.3 short paths vs full paths).
 func newTestGitRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -28,7 +31,13 @@ func newTestGitRepo(t *testing.T) string {
 	// Remove hooks so pre-commit doesn't run in temp repos.
 	_ = os.RemoveAll(filepath.Join(dir, ".git", "hooks"))
 	run("git", "commit", "--allow-empty", "-m", "init")
-	return dir
+
+	// Normalize via git rev-parse so the returned path matches what
+	// GitRepoRoot() returns inside RegisterPeer (avoids Windows 8.3 vs
+	// full path mismatch).
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output()
+	require.NoError(t, err)
+	return strings.TrimSpace(string(out))
 }
 
 // newTestRegistry creates a fresh WorktreeRegistry for testing.

--- a/tools/worktree_registry_test.go
+++ b/tools/worktree_registry_test.go
@@ -1,0 +1,173 @@
+package tools
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestGitRepo creates a temporary git repo and returns its path.
+func newTestGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(name string, args ...string) {
+		cmd := exec.Command(name, args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s %v: %s", name, args, out)
+	}
+	run("git", "init")
+	// Remove hooks so pre-commit doesn't run in temp repos.
+	_ = os.RemoveAll(filepath.Join(dir, ".git", "hooks"))
+	run("git", "commit", "--allow-empty", "-m", "init")
+	return dir
+}
+
+// newTestRegistry creates a fresh WorktreeRegistry for testing.
+func newTestRegistry() *WorktreeRegistry {
+	return &WorktreeRegistry{
+		bySess: make(map[string]*WorktreeEntry),
+		byRepo: make(map[string][]*WorktreeEntry),
+	}
+}
+
+func TestRegisterPeer_FirstSessionBecomesPrimary(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	reg.RegisterPeer("cli:repo:session-1", repoPath)
+
+	entry := reg.GetBySession("cli:repo:session-1")
+	require.NotNil(t, entry)
+	assert.Equal(t, "primary", entry.Role, "first session in repo should be primary")
+	assert.Equal(t, repoPath, entry.RepoPath)
+	assert.Equal(t, "", entry.WorktreeDir, "no worktree dir for RegisterPeer mode")
+	assert.Equal(t, "", entry.Branch, "no branch for RegisterPeer mode")
+}
+
+func TestRegisterPeer_SecondSessionBecomesPeer(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	reg.RegisterPeer("cli:repo:session-1", repoPath)
+	reg.RegisterPeer("cli:repo:session-2", repoPath)
+
+	e1 := reg.GetBySession("cli:repo:session-1")
+	e2 := reg.GetBySession("cli:repo:session-2")
+	require.NotNil(t, e1)
+	require.NotNil(t, e2)
+	assert.Equal(t, "primary", e1.Role, "first session should be primary")
+	assert.Equal(t, "peer", e2.Role, "second session should be peer")
+}
+
+func TestRegisterPeer_ManySessions(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	for i := 0; i < 5; i++ {
+		key := "cli:repo:session-" + string(rune('0'+i))
+		reg.RegisterPeer(key, repoPath)
+	}
+
+	entries := reg.ListRepo(repoPath)
+	require.Len(t, entries, 5)
+	assert.Equal(t, "primary", entries[0].Role)
+	for _, e := range entries[1:] {
+		assert.Equal(t, "peer", e.Role, "all sessions after first should be peer")
+	}
+}
+
+func TestRegisterPeer_Idempotent(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	reg.RegisterPeer("cli:repo:session-1", repoPath)
+	reg.RegisterPeer("cli:repo:session-1", repoPath) // duplicate
+
+	entries := reg.ListRepo(repoPath)
+	assert.Len(t, entries, 1, "duplicate RegisterPeer should be a no-op")
+}
+
+func TestRegisterPeer_NotGitRepo(t *testing.T) {
+	reg := newTestRegistry()
+	dir := t.TempDir() // not a git repo
+
+	reg.RegisterPeer("cli:repo:session-1", dir)
+
+	entry := reg.GetBySession("cli:repo:session-1")
+	assert.Nil(t, entry, "non-git dir should not register")
+}
+
+func TestRegisterPeer_DifferentRepos(t *testing.T) {
+	repo1 := newTestGitRepo(t)
+	repo2 := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	reg.RegisterPeer("cli:repo1:session-1", repo1)
+	reg.RegisterPeer("cli:repo2:session-1", repo2)
+
+	e1 := reg.GetBySession("cli:repo1:session-1")
+	e2 := reg.GetBySession("cli:repo2:session-1")
+	require.NotNil(t, e1)
+	require.NotNil(t, e2)
+	assert.Equal(t, "primary", e1.Role, "first session in repo1 should be primary")
+	assert.Equal(t, "primary", e2.Role, "first session in repo2 should be primary")
+}
+
+func TestRegisterPeer_PersistenceAndReload(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	reg.RegisterPeer("cli:repo:session-1", repoPath)
+	reg.RegisterPeer("cli:repo:session-2", repoPath)
+
+	// Verify persistence file was created
+	persistPath := registryPath(repoPath)
+	data, err := os.ReadFile(persistPath)
+	require.NoError(t, err, "registry should be persisted to disk")
+	t.Logf("persisted: %s", data)
+
+	// Load into a fresh registry
+	reg2 := newTestRegistry()
+	reg2.RegisterPeer("cli:repo:session-3", repoPath) // triggers loadRepoLocked
+
+	// All 3 sessions should be visible
+	e1 := reg2.GetBySession("cli:repo:session-1")
+	e2 := reg2.GetBySession("cli:repo:session-2")
+	e3 := reg2.GetBySession("cli:repo:session-3")
+	require.NotNil(t, e1)
+	require.NotNil(t, e2)
+	require.NotNil(t, e3)
+	assert.Equal(t, "primary", e1.Role)
+	assert.Equal(t, "peer", e2.Role)
+	assert.Equal(t, "peer", e3.Role, "third session after reload should also be peer")
+}
+
+func TestRegisterPeer_GetPrimary(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	// No primary yet
+	assert.Nil(t, reg.GetPrimary(repoPath))
+
+	// Register first → primary
+	reg.RegisterPeer("cli:repo:session-1", repoPath)
+	primary := reg.GetPrimary(repoPath)
+	require.NotNil(t, primary)
+	assert.Equal(t, "primary", primary.Role)
+	assert.Equal(t, "cli:repo:session-1", primary.SessionKey)
+
+	// Register more → primary unchanged
+	reg.RegisterPeer("cli:repo:session-2", repoPath)
+	primary = reg.GetPrimary(repoPath)
+	require.NotNil(t, primary)
+	assert.Equal(t, "cli:repo:session-1", primary.SessionKey, "primary should remain the first session")
+}

--- a/tools/worktree_registry_test.go
+++ b/tools/worktree_registry_test.go
@@ -20,7 +20,10 @@ func newTestGitRepo(t *testing.T) string {
 	run := func(name string, args ...string) {
 		cmd := exec.Command(name, args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
+		// Use cleanGitEnv to strip GIT_DIR etc. leaked from the parent
+		// repo's pre-commit hook. Without this, the test's git commands
+		// would operate on the *host* repo instead of the temp dir.
+		cmd.Env = append(cleanGitEnv(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
 		)


### PR DESCRIPTION
## Bug

When `auto_worktree` is disabled (default), `RegisterPeer()` hardcoded `Role: "shared"` for all sessions. All 30+ sessions showed as `[shared]` with no branch and no worktree, making it impossible to distinguish the first session from subsequent ones.

## Fix

`RegisterPeer` now mirrors the logic in `AutoDetectAndInit`:
- **First session** in a repo → `Role: "primary"`
- **Subsequent sessions** → `Role: "peer"` (no file isolation, but correct role for peer awareness)

The primary detection is done inline inside the existing `mu.Lock()` section to avoid deadlock with `GetPrimary()` which uses `RLock`.

## Files Changed

| File | Change |
|------|--------|
| `tools/worktree_registry.go` | `RegisterPeer()` — inline primary check instead of hardcoded `"shared"` |
| `tools/worktree_registry_test.go` | 8 new tests |

## Test Coverage

- First session becomes primary
- Second session becomes peer
- Many sessions, idempotency, non-git repos
- Different repos, persistence/reload, GetPrimary consistency