### PR TITLE
fix(cli): fix invisible/dropped text on ANSI 16-color terminals (Linux console)

### DIFF
--- a/channel/cli_theme.go
+++ b/channel/cli_theme.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"fmt"
+	"github.com/charmbracelet/colorprofile"
 	"github.com/muesli/termenv"
 	"hash/fnv"
 	"image/color"
@@ -22,6 +23,12 @@ import (
 func init() {
 	termenv.SetDefaultOutput(termenv.NewOutput(os.Stdout, termenv.WithTTY(false)))
 }
+
+// terminalProfile stores the detected terminal color profile.
+// Updated when BubbleTea sends ColorProfileMsg. Used by buildStyles
+// to ensure muted/dim colors remain visible on low-color terminals
+// (e.g. Linux console with ANSI 16-color profile).
+var terminalProfile colorprofile.Profile
 
 // Theme system — semantic color palette with foreground/background layering.
 // All schemes are designed for dark terminal backgrounds.
@@ -636,6 +643,19 @@ type cliStyles struct {
 
 func buildStyles(width int) cliStyles {
 	t := currentTheme
+
+	// On low-color terminals (ANSI 16-color, e.g. Linux console / VT),
+	// dark muted colors like "#5f6368" get downgraded to black by
+	// colorprofile.Convert16, becoming invisible on dark backgrounds.
+	// Override these theme colors with ANSI-safe equivalents that are
+	// guaranteed visible.
+	if terminalProfile == colorprofile.ANSI {
+		t.TextMuted = "7"     // light gray — clearly visible on black bg
+		t.TextSecondary = "7" // light gray
+		t.FGMostSubtle = "8"  // bright black (dark gray) — faint but visible
+		t.FGGuide = "8"       // bright black for guide lines
+	}
+
 	c := func(s string) color.Color { return lipgloss.Color(s) }
 	cw := width - 4
 	if cw < 10 {
@@ -670,7 +690,7 @@ func buildStyles(width int) cliStyles {
 		ProgressError:    lipgloss.NewStyle().Foreground(c(t.Error)),
 		ProgressElapsed:  lipgloss.NewStyle().Foreground(c(t.TextSecondary)).Faint(true),
 		ProgressIndent:   lipgloss.NewStyle().Foreground(c(t.TextPrimary)),
-		ProgressDim:      lipgloss.NewStyle().Faint(true),
+		ProgressDim:      lipgloss.NewStyle().Foreground(c(t.FGMostSubtle)).Faint(true),
 		ProgressBlock:    lipgloss.NewStyle().Padding(0, 1).Width(cw),
 		Accent:           lipgloss.NewStyle().Foreground(c(t.Accent)),
 		TextMutedSt:      lipgloss.NewStyle().Foreground(c(t.TextMuted)),

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -61,6 +61,19 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 	default:
 	}
 
+	// Terminal color profile detected by BubbleTea.
+	// Cache it and rebuild styles so muted/dim colors stay visible on
+	// low-color terminals (e.g. Linux console with ANSI 16-color).
+	if cpMsg, ok := msg.(tea.ColorProfileMsg); ok {
+		prev := terminalProfile
+		terminalProfile = cpMsg.Profile
+		if terminalProfile != prev {
+			m.styles = buildStyles(m.width)
+			m.updateViewportContent()
+		}
+		return m, nil
+	}
+
 	// Model list load error notification from LLM goroutines
 	select {
 	case err := <-modelsLoadErrorCh:


### PR DESCRIPTION
## Problem

On Linux console (TTY, Ctrl+Alt+F1/F3) and other ANSI 16-color terminals, reasoning/streaming text appeared to lose characters at the start of each line. After restart, all historical reasoning blocks were completely invisible (black on black).

## Root Cause

Theme colors like `#5f6368` (TextMuted) are rendered as truecolor SGR sequences (`\x1b[38;2;95;99;104m`, 17 bytes). BubbleTea v2's `TerminalRenderer` uses `colorprofile.Convert16` to downgrade these to ANSI 16-color at render time. `#5f6368` (dark gray) maps to ANSI black (color 0), making text invisible on dark backgrounds.

The long truecolor SGR sequences also caused BubbleTea's diff renderer to produce larger frames that race with the VT parser on slow terminals (Linux console has no synchronized output support), resulting in visible character drops during streaming.

## Fix

- Listen for `tea.ColorProfileMsg` to detect the terminal's actual color profile
- When profile is ANSI (16-color), override dark muted theme colors with ANSI-safe equivalents:
  - `TextMuted` → `"7"` (light gray)
  - `TextSecondary` → `"7"` (light gray)
  - `FGMostSubtle` → `"8"` (bright black / dark gray)
  - `FGGuide` → `"8"` (bright black for guide lines)
- Give `ProgressDim` an explicit `Foreground(FGMostSubtle)` instead of bare `Faint(true)`
- Rebuild styles and refresh viewport when color profile changes on startup

## Files Changed

- `channel/cli_theme.go` — add `terminalProfile` global, ANSI color overrides in `buildStyles()`, fix `ProgressDim`
- `channel/cli_update.go` — handle `tea.ColorProfileMsg`