### PR TITLE
ci: fix nightly release — direct trigger on master push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,26 +112,3 @@ jobs:
         working-directory: web
         run: yarn build
 
-  # Trigger nightly release after CI passes on master push
-  nightly:
-    name: Nightly Release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [lint, build, test, build-windows, test-windows, frontend]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Trigger nightly release workflow
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'release.yml',
-              ref: 'master',
-              inputs: {
-                channel: 'nightly'
-              }
-            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - master           # nightly: auto on merge
     tags:
       - 'v*'             # stable: v1.2.3  /  beta: v1.2.3-beta.1
   workflow_dispatch:
@@ -31,7 +33,14 @@ jobs:
     steps:
       - id: meta
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "branch" ]]; then
+            # push to master → nightly
+            DATE=$(date -u +%Y%m%d)
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+            echo "version=nightly-${DATE}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+            echo "channel=nightly" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            # push tag → stable or beta
             TAG="${{ github.ref_name }}"
             echo "version=${TAG}" >> "$GITHUB_OUTPUT"
             if [[ "$TAG" == *"-"* ]]; then
@@ -40,6 +49,7 @@ jobs:
               echo "channel=stable" >> "$GITHUB_OUTPUT"
             fi
           else
+            # workflow_dispatch → manual nightly or beta
             CH="${{ github.event.inputs.channel }}"
             DATE=$(date -u +%Y%m%d)
             if [[ "$CH" == "nightly" ]]; then


### PR DESCRIPTION
## Problem

Nightly release workflow failed with `403 Resource not accessible by integration` ([failed run](https://github.com/ai-pivot/xbot/actions/runs/25954084168/job/76297756438)).

Root cause: ci.yml `nightly` job used `GITHUB_TOKEN` to call `workflow_dispatch` on release.yml, but GitHub blocks `GITHUB_TOKEN` from triggering other workflows.

## Fix

- **ci.yml**: Remove the indirect `nightly` job (the `actions/github-script` trigger that was getting 403)
- **release.yml**: Add `push.branches: master` trigger directly, so master push starts the Release workflow without needing an intermediary

## Release channels after this PR

| Channel | Trigger | Version example | Prerelease |
|---------|---------|-----------------|------------|
| **Nightly** | Push/merge to `master` (automatic) | `nightly-20260516-d9e5abd` | ✅ |
| **Beta** | Manual `workflow_dispatch` | `beta-20260516` | ✅ |
| **Stable** | Push tag `v1.2.3` | `v1.2.3` | ❌ |

No PAT or extra secrets needed.