### PR TITLE
fix: cleanup worktree/peer registration when session is deleted or closed

### DIFF
--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 	"xbot/protocol"
+	"xbot/tools"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -1803,6 +1804,9 @@ func (m *cliModel) handleSessionControlMsg(sc cliSessionControlMsg) tea.Cmd {
 						return nil
 					}
 				}
+				// Clean up worktree / peer registration for closed session.
+				sessionKey := "cli:" + entry.ID
+				tools.GlobalWorktreeRegistry.CleanupSession(sessionKey)
 				sc.result <- &cliSessionResult{ok: true}
 				return nil
 			}

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -14,6 +14,7 @@ import (
 	"xbot/internal/textarea"
 	"xbot/llm"
 	log "xbot/logger"
+	"xbot/tools"
 )
 
 // --- §12 Interactive Panel ---
@@ -3530,6 +3531,9 @@ func (m *cliModel) deleteLocalSession(entry SessionPanelEntry) tea.Cmd {
 			log.WithError(err).WithField("chatID", entry.ID).Warn("Local session remove failed")
 		}
 	}
+	// 3. Clean up worktree / peer registration for this session.
+	sessionKey := "cli:" + entry.ID
+	tools.GlobalWorktreeRegistry.CleanupSession(sessionKey)
 	// If we deleted the active session, switch to default
 	if entry.Active {
 		m.saveCurrentSession()

--- a/internal/uninstall/uninstall.go
+++ b/internal/uninstall/uninstall.go
@@ -1,0 +1,167 @@
+package uninstall
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Run executes the uninstall subcommand.
+func Run(args []string) error {
+	purge := false
+	skipConfirm := false
+
+	for _, arg := range args {
+		switch arg {
+		case "--purge":
+			purge = true
+		case "-y", "--yes":
+			skipConfirm = true
+		case "--help", "-h":
+			printUsage()
+			return nil
+		}
+	}
+
+	fmt.Println("xbot uninstaller")
+	fmt.Println("================")
+	fmt.Println()
+
+	// Show what will be removed
+	steps := []string{"Stop xbot-server service (if running)"}
+	steps = append(steps, platformServiceLabel())
+	steps = append(steps, "Remove xbot-cli binary")
+	steps = append(steps, "Clean PATH entries")
+	if purge {
+		steps = append(steps, "Remove ~/.xbot/ directory (config, data, logs)")
+	} else {
+		steps = append(steps, "Keep ~/.xbot/ directory (use --purge to remove)")
+	}
+
+	fmt.Println("The following steps will be performed:")
+	for i, s := range steps {
+		fmt.Printf("  %d. %s\n", i+1, s)
+	}
+	fmt.Println()
+
+	if !skipConfirm {
+		fmt.Print("Continue? [y/N] ")
+		reader := bufio.NewReader(os.Stdin)
+		resp, _ := reader.ReadString('\n')
+		resp = strings.TrimSpace(strings.ToLower(resp))
+		if resp != "y" && resp != "yes" {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	// Step 1: Stop the running service/process
+	fmt.Println("\n[1] Stopping xbot-server...")
+	if err := stopService(); err != nil {
+		fmt.Printf("  Warning: %v\n", err)
+	}
+
+	// Step 2: Remove service registration
+	fmt.Println("[2] Removing service registration...")
+	if err := removeService(); err != nil {
+		fmt.Printf("  Warning: %v\n", err)
+	}
+
+	// Step 3: Remove binary
+	fmt.Println("[3] Removing binary...")
+	if err := removeBinary(); err != nil {
+		fmt.Printf("  Warning: %v\n", err)
+	}
+
+	// Step 4: Clean PATH
+	fmt.Println("[4] Cleaning PATH...")
+	if err := cleanPATH(); err != nil {
+		fmt.Printf("  Warning: %v\n", err)
+	}
+
+	// Step 5 (optional): Remove ~/.xbot/
+	if purge {
+		fmt.Println("[5] Removing ~/.xbot/...")
+		if err := removeDataDir(); err != nil {
+			fmt.Printf("  Warning: %v\n", err)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("✓ Uninstall complete.")
+	if !purge {
+		home, _ := os.UserHomeDir()
+		fmt.Printf("  ~/.xbot/ directory preserved. Remove manually if not needed:\n")
+		fmt.Printf("    rm -rf %s\n", filepath.Join(home, ".xbot"))
+	}
+	return nil
+}
+
+func printUsage() {
+	fmt.Println("Usage: xbot-cli uninstall [options]")
+	fmt.Println()
+	fmt.Println("Uninstall xbot from this system.")
+	fmt.Println()
+	fmt.Println("Options:")
+	fmt.Println("  --purge    Also remove ~/.xbot/ (config, database, logs)")
+	fmt.Println("  -y, --yes  Skip confirmation prompt")
+	fmt.Println("  --help     Show this help")
+}
+
+// removeDataDir removes the ~/.xbot/ directory.
+func removeDataDir() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	xbotDir := filepath.Join(home, ".xbot")
+	if _, err := os.Stat(xbotDir); os.IsNotExist(err) {
+		fmt.Println("  ~/.xbot/ does not exist, skipping.")
+		return nil
+	}
+	if err := os.RemoveAll(xbotDir); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", xbotDir, err)
+	}
+	fmt.Printf("  Removed %s\n", xbotDir)
+	return nil
+}
+
+// getBinaryPath returns the expected binary path.
+func getBinaryPath() string {
+	home, _ := os.UserHomeDir()
+	if runtime.GOOS == "windows" {
+		return filepath.Join(home, ".local", "bin", "xbot-cli.exe")
+	}
+	return filepath.Join(home, ".local", "bin", "xbot-cli")
+}
+
+// removeBinary removes the xbot-cli binary.
+func removeBinary() error {
+	binPath := getBinaryPath()
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		fmt.Println("  Binary not found, skipping.")
+		return nil
+	}
+	if err := os.Remove(binPath); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", binPath, err)
+	}
+	fmt.Printf("  Removed %s\n", binPath)
+
+	// Try to remove .local/bin if empty
+	home, _ := os.UserHomeDir()
+	localBin := filepath.Join(home, ".local", "bin")
+	if entries, err := os.ReadDir(localBin); err == nil && len(entries) == 0 {
+		os.Remove(localBin)
+		fmt.Printf("  Removed empty directory %s\n", localBin)
+		// Try .local if also empty
+		localDir := filepath.Join(home, ".local")
+		if entries, err := os.ReadDir(localDir); err == nil && len(entries) == 0 {
+			os.Remove(localDir)
+			fmt.Printf("  Removed empty directory %s\n", localDir)
+		}
+	}
+	return nil
+}

--- a/internal/uninstall/uninstall_unix.go
+++ b/internal/uninstall/uninstall_unix.go
@@ -1,0 +1,179 @@
+//go:build !windows
+
+package uninstall
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func platformServiceLabel() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "Remove launchd LaunchAgent plist"
+	case "linux":
+		return "Remove systemd user unit"
+	default:
+		return "Remove service registration"
+	}
+}
+
+func stopService() error {
+	switch runtime.GOOS {
+	case "linux":
+		return stopSystemd()
+	case "darwin":
+		return stopLaunchd()
+	default:
+		return killProcess()
+	}
+}
+
+func stopSystemd() error {
+	cmd := exec.Command("systemctl", "--user", "stop", "xbot-server")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		// Service might not exist, try killing the process
+		return killProcess()
+	}
+	fmt.Println("  Stopped systemd xbot-server service.")
+	return nil
+}
+
+func stopLaunchd() error {
+	home, _ := os.UserHomeDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.xbot.server.plist")
+	if _, err := os.Stat(plistPath); os.IsNotExist(err) {
+		return killProcess()
+	}
+	cmd := exec.Command("launchctl", "unload", "-w", plistPath)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("launchctl unload failed: %w", err)
+	}
+	fmt.Println("  Unloaded launchd service.")
+	return nil
+}
+
+func killProcess() error {
+	// Try pkill xbot-cli
+	cmd := exec.Command("pkill", "-f", "xbot-cli")
+	_ = cmd.Run() // Ignore error if no process found
+	fmt.Println("  Attempted to stop xbot-cli processes.")
+	return nil
+}
+
+func removeService() error {
+	switch runtime.GOOS {
+	case "linux":
+		return removeSystemdUnit()
+	case "darwin":
+		return removeLaunchdPlist()
+	default:
+		return nil
+	}
+}
+
+func removeSystemdUnit() error {
+	home, _ := os.UserHomeDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "xbot-server.service")
+	if _, err := os.Stat(unitPath); os.IsNotExist(err) {
+		fmt.Println("  systemd unit not found, skipping.")
+		return nil
+	}
+
+	// Disable first
+	_ = exec.Command("systemctl", "--user", "disable", "xbot-server").Run()
+
+	if err := os.Remove(unitPath); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", unitPath, err)
+	}
+	fmt.Printf("  Removed %s\n", unitPath)
+
+	// Reload systemd
+	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
+	fmt.Println("  Reloaded systemd daemon.")
+	return nil
+}
+
+func removeLaunchdPlist() error {
+	home, _ := os.UserHomeDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.xbot.server.plist")
+	if _, err := os.Stat(plistPath); os.IsNotExist(err) {
+		fmt.Println("  launchd plist not found, skipping.")
+		return nil
+	}
+	if err := os.Remove(plistPath); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", plistPath, err)
+	}
+	fmt.Printf("  Removed %s\n", plistPath)
+	return nil
+}
+
+func cleanPATH() error {
+	home, _ := os.UserHomeDir()
+	localBin := filepath.Join(home, ".local", "bin")
+
+	// Determine shell config file
+	shell := os.Getenv("SHELL")
+	var profiles []string
+	if strings.Contains(shell, "zsh") {
+		profiles = []string{filepath.Join(home, ".zshrc")}
+	} else {
+		profiles = []string{filepath.Join(home, ".bashrc"), filepath.Join(home, ".bash_profile")}
+	}
+
+	cleaned := false
+	for _, profile := range profiles {
+		if _, err := os.Stat(profile); os.IsNotExist(err) {
+			continue
+		}
+		if err := removePathEntry(profile, localBin); err != nil {
+			fmt.Printf("  Warning: failed to clean %s: %v\n", profile, err)
+			continue
+		}
+		cleaned = true
+	}
+	if !cleaned {
+		fmt.Println("  No PATH entries to clean.")
+	}
+	return nil
+}
+
+// removePathEntry removes lines containing the given path from a shell config file.
+func removePathEntry(profilePath, targetPath string) error {
+	data, err := os.ReadFile(profilePath)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var kept []string
+	changed := false
+
+	for _, line := range lines {
+		if strings.Contains(line, targetPath) && (strings.Contains(line, "export") || strings.Contains(line, "PATH")) {
+			changed = true
+			continue
+		}
+		kept = append(kept, line)
+	}
+
+	if !changed {
+		return nil
+	}
+
+	// Write back
+	result := strings.Join(kept, "\n")
+	// Avoid trailing newlines growing
+	result = strings.TrimRight(result, "\n") + "\n"
+	if err := os.WriteFile(profilePath, []byte(result), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("  Cleaned PATH entry from %s\n", filepath.Base(profilePath))
+	return nil
+}

--- a/internal/uninstall/uninstall_windows.go
+++ b/internal/uninstall/uninstall_windows.go
@@ -1,0 +1,121 @@
+//go:build windows
+
+package uninstall
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func platformServiceLabel() string {
+	return "Remove startup shortcut / scheduled task / nssm service"
+}
+
+func stopService() error {
+	// Try to stop the process
+	cmd := exec.Command("taskkill", "/F", "/IM", "xbot-cli.exe")
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+
+	// Also try nssm service if present
+	home, _ := os.UserHomeDir()
+	nssmPath := filepath.Join(home, ".local", "bin", "nssm.exe")
+	if _, err := os.Stat(nssmPath); err == nil {
+		_ = exec.Command(nssmPath, "stop", "xbot-server").Run()
+	}
+	// Try scheduled task
+	_ = exec.Command("schtasks", "/End", "/TN", "xbot-server").Run()
+
+	fmt.Println("  Attempted to stop xbot-cli processes.")
+	return nil
+}
+
+func removeService() error {
+	home, _ := os.UserHomeDir()
+	xbotHome := filepath.Join(home, ".xbot")
+
+	// 1. Remove Startup folder shortcut
+	startupFolder := os.Getenv("APPDATA")
+	if startupFolder != "" {
+		shortcut := filepath.Join(startupFolder, "Microsoft", "Windows", "Start Menu", "Programs", "Startup", "xbot-server.lnk")
+		if _, err := os.Stat(shortcut); err == nil {
+			if err := os.Remove(shortcut); err != nil {
+				fmt.Printf("  Warning: failed to remove startup shortcut: %v\n", err)
+			} else {
+				fmt.Println("  Removed startup shortcut.")
+			}
+		}
+	}
+
+	// 2. Remove scheduled task (if exists)
+	cmd := exec.Command("schtasks", "/Query", "/TN", "xbot-server")
+	if cmd.Run() == nil {
+		_ = exec.Command("schtasks", "/Delete", "/TN", "xbot-server", "/F").Run()
+		fmt.Println("  Removed scheduled task.")
+	}
+
+	// 3. Remove nssm service (if registered)
+	nssmPath := filepath.Join(home, ".local", "bin", "nssm.exe")
+	if _, err := os.Stat(nssmPath); err == nil {
+		_ = exec.Command(nssmPath, "remove", "xbot-server", "confirm").Run()
+		fmt.Println("  Removed nssm service (if registered).")
+	}
+
+	// 4. Remove helper scripts
+	scriptsDir := filepath.Join(xbotHome, "scripts")
+	if _, err := os.Stat(scriptsDir); err == nil {
+		_ = os.RemoveAll(scriptsDir)
+		fmt.Println("  Removed helper scripts.")
+	}
+
+	return nil
+}
+
+func cleanPATH() error {
+	home, _ := os.UserHomeDir()
+	localBin := filepath.Join(home, ".local", "bin")
+
+	// Read current user PATH
+	currentPath := os.Getenv("PATH")
+	// Also check the persistent user env var
+	cmd := exec.Command("powershell", "-Command",
+		fmt.Sprintf("[Environment]::GetEnvironmentVariable('Path', 'User')"))
+	output, err := cmd.Output()
+	if err != nil {
+		fmt.Println("  Could not read user PATH, skipping.")
+		return nil
+	}
+	userPathStr := strings.TrimSpace(string(output))
+	entries := strings.Split(userPathStr, ";")
+
+	var newEntries []string
+	for _, entry := range entries {
+		cleaned := strings.TrimSpace(entry)
+		if cleaned == "" {
+			continue
+		}
+		// Compare case-insensitively on Windows
+		if !strings.EqualFold(cleaned, localBin) {
+			newEntries = append(newEntries, cleaned)
+		}
+	}
+
+	newPath := strings.Join(newEntries, ";")
+	if newPath == userPathStr {
+		fmt.Println("  No PATH entries to clean.")
+		return nil
+	}
+
+	// Set the new user PATH
+	setCmd := exec.Command("powershell", "-Command",
+		fmt.Sprintf("[Environment]::SetEnvironmentVariable('Path', '%s', 'User')", newPath))
+	if err := setCmd.Run(); err != nil {
+		return fmt.Errorf("failed to update user PATH: %w", err)
+	}
+	fmt.Println("  Cleaned .local\\bin from user PATH.")
+	_ = currentPath // suppress unused warning
+	return nil
+}

--- a/tools/worktree_registry.go
+++ b/tools/worktree_registry.go
@@ -75,6 +75,8 @@ func (r *WorktreeRegistry) Register(entry *WorktreeEntry) error {
 }
 
 // Deregister removes an entry and cleans up empty repo buckets.
+// For entries with physical worktrees, use CleanupSession instead which also
+// removes the git worktree and branch.
 func (r *WorktreeRegistry) Deregister(sessionKey string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -96,6 +98,21 @@ func (r *WorktreeRegistry) Deregister(sessionKey string) {
 		delete(r.byRepo, entry.RepoPath)
 	}
 	r.saveRepoLocked(entry.RepoPath)
+}
+
+// CleanupSession removes a session's worktree registration and, if the session
+// has a physical worktree (WorktreeDir != ""), deletes the git worktree and branch.
+// This is the correct method to call when a session is deleted/closed.
+func (r *WorktreeRegistry) CleanupSession(sessionKey string) {
+	entry := r.GetBySession(sessionKey)
+	if entry == nil {
+		return
+	}
+	// Remove physical worktree + branch if present
+	if entry.WorktreeDir != "" && entry.RepoPath != "" && entry.Branch != "" {
+		_ = removeWorktree(entry.RepoPath, entry.WorktreeDir, entry.Branch)
+	}
+	r.Deregister(sessionKey)
 }
 
 // GetPeers returns all entries for a repo, excluding the given sessionKey.
@@ -488,6 +505,11 @@ func removeWorktree(repoPath, worktreePath, branch string) error {
 // Every session gets its own worktree — no primary concept. All agents are equal peers.
 // Returns the worktree entry, or nil if not a git repo or worktree creation fails.
 func AutoDetectAndInit(workDir, sessionKey string) *WorktreeEntry {
+	return autoDetectAndInitInto(workDir, sessionKey, GlobalWorktreeRegistry)
+}
+
+// autoDetectAndInitInto is the testable core that accepts a custom registry.
+func autoDetectAndInitInto(workDir, sessionKey string, reg *WorktreeRegistry) *WorktreeEntry {
 	// Check if in a git repo
 	repoPath, err := GitRepoRoot(workDir)
 	if err != nil {
@@ -495,7 +517,7 @@ func AutoDetectAndInit(workDir, sessionKey string) *WorktreeEntry {
 	}
 
 	// Already registered?
-	if entry := GlobalWorktreeRegistry.GetBySession(sessionKey); entry != nil {
+	if entry := reg.GetBySession(sessionKey); entry != nil {
 		return entry
 	}
 
@@ -504,9 +526,9 @@ func AutoDetectAndInit(workDir, sessionKey string) *WorktreeEntry {
 	branch = strings.ReplaceAll(branch, ":", "-") // sessionKey may contain ":"
 
 	// Serialize worktree creation
-	GlobalWorktreeRegistry.mu.Lock()
+	reg.mu.Lock()
 	worktreePath, err := createWorktree(repoPath, branch)
-	GlobalWorktreeRegistry.mu.Unlock()
+	reg.mu.Unlock()
 	if err != nil {
 		return nil
 	}
@@ -519,7 +541,7 @@ func AutoDetectAndInit(workDir, sessionKey string) *WorktreeEntry {
 		Branch:      branch,
 		Status:      "working",
 	}
-	if err := GlobalWorktreeRegistry.Register(entry); err != nil {
+	if err := reg.Register(entry); err != nil {
 		removeWorktree(repoPath, worktreePath, branch)
 		return nil
 	}

--- a/tools/worktree_registry_test.go
+++ b/tools/worktree_registry_test.go
@@ -180,3 +180,127 @@ func TestRegisterPeer_GetPrimary(t *testing.T) {
 	require.NotNil(t, primary)
 	assert.Equal(t, "cli:repo:session-1", primary.SessionKey, "primary should remain the first session")
 }
+
+func TestCleanupSession_PeerOnly(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	// Register two peer-awareness sessions (no physical worktrees)
+	reg.RegisterPeer("cli:repo:session-1", repoPath)
+	reg.RegisterPeer("cli:repo:session-2", repoPath)
+
+	require.Len(t, reg.ListRepo(repoPath), 2)
+
+	// Cleanup session-2 (peer, no worktree)
+	reg.CleanupSession("cli:repo:session-2")
+
+	assert.Nil(t, reg.GetBySession("cli:repo:session-2"), "cleaned session should be gone")
+	assert.NotNil(t, reg.GetBySession("cli:repo:session-1"), "other session should remain")
+	assert.Len(t, reg.ListRepo(repoPath), 1, "only one session should remain")
+}
+
+func TestCleanupSession_PeerOnly_NotRegistered(t *testing.T) {
+	reg := newTestRegistry()
+	// Should not panic on nonexistent session
+	reg.CleanupSession("cli:repo:nonexistent")
+}
+
+func TestCleanupSession_WithWorktree(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	// Use AutoDetectAndInit to create a real worktree for session-1
+	entry := autoDetectAndInitInto(repoPath, "cli:repo:session-1", reg)
+	require.NotNil(t, entry, "AutoDetectAndInit should succeed")
+	require.NotEmpty(t, entry.WorktreeDir, "should have a worktree dir")
+
+	// Register a second peer-awareness session
+	reg.RegisterPeer("cli:repo:session-2", repoPath)
+
+	// Verify both are registered
+	require.Len(t, reg.ListRepo(repoPath), 2)
+
+	// Verify worktree dir exists on disk
+	_, err := os.Stat(entry.WorktreeDir)
+	require.NoError(t, err, "worktree dir should exist before cleanup")
+
+	// Cleanup session-1 (has physical worktree)
+	reg.CleanupSession("cli:repo:session-1")
+
+	// Registry entry should be gone
+	assert.Nil(t, reg.GetBySession("cli:repo:session-1"), "cleaned session should be gone from registry")
+
+	// session-2 should remain
+	assert.NotNil(t, reg.GetBySession("cli:repo:session-2"), "other session should remain")
+
+	// Worktree dir should be removed from disk
+	_, err = os.Stat(entry.WorktreeDir)
+	assert.True(t, os.IsNotExist(err), "worktree dir should be removed after CleanupSession")
+
+	// Git worktree should be gone from `git worktree list`
+	out, _ := exec.Command("git", "-C", repoPath, "worktree", "list").Output()
+	assert.NotContains(t, string(out), entry.WorktreeDir, "worktree should not appear in git worktree list")
+}
+
+func TestCleanupSession_AllSessions(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	reg.RegisterPeer("cli:repo:session-1", repoPath)
+	reg.RegisterPeer("cli:repo:session-2", repoPath)
+	reg.RegisterPeer("cli:repo:session-3", repoPath)
+
+	require.Len(t, reg.ListRepo(repoPath), 3)
+
+	// Cleanup all
+	reg.CleanupSession("cli:repo:session-1")
+	reg.CleanupSession("cli:repo:session-2")
+	reg.CleanupSession("cli:repo:session-3")
+
+	assert.Empty(t, reg.ListRepo(repoPath), "repo should have no sessions after all cleaned up")
+}
+
+func TestAutoDetectAndInit_SetsWorktreeDir(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	entry := autoDetectAndInitInto(repoPath, "cli:repo:main-session", reg)
+	require.NotNil(t, entry)
+
+	// Worktree dir should be under the base dir
+	baseDir := filepath.Join(filepath.Dir(repoPath), ".xbot-worktrees")
+	assert.Contains(t, entry.WorktreeDir, baseDir, "worktree should be under base dir")
+
+	// Worktree dir should exist on disk
+	info, err := os.Stat(entry.WorktreeDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	// Worktree should be a valid git worktree
+	gitFile := filepath.Join(entry.WorktreeDir, ".git")
+	data, err := os.ReadFile(gitFile)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(data), "gitdir:"), ".git file should point to main repo")
+}
+
+func TestAutoDetectAndInit_CleanupThenRecreate(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+	reg := newTestRegistry()
+
+	// Create worktree for session-1
+	entry1 := autoDetectAndInitInto(repoPath, "cli:repo:session-1", reg)
+	require.NotNil(t, entry1)
+
+	// Cleanup it
+	reg.CleanupSession("cli:repo:session-1")
+	assert.Nil(t, reg.GetBySession("cli:repo:session-1"))
+
+	// Create a new worktree for session-2 — should succeed without conflict
+	entry2 := autoDetectAndInitInto(repoPath, "cli:repo:session-2", reg)
+	require.NotNil(t, entry2)
+	assert.NotEqual(t, entry1.WorktreeDir, entry2.WorktreeDir, "new worktree should be a different dir")
+
+	// Old worktree dir should be gone
+	_, err := os.Stat(entry1.WorktreeDir)
+	assert.True(t, os.IsNotExist(err), "old worktree dir should be cleaned up")
+}


### PR DESCRIPTION
## Problem

When a session is deleted (sidebar × button or sessions panel D) or closed (tui_control close_session), the corresponding git worktree and peer registration are **not cleaned up**. This causes:

1. **Orphaned worktrees** — physical git worktree directories and branches accumulate on disk
2. **Inflated peer counts** — deleted sessions still appear as active peers in collaboration reminders
3. **Stale git branches** — `agent/peer/*` branches pile up

## Changes

| File | Change |
|------|--------|
| `tools/worktree_registry.go` | New `CleanupSession()` — deregisters entry + removes physical git worktree & branch. Refactor `AutoDetectAndInit` → `autoDetectAndInitInto` for testability. |
| `channel/cli_panel.go` | Call `CleanupSession` in `deleteLocalSession()` |
| `channel/cli_helpers.go` | Call `CleanupSession` in `close` session handler |
| `tools/worktree_registry_test.go` | 6 new tests (see below) |

## New Tests

| Test | Verifies |
|------|----------|
| `TestCleanupSession_PeerOnly` | Peer-only (no worktree) cleanup removes from registry |
| `TestCleanupSession_PeerOnly_NotRegistered` | No-op on nonexistent session, no panic |
| `TestCleanupSession_WithWorktree` | Worktree dir deleted from disk, removed from `git worktree list` |
| `TestCleanupSession_AllSessions` | Cleaning all sessions leaves repo list empty |
| `TestAutoDetectAndInit_SetsWorktreeDir` | Worktree created in correct base dir, .git points to main repo |
| `TestAutoDetectAndInit_CleanupThenRecreate` | After cleanup, new worktree can be created without conflict |