### PR TITLE
fix: bg subagent prematurely destroyed after natural Run() completion

### DIFF
--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -595,9 +595,14 @@ func (a *Agent) SpawnInteractiveSession(
 			}()
 
 			out := Run(runCtx, cfg)
-			runCancel()
 
+			// Check cancellation BEFORE calling runCancel().
+			// runCancel() cancels the context, making runCtx.Err() always non-nil.
+			// We need to know if Run() was cancelled externally (parent unload,
+			// agent shutdown) vs completed naturally — only externally cancelled
+			// sessions should be destroyed.
 			cancelled := runCtx.Err() != nil
+			runCancel()
 
 			// Notify parent agent about completion
 			if notifyMgr != nil {

--- a/agent/interactive_bg_test.go
+++ b/agent/interactive_bg_test.go
@@ -1,0 +1,152 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestBgSession_NaturalCompletion_SessionPreserved verifies that a background
+// interactive session is NOT destroyed when Run() completes naturally (i.e. the
+// context was not cancelled externally). This is a regression test for the bug
+// where runCancel() was called BEFORE checking cancelled, causing all bg
+// sessions to be incorrectly destroyed on natural completion.
+func TestBgSession_NaturalCompletion_SessionPreserved(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a := &Agent{
+		agentCtx:             ctx,
+		interactiveSubAgents: sync.Map{},
+	}
+
+	key := "cli:test/bg-agent:test-inst"
+	placeholder := &interactiveAgent{
+		roleName:   "bg-agent",
+		instance:   "test-inst",
+		lastUsed:   time.Now(),
+		background: true,
+		running:    true,
+	}
+	a.interactiveSubAgents.Store(key, placeholder)
+
+	// Simulate the bg goroutine logic — the exact pattern from SpawnInteractiveSession:
+	// Run() returns, then we check cancelled BEFORE calling runCancel().
+	bgBase := a.agentCtx
+	runCtx, runCancel := context.WithCancel(bgBase)
+
+	// Simulate Run() completing naturally (no external cancellation).
+	// The key fix: check cancelled BEFORE calling runCancel().
+	cancelled := runCtx.Err() != nil
+	runCancel()
+
+	if cancelled {
+		// Bug path: session would be destroyed here
+		a.interactiveSubAgents.Delete(key)
+		t.Fatal("cancelled should be false for natural completion, but got true — session would be incorrectly destroyed")
+	}
+
+	// Natural completion: session should still exist
+	val, ok := a.interactiveSubAgents.Load(key)
+	if !ok {
+		t.Fatal("bg session was removed from map after natural completion — should be preserved for future send/unload")
+	}
+	ia, ok := val.(*interactiveAgent)
+	if !ok {
+		t.Fatal("loaded value is not *interactiveAgent")
+	}
+	if ia.roleName != "bg-agent" {
+		t.Errorf("roleName = %q, want %q", ia.roleName, "bg-agent")
+	}
+}
+
+// TestBgSession_ExternalCancel_SessionDestroyed verifies that a background
+// interactive session IS destroyed when the parent context is cancelled
+// (e.g. agent shutdown or parent unload).
+func TestBgSession_ExternalCancel_SessionDestroyed(t *testing.T) {
+	parentCtx, parentCancel := context.WithCancel(context.Background())
+	a := &Agent{
+		agentCtx:             parentCtx,
+		interactiveSubAgents: sync.Map{},
+	}
+
+	key := "cli:test/bg-agent:cancel-inst"
+	placeholder := &interactiveAgent{
+		roleName:   "bg-agent",
+		instance:   "cancel-inst",
+		lastUsed:   time.Now(),
+		background: true,
+		running:    true,
+	}
+	a.interactiveSubAgents.Store(key, placeholder)
+
+	// Simulate bg goroutine: derive context from agent lifecycle
+	bgBase := a.agentCtx
+	runCtx, runCancel := context.WithCancel(bgBase)
+
+	// Simulate external cancellation (e.g. agent shutdown)
+	parentCancel()
+
+	// Wait for cancellation to propagate
+	time.Sleep(10 * time.Millisecond)
+
+	// Check cancelled BEFORE runCancel — should be true now
+	cancelled := runCtx.Err() != nil
+	runCancel()
+
+	if !cancelled {
+		t.Fatal("cancelled should be true after external context cancellation")
+	}
+
+	// Cancelled path: session should be destroyed
+	if _, ok := a.interactiveSubAgents.Load(key); !ok {
+		// Already removed, which is correct
+		return
+	}
+	// If still present, simulate the destroy path
+	a.interactiveSubAgents.Delete(key)
+
+	_, ok := a.interactiveSubAgents.Load(key)
+	if ok {
+		t.Fatal("session should be removed after external cancellation + destroy")
+	}
+}
+
+// TestBgSession_CancelOrderRegression is a focused regression test.
+// Before the fix, the code was:
+//
+//	out := Run(runCtx, cfg)
+//	runCancel()                    // ← cancels the context
+//	cancelled := runCtx.Err() != nil  // ← always true after runCancel!
+//
+// This meant ALL bg sessions were treated as cancelled and destroyed,
+// even on natural completion. After the fix:
+//
+//	cancelled := runCtx.Err() != nil  // ← check BEFORE cancel
+//	runCancel()                    // ← now safe to clean up
+func TestBgSession_CancelOrderRegression(t *testing.T) {
+	// Demonstrate the bug pattern with plain context operations
+	ctx := context.Background()
+
+	// --- BEFORE fix pattern ---
+	runCtx, runCancel := context.WithCancel(ctx)
+	// Simulate: Run() completes normally, context is NOT cancelled
+	_ = runCtx  // Run(runCtx, cfg) would use this
+	runCancel() // cleanup
+	cancelledBefore := runCtx.Err() != nil
+
+	// --- AFTER fix pattern ---
+	runCtx2, runCancel2 := context.WithCancel(ctx)
+	cancelledAfter := runCtx2.Err() != nil // check BEFORE cancel
+	runCancel2()                           // cleanup
+
+	if !cancelledBefore {
+		t.Log("Note: cancelledBefore is false — this means the old code might actually work in some cases, " +
+			"but the bug manifests when Run() itself calls runCtx.Done() or when there's a race")
+	}
+
+	if cancelledAfter {
+		t.Error("cancelledAfter should be false for natural completion (context not cancelled)")
+	}
+}


### PR DESCRIPTION
## Bug

后台 subagent（`background=true`）在 `Run()` 自然完成后立即从 session map 中被删除，导致主 agent 后续 `inspect`/`send` 找不到该 subagent。

## 根因

`agent/interactive.go` 中 bg goroutine 的代码顺序有误：

```go
// ❌ 修复前
out := Run(runCtx, cfg)
runCancel()                    // ← 先取消 context
cancelled := runCtx.Err() != nil  // ← 永远为 true（因为刚取消了）
```

`runCancel()` 取消 context 后，`runCtx.Err()` 始终返回非 nil，导致 `cancelled` 永远为 `true`。即使 Run 自然完成也会进入 cancelled 分支 → `destroyInteractiveSession()` → session 被删除。

## 修复

调换 `cancelled` 检查和 `runCancel()` 的顺序：

```go
// ✅ 修复后
cancelled := runCtx.Err() != nil  // ← 先检查是否被外部取消
runCancel()                       // ← 再清理 context 资源
```

`runCancel()` 只取消 bg goroutine 的局部 `runCtx`，用于释放 context 资源。后续 `send` 使用全新 context，不依赖这个 `runCtx`。

## 影响范围

仅影响 `background=true` 的 interactive subagent。Foreground subagent 走不同的代码路径，不受影响。

## 测试

- 新增 3 个回归测试：自然完成保留 session、外部取消销毁 session、顺序验证
- 全量 `go test ./...` 通过