### PR TITLE
fix: hardWrapRunes ANSI replay order causes streaming character loss

### DIFF
--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -196,6 +196,15 @@ func hardWrapRunes(line string, maxW int) string {
 	var ansiState strings.Builder // accumulated SGR sequences since last reset
 	haveAnsiState := false
 
+	// Snapshot of ansiState at the lastBreakable position.
+	// When breaking at lastBreakable, rest already contains escape sequences
+	// that came after the break point. If we blindly replay the CURRENT
+	// ansiState (which accumulated more escapes since lastBreakable),
+	// we inject escape sequences into the middle of rest's text,
+	// corrupting the terminal output and causing visible "character loss".
+	var breakAnsiState string
+	breakHaveAnsi := false
+
 	for _, r := range line {
 		if r == '\x1b' {
 			inEscape = true
@@ -229,6 +238,14 @@ func hardWrapRunes(line string, maxW int) string {
 		// Mark breakable positions: after space or after CJK character
 		if r == ' ' || isCJK(r) {
 			lastBreakable = buf.Len() + utf8.RuneLen(r)
+			// Snapshot ANSI state at this breakable position so we can
+			// replay the correct state on the continuation line.
+			if haveAnsiState {
+				breakAnsiState = ansiState.String()
+			} else {
+				breakAnsiState = ""
+			}
+			breakHaveAnsi = haveAnsiState
 		}
 
 		if w+rw > maxW {
@@ -238,8 +255,15 @@ func hardWrapRunes(line string, maxW int) string {
 				rest := buf.String()[lastBreakable:]
 				lines = append(lines, keep)
 				buf.Reset()
+				// Replay ANSI state BEFORE rest so the continuation line
+				// inherits the correct color/style. Without this, the replay
+				// ends up AFTER rest's text, corrupting the terminal output
+				// (ANSI escape injected mid-word causes visible "character loss").
+				if breakHaveAnsi {
+					buf.WriteString(breakAnsiState)
+				}
 				buf.WriteString(rest)
-				w = lipgloss.Width(rest)
+				w = lipgloss.Width(buf.String())
 				lastBreakable = -1
 			} else {
 				// No breakable position found, hard break here
@@ -247,10 +271,12 @@ func hardWrapRunes(line string, maxW int) string {
 				buf.Reset()
 				w = 0
 				lastBreakable = -1
-			}
-			// Replay active ANSI state on continuation line
-			if haveAnsiState {
-				buf.WriteString(ansiState.String())
+				// For hard breaks, the current ansiState is correct —
+				// no escape sequences were accumulated between buf.String()
+				// and this point (the current rune hasn't been written yet).
+				if haveAnsiState {
+					buf.WriteString(ansiState.String())
+				}
 			}
 		}
 		buf.WriteRune(r)

--- a/channel/cli_types_test.go
+++ b/channel/cli_types_test.go
@@ -268,3 +268,103 @@ func TestHardWrapRunes_AnsiResetClearsState(t *testing.T) {
 		t.Errorf("continuation replayed color after reset: %q", lines[1])
 	}
 }
+
+// TestHardWrapRunes_AnsiColorBreakOrder verifies that ANSI state is replayed
+// BEFORE the rest text on continuation lines, not after. This was the root
+// cause of "character loss" during TUI streaming: the escape sequence was
+// injected mid-word, corrupting the terminal output.
+//
+// Before fix: line 1 = "W\x1b[36morld..." (escape after 'W', before 'orld')
+// After fix:  line 1 = "\x1b[36mWorld..." (escape before the text)
+func TestHardWrapRunes_AnsiColorBreakOrder(t *testing.T) {
+	// "Hello" (plain) + "\x1b[36m" (cyan) + " World" (cyan) + "\x1b[0m" (reset) + "ABCDEFGHIJKLMNO"
+	input := "Hello\x1b[36m World\x1b[0mABCDEFGHIJKLMNO"
+	got := hardWrapRunes(input, 7)
+	lines := strings.Split(got, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected >= 3 lines, got %d: %q", len(lines), got)
+	}
+
+	// Verify: no line should have an ANSI escape in the MIDDLE of a word.
+	// Each line should either start with an escape or have plain text.
+	for i, line := range lines {
+		plain := ansi.Strip(line)
+		// Check that the line is not empty
+		if plain == "" {
+			t.Errorf("line %d is empty: %q", i, line)
+		}
+		// Check that the plain text is a substring of the original plain text
+		orig := ansi.Strip(input)
+		if !strings.Contains(orig, plain) && len(plain) > 0 {
+			t.Errorf("line %d: plain %q not found in original %q", i, plain, orig)
+		}
+	}
+
+	// Verify: total plain text reconstruction equals original
+	var recon []string
+	for _, line := range lines {
+		recon = append(recon, ansi.Strip(line))
+	}
+	orig := ansi.Strip(input)
+	reconstructed := strings.Join(recon, "")
+	if orig != reconstructed {
+		t.Errorf("character loss: got %q, want %q", reconstructed, orig)
+	}
+}
+
+// TestHardWrapRunes_AnsiBreakBeforeRest verifies the fix for the streaming
+// character loss bug: when breaking at a breakable position inside styled text,
+// the continuation line must replay the ANSI state BEFORE rest text.
+func TestHardWrapRunes_AnsiBreakBeforeRest(t *testing.T) {
+	// Styled text with a space as break point, followed by more styled text.
+	// The break should produce lines where the ANSI replay is at the START
+	// of the continuation line, not injected into the middle of text.
+	input := "\x1b[36mABCDEF\x1b[0m GHIJKLMNOP"
+	got := hardWrapRunes(input, 6)
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected >= 2 lines, got %d", len(lines))
+	}
+
+	// Line 0 should end the cyan region cleanly
+	line0 := lines[0]
+	if !strings.HasSuffix(line0, "\x1b[0m") && !strings.Contains(line0, "\x1b[0m ") {
+		// Line 0 has the reset, which is fine
+	}
+
+	// Line 1 should NOT have an escape injected between characters of a word.
+	// Before the fix, line 1 could be "G\x1b[0mHIJKL" with escape between G and H.
+	line1 := lines[1]
+	plain1 := ansi.Strip(line1)
+	// The plain text should be a contiguous substring of the original
+	orig := ansi.Strip(input)
+	if !strings.Contains(orig, plain1) {
+		t.Errorf("line 1 plain %q not found in original %q\nfull line: %q", plain1, orig, line1)
+	}
+}
+
+// TestHardWrapRunes_MultipleColorsNoLoss verifies that wrapping text with
+// multiple color changes doesn't lose any characters.
+func TestHardWrapRunes_MultipleColorsNoLoss(t *testing.T) {
+	input := "This is a \x1b[36mcode\x1b[0m block with \x1b[33mmore\x1b[0m text here"
+	for _, maxW := range []int{10, 15, 20, 25} {
+		got := hardWrapRunes(input, maxW)
+		lines := strings.Split(got, "\n")
+		var recon []string
+		for _, l := range lines {
+			recon = append(recon, ansi.Strip(l))
+		}
+		reconstructed := strings.Join(recon, "")
+		orig := ansi.Strip(input)
+		if orig != reconstructed {
+			t.Errorf("maxW=%d: character loss. got %q, want %q", maxW, reconstructed, orig)
+		}
+		// Width constraint
+		for i, l := range lines {
+			w := ansi.StringWidth(l)
+			if w > maxW {
+				t.Errorf("maxW=%d line %d: width %d exceeds maxW: %q", maxW, i, w, l)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Two bugs in hardWrapRunes caused probabilistic character loss during TUI streaming:

1. ANSI state was replayed AFTER rest text instead of BEFORE it. When breaking at lastBreakable, the code wrote rest to buf first, then replayed ansiState. This injected the escape sequence into the MIDDLE of the continuation line's text (e.g., 'W\x1b[36morld' instead of '\x1b[36mWorld'). The terminal misinterpreted text characters as escape parameters, making them invisible.

2. The replay used the CURRENT ansiState (accumulated through the entire buffer) instead of a snapshot from the break position. After the break point, more escape sequences may have been read, making the replay state incorrect for the continuation line.

Fix:
- Record breakAnsiState snapshot at each breakable position
- Replay the snapshot BEFORE rest text in the continuation buffer
- For hard breaks, current ansiState remains correct (no intervening escape sequences between buf content and break point)

Tests added:
- TestHardWrapRunes_AnsiColorBreakOrder: verifies escape appears before text, not mid-word
- TestHardWrapRunes_AnsiBreakBeforeRest: verifies continuation plain text is contiguous in original
- TestHardWrapRunes_MultipleColorsNoLoss: verifies zero character loss across multiple color changes at various widths