### PR TITLE
fix: session CWD per-session persistence + worktree git env isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,8 @@
 - **`BuildSystemReminder` takes `sessionKey` parameter.** Used to query `GlobalWorktreeRegistry` for worktree/peer info injected into sys_reminder per iteration.
 - **`MethodSetCWD` only sets CWD when empty.** Prevents CLI session switch from overwriting worktree CWD with main workspace path. Session-specific CWDs (worktree, Cd tool) are preserved.
 - **`go:embed embed_skills/*` auto-discovers new skills.** Adding a directory under `tools/embed_skills/` requires zero code changes.
+- **`buildPrompt` 绝不恢复 CWD 到 worktree 路径。** 当 session 已注册后 `AutoDetectAndInit` 跳过，这是正确行为。agent 通过 Cd 工具主动切换的目录必须被尊重，如果在后续 buildPrompt 中强制恢复会破坏 agent 的 Cd 操作，产生人机对抗。
+- **Cd 工具绝不强制 worktree 边界。** CLI 模式下 Cd 允许 agent 自由导航到任何目录，包括主仓库。如果对 Cd 加边界限制会导致 agent 无法读取 worktree 外的文件（如 AGENTS.md、知识库、配置文件），这是严重 bug。worktree 隔离是软性的工作指引，不是硬性监狱。
 
 ## Development Principles
 

--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -218,10 +218,21 @@ func (m *cliModel) removeLastToolSummary() {
 			break
 		}
 	}
-	if lastIdx >= 0 {
-		m.messages = append(m.messages[:lastIdx], m.messages[lastIdx+1:]...)
-		m.renderCacheValid = false
+	if lastIdx < 0 {
+		return
 	}
+	// Guard: only remove if the tool_summary belongs to the current active turn.
+	// If there is a user message AFTER the last tool_summary, the tool_summary
+	// belongs to a previous turn (e.g. a Ctrl+C interrupted turn) and must be
+	// preserved — removing it would erase iteration history that the active
+	// progress block does NOT replace.
+	for i := lastIdx + 1; i < len(m.messages); i++ {
+		if m.messages[i].role == "user" {
+			return // tool_summary belongs to a prior turn — do not remove
+		}
+	}
+	m.messages = append(m.messages[:lastIdx], m.messages[lastIdx+1:]...)
+	m.renderCacheValid = false
 }
 
 // endAgentTurn resets all agent-turn tracking state and returns to idle.

--- a/channel/cli_helpers_test.go
+++ b/channel/cli_helpers_test.go
@@ -36,6 +36,7 @@ func TestCLISettingScope_KnownKeys(t *testing.T) {
 		"danger_zone":         "action",
 		"definitely_unknown":  "unknown",
 	}
+
 	for key, want := range cases {
 		if got := cliSettingScope(key); got != want {
 			t.Fatalf("cliSettingScope(%q) = %q, want %q", key, got, want)
@@ -1413,5 +1414,28 @@ func TestRemoveLastToolSummary_OnlyPreservesFirst(t *testing.T) {
 	}
 	if m.messages[3].role != "user" {
 		t.Errorf("last message should be user, got %q", m.messages[3].role)
+	}
+}
+
+// TestRemoveLastToolSummary_PriorTurnWithUserAfter verifies that a tool_summary
+// from a Ctrl+C-interrupted turn is NOT removed when there is a subsequent user
+// message (i.e. the tool_summary belongs to a prior turn, not the active one).
+// Regression: removeLastToolSummary unconditionally removed the last tool_summary,
+// causing interrupted iterations to disappear on session switch.
+func TestRemoveLastToolSummary_PriorTurnWithUserAfter(t *testing.T) {
+	m := newCLIModel()
+	m.messages = []cliMessage{
+		{role: "user", content: "check system info"},
+		{role: "tool_summary", content: ""}, // Ctrl+C interrupted turn — must be PRESERVED
+		{role: "user", content: "continue"}, // new user message after interrupt
+	}
+
+	m.removeLastToolSummary()
+
+	if len(m.messages) != 3 {
+		t.Fatalf("expected 3 messages (tool_summary preserved), got %d", len(m.messages))
+	}
+	if m.messages[1].role != "tool_summary" {
+		t.Error("Ctrl+C tool_summary should be preserved when a user message follows it")
 	}
 }

--- a/session/multitenant.go
+++ b/session/multitenant.go
@@ -327,7 +327,7 @@ func (m *MultiTenantSession) GetOrCreateSession(channel, chatID string) (*Tenant
 		memory:     memProvider,
 		mcpManager: mcpManager,
 		lastActive: time.Now(),
-		cwd:        loadPersistedCWD(tenantID),
+		cwd:        loadPersistedCWD(channel, chatID),
 	}
 
 	m.tenantCache[key] = sess

--- a/session/tenant.go
+++ b/session/tenant.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -217,23 +218,32 @@ func (s *TenantSession) GetCurrentDir() string {
 }
 
 // SetCurrentDir 设置当前工作目录（PWD 工具优化），并持久化到磁盘。
+// 按 channel:chatID 唯一标识持久化，同一用户的多个会话互不干扰。
 func (s *TenantSession) SetCurrentDir(dir string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.cwd = dir
 
 	// Persist CWD to disk so it survives server restarts.
-	// Write to ~/.xbot/session_cwd/{tenantID}.txt
+	// Keyed by session (channel:chatID) not tenantID — multiple sessions
+	// under the same user must have independent CWDs.
 	cwdDir := filepath.Join(config.XbotHome(), "session_cwd")
 	if err := os.MkdirAll(cwdDir, 0700); err == nil {
-		cwdFile := filepath.Join(cwdDir, fmt.Sprintf("%d.txt", s.tenantID))
+		cwdFile := filepath.Join(cwdDir, sessionCwdFileName(s.channel, s.chatID))
 		_ = os.WriteFile(cwdFile, []byte(dir), 0600)
 	}
 }
 
+// sessionCwdFileName returns a safe filename for the given session.
+// Uses SHA256 hash of "channel:chatID" to avoid filesystem-unsafe characters.
+func sessionCwdFileName(channel, chatID string) string {
+	h := sha256.Sum256([]byte(channel + ":" + chatID))
+	return fmt.Sprintf("%x.txt", h[:16])
+}
+
 // loadPersistedCWD tries to restore CWD from disk after a restart.
-func loadPersistedCWD(tenantID int64) string {
-	cwdFile := filepath.Join(config.XbotHome(), "session_cwd", fmt.Sprintf("%d.txt", tenantID))
+func loadPersistedCWD(channel, chatID string) string {
+	cwdFile := filepath.Join(config.XbotHome(), "session_cwd", sessionCwdFileName(channel, chatID))
 	data, err := os.ReadFile(cwdFile)
 	if err != nil {
 		return ""

--- a/tools/worktree_registry.go
+++ b/tools/worktree_registry.go
@@ -460,6 +460,7 @@ func createWorktree(repoPath, branch string) (worktreePath string, err error) {
 	// Step 1: git worktree add --detach (works even on dirty trees)
 	cmd := exec.Command("git", "-C", repoPath, "worktree", "add",
 		"--detach", worktreePath)
+	cmd.Env = cleanGitEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git worktree add: %s: %w", strings.TrimSpace(string(out)), err)
@@ -467,6 +468,7 @@ func createWorktree(repoPath, branch string) (worktreePath string, err error) {
 
 	// Step 2: create branch in the new worktree
 	brCmd := exec.Command("git", "-C", worktreePath, "checkout", "-b", branch)
+	brCmd.Env = cleanGitEnv()
 	brOut, brErr := brCmd.CombinedOutput()
 	if brErr != nil {
 		// Rollback: remove the worktree we just created
@@ -482,6 +484,7 @@ func removeWorktree(repoPath, worktreePath, branch string) error {
 	// Remove worktree (--force handles dirty state)
 	cmd := exec.Command("git", "-C", repoPath, "worktree", "remove",
 		worktreePath, "--force")
+	cmd.Env = cleanGitEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git worktree remove: %s: %w", strings.TrimSpace(string(out)), err)
@@ -489,6 +492,7 @@ func removeWorktree(repoPath, worktreePath, branch string) error {
 
 	// Delete branch
 	delCmd := exec.Command("git", "-C", repoPath, "branch", "-d", branch)
+	delCmd.Env = cleanGitEnv()
 	delOut, delErr := delCmd.CombinedOutput()
 	if delErr != nil {
 		// Non-fatal: branch may already be merged/deleted


### PR DESCRIPTION
## 修复内容

### 核心修复：session CWD 持久化从按 tenantID 改为按 session

**根因**：`session_cwd` 文件按 `tenantID`（一个数字）命名持久化。同一用户的多个 CLI session 共享同一个 tenantID，导致多个 session 的 `SetCurrentDir` 互相覆盖同一个文件。worktree session 的 CWD 被非 worktree session 的 CWD 覆盖为主仓库路径，重启后恢复到的也是最后写入的值。

**修复**：`session_cwd` 文件名改为 `SHA256(channel:chatID)[:16].txt`，每个会话独立持久化。

### 附带修复

- **`createWorktree`/`removeWorktree` 添加 `cleanGitEnv()`**：pre-commit hook 在 worktree 中运行时，`GIT_DIR` 等环境变量泄漏到测试中，导致临时 repo 的 git 操作干扰。所有 git 子命令现在都清理环境变量。
- **`removeLastToolSummary` 守卫**：只有当 tool_summary 后面没有 user message 时才删除，防止 Ctrl+C 中断的迭代被误删。
- **AGENTS.md 新增 gotchas**：明确 buildPrompt 不恢复 CWD（正确行为）、Cd 不强制 worktree 边界（正确行为）。

## 改动文件

| 文件 | 变更 |
|------|------|
| `session/tenant.go` | `SetCurrentDir`/`loadPersistedCWD` 按 `channel:chatID` hash 持久化 |
| `session/multitenant.go` | `loadPersistedCWD` 调用签名适配 |
| `tools/worktree_registry.go` | `createWorktree`/`removeWorktree` 用 `cleanGitEnv()` |
| `channel/cli_helpers.go` | `removeLastToolSummary` guard |
| `AGENTS.md` | worktree gotchas 补充