### PR TITLE
fix: bg task sidebar status icons + dynamic session key + SubAgent worktree CWD

### DIFF
--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -474,6 +474,17 @@ func (a *Agent) buildSubAgentRunConfig(
 	if cwd == "" {
 		cwd = workDir
 	}
+
+	// Worktree isolation: if the parent's CWD is inside a worktree directory,
+	// rewrite workDir to the worktree path so the SubAgent's system prompt
+	// shows the correct workspace and all path resolution uses worktree-relative paths.
+	// This must happen before system prompt construction (below) so the prompt
+	// displays the worktree as "工作目录".
+	isWorktreeIsolated := parentCtx.IsWorktreeIsolated
+	if strings.Contains(cwd, ".xbot-worktrees") {
+		workDir = cwd
+		isWorktreeIsolated = true
+	}
 	cwdPart := "\n- 当前目录：" + cwd
 
 	// role.SystemPrompt 作为角色专有能力描述（非通用 prompt）
@@ -632,7 +643,8 @@ func (a *Agent) buildSubAgentRunConfig(
 
 		// Worktree isolation: if the parent is in a worktree, rewrite
 		// WorkspaceRoot to the worktree path and enable isolation.
-		IsWorktreeIsolated: parentCtx.IsWorktreeIsolated,
+		// (Already computed above before system prompt construction.)
+		IsWorktreeIsolated: isWorktreeIsolated,
 
 		MaxIterations: a.getMaxIterations(), // 继承主 Agent 配置
 		// SubAgent 不设独立超时，直接使用父 context 携带的 deadline
@@ -647,11 +659,11 @@ func (a *Agent) buildSubAgentRunConfig(
 		// ToolExecutor = nil → 使用 defaultToolExecutor（统一 buildToolContext）
 	}
 
-	// If the SubAgent's InitialCWD is inside a worktree directory,
+	// If the SubAgent's CWD is inside a worktree directory,
 	// rewrite WorkspaceRoot to the worktree path for path isolation.
-	if strings.Contains(cfg.InitialCWD, ".xbot-worktrees") {
-		cfg.WorkspaceRoot = cfg.InitialCWD
-		cfg.IsWorktreeIsolated = true
+	// (workDir was already rewritten above before system prompt construction.)
+	if isWorktreeIsolated {
+		cfg.WorkspaceRoot = workDir
 	}
 
 	// Per-user token usage tracking：SubAgent 的 token 消耗归属原始用户

--- a/channel/cli.go
+++ b/channel/cli.go
@@ -602,6 +602,13 @@ func (c *CLIChannel) CurrentChatID() string {
 	return ""
 }
 
+// BgSessionKey returns the current background task session key.
+// This is dynamically read so that closures capturing it always use the latest value
+// after session switches (which update c.bgSessionKey via cli_panel.go).
+func (c *CLIChannel) BgSessionKey() string {
+	return c.bgSessionKey
+}
+
 // SyncPluginWidgetChatID updates the remote plugin cache's chatID after Cd
 // so that refreshWidgets() RPC fetches widgets for the correct session.
 func (c *CLIChannel) SyncPluginWidgetChatID(chatID string) {

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -654,10 +654,27 @@ func (m *cliModel) renderSidebarActive(w int) string {
 			b.WriteString(m.styles.SidebarItem.Render(fmt.Sprintf("  bg tasks: %d", m.bgTaskCount)))
 			sidebarBgTaskLines = append(sidebarBgTaskLines, -1)
 		} else {
+			s := &m.styles
 			for i, task := range tasks {
 				b.WriteByte('\n')
-				// Layout: " <command>" padded to width w
-				maxCmdW := w - 2 // 2 for leading "  "
+				// Status icon: ● running, ✓ done, ✗ error/killed
+				icon, iconStyle := "●", s.ProgressRunning
+				switch task.Status {
+				case BgTaskDone:
+					if task.Error != "" || task.ExitCode != 0 {
+						icon, iconStyle = "✗", s.ProgressError
+					} else {
+						icon, iconStyle = "✓", s.ProgressDone
+					}
+				case BgTaskKilled:
+					icon, iconStyle = "✗", s.ProgressError
+				case BgTaskError:
+					icon, iconStyle = "✗", s.ProgressError
+				}
+				// Layout: " <icon> <command>" padded to width w
+				iconRendered := iconStyle.Render(icon)
+				iconW := lipgloss.Width(iconRendered)
+				maxCmdW := w - 2 - iconW - 1 // 2 for leading spaces, 1 for space after icon
 				if maxCmdW < 5 {
 					maxCmdW = 5
 				}
@@ -665,7 +682,7 @@ func (m *cliModel) renderSidebarActive(w int) string {
 				if lipgloss.Width(cmd) > maxCmdW {
 					cmd = truncateToWidth(cmd, maxCmdW)
 				}
-				line := "  " + cmd
+				line := "  " + iconRendered + " " + cmd
 				lineVisW := lipgloss.Width(line)
 				padding := w - lineVisW
 				if padding < 0 {

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -1488,12 +1488,13 @@ func main() {
 			cliCh.InjectUserMessage(ev.ChatID, ev.Content)
 		})
 		// Inject bg task callbacks via RPC (unified local/remote path)
-		bgSessionKey := "cli:" + cliCfg.ChatID
+		// Closures read bgSessionKey dynamically via cliCh.BgSessionKey()
+		// so they always use the current session's key after session switches.
 		cliCh.SetBgTaskRemoteCallbacks(
-			bgSessionKey,
-			func() int { return app.client.GetBgTaskCount(bgSessionKey) },
+			"cli:"+cliCfg.ChatID,
+			func() int { return app.client.GetBgTaskCount(cliCh.BgSessionKey()) },
 			func() []*channel.BgTask {
-				tasks, _ := app.client.ListBgTasks(bgSessionKey)
+				tasks, _ := app.client.ListBgTasks(cliCh.BgSessionKey())
 				if tasks == nil {
 					return nil
 				}
@@ -1519,7 +1520,7 @@ func main() {
 				return result
 			},
 			func(taskID string) error { return app.client.KillBgTask(taskID) },
-			func() { app.client.CleanupCompletedBgTasks(bgSessionKey) },
+			func() { app.client.CleanupCompletedBgTasks(cliCh.BgSessionKey()) },
 		)
 		// Inject TrimHistoryFn for Ctrl+K session truncation (RPC-backed, unified path)
 		cliCh.SetTrimHistoryFn(func(cutoff time.Time) error {


### PR DESCRIPTION
## Changes

### 1. Sidebar bg task status icons (`channel/cli_view.go`)

Sidebar task list now shows colored status icons:
- `●` yellow = running
- `✓` green = done
- `✗` red = error/killed

### 2. Dynamic bg task session key (`cmd/xbot-cli/main.go`, `channel/cli.go`)

`bgTaskCountFn`/`bgTaskListFn`/`bgTaskCleanupFn` closures captured a static `bgSessionKey` local variable at startup. After TUI session switch, `c.bgSessionKey` was updated but closures still queried the old key — making bg tasks invisible in the panel.

Fix: closures now call `cliCh.BgSessionKey()` dynamically, always reading the current session key.

### 3. SubAgent worktree workDir in system prompt (`agent/engine_wire.go`)

`buildSubAgentRunConfig` computed `workDir` from `parentCtx.WorkspaceRoot` (main workspace) **before** checking for worktree isolation. The worktree rewrite only ran after the system prompt was formatted, so the SubAgent saw:
```
- 工作目录：/home/user/src/xbot          ← main workspace (wrong)
- 当前目录：/home/user/src/.xbot-worktrees/xxx  ← worktree (correct)
```

Fix: moved worktree detection before system prompt construction so both paths consistently point to the worktree.

## Test

```
go build ./... ✅
go test ./... ✅ (all packages pass)
```