### PR TITLE
fix(channel): ParseChatID fails to extract session name on Windows

### DIFF
--- a/channel/cli_session.go
+++ b/channel/cli_session.go
@@ -32,6 +32,27 @@ func SessionChatID(workDir, sessionName string) string {
 	return workDir + ":" + sessionName
 }
 
+// isWorkDirPath returns true if s looks like a valid filesystem path (Unix or Windows).
+func isWorkDirPath(s string) bool {
+	if s == "" {
+		return false
+	}
+	// Unix: absolute (/...), relative (./...), or home (~...)
+	if s[0] == '/' || s[0] == '.' || s[0] == '~' {
+		return true
+	}
+	// Windows absolute: drive letter + colon + separator (e.g. "C:\", "D:/")
+	return isWindowsAbs(s)
+}
+
+// isWindowsAbs returns true if s looks like a Windows absolute path (drive letter + colon + separator).
+func isWindowsAbs(s string) bool {
+	if len(s) >= 3 && s[1] == ':' && (s[2] == '\\' || s[2] == '/') {
+		return (s[0] >= 'A' && s[0] <= 'Z') || (s[0] >= 'a' && s[0] <= 'z')
+	}
+	return false
+}
+
 // ParseChatID extracts the workDir and sessionName from a chatID.
 // Returns (workDir, sessionName). If there's no ":" separator, sessionName is "default".
 func ParseChatID(chatID string) (workDir, sessionName string) {
@@ -42,11 +63,13 @@ func ParseChatID(chatID string) (workDir, sessionName string) {
 	workDir = chatID[:idx]
 	sessionName = chatID[idx+1:]
 	// Validate: workDir should look like an absolute or relative path
-	if !strings.HasPrefix(workDir, "/") && !strings.HasPrefix(workDir, ".") && !strings.HasPrefix(workDir, "~") {
+	if !isWorkDirPath(workDir) {
 		return chatID, defaultSessionName
 	}
-	// Resolve relative workDir (e.g. "." from legacy sessions) to absolute path
-	if !filepath.IsAbs(workDir) {
+	// Resolve relative workDir (e.g. "." from legacy sessions) to absolute path.
+	// Skip for Windows absolute paths (drive letter) since filepath.IsAbs
+	// returns false for them on non-Windows OS.
+	if !isWindowsAbs(workDir) && !filepath.IsAbs(workDir) {
 		if abs, err := filepath.Abs(workDir); err == nil {
 			workDir = abs
 		}

--- a/channel/cli_session_test.go
+++ b/channel/cli_session_test.go
@@ -1,0 +1,186 @@
+package channel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsWorkDirPath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		// Unix paths
+		{"/home/user", true},
+		{"/tmp", true},
+		{".", true},
+		{"./relative", true},
+		{"~/home", true},
+		// Windows paths
+		{`C:\Users\foo`, true},
+		{`D:\`, true},
+		{`C:/Users/foo`, true},
+		{`e:\path\to\dir`, true},
+		// Invalid
+		{"", false},
+		{"just-a-string", false},
+		{"Agent-brave-fox", false},
+		{"1:\\invalid", false},
+		{"_:\\nope", false},
+		{"C:", false}, // no separator after colon
+		{`C?bad`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := isWorkDirPath(tt.input); got != tt.want {
+				t.Errorf("isWorkDirPath(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseChatID_Unix(t *testing.T) {
+	tests := []struct {
+		chatID      string
+		wantWorkDir string
+		wantSession string
+	}{
+		// No session name → default
+		{"/home/user/project", "/home/user/project", "default"},
+		// With session name
+		{"/home/user/project:Agent-brave-fox", "/home/user/project", "Agent-brave-fox"},
+		{"/home/user/project:my-session", "/home/user/project", "my-session"},
+		// Tilde
+		{"~/project:my-session", "", "my-session"}, // workDir gets resolved by filepath.Abs
+		// No colon at all
+		{"/tmp", "/tmp", "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.chatID, func(t *testing.T) {
+			workDir, sessionName := ParseChatID(tt.chatID)
+			if tt.wantWorkDir != "" && workDir != tt.wantWorkDir {
+				t.Errorf("workDir = %q, want %q", workDir, tt.wantWorkDir)
+			}
+			if sessionName != tt.wantSession {
+				t.Errorf("sessionName = %q, want %q", sessionName, tt.wantSession)
+			}
+		})
+	}
+}
+
+func TestParseChatID_Windows(t *testing.T) {
+	tests := []struct {
+		name        string
+		chatID      string
+		wantWorkDir string
+		wantSession string
+	}{
+		{
+			name:        "windows backslash with session",
+			chatID:      `C:\Users\foo\project:Agent-brave-fox`,
+			wantWorkDir: `C:\Users\foo\project`,
+			wantSession: "Agent-brave-fox",
+		},
+		{
+			name:        "windows forward slash with session",
+			chatID:      `C:/Users/foo/project:my-session`,
+			wantWorkDir: `C:/Users/foo/project`,
+			wantSession: "my-session",
+		},
+		{
+			name:        "windows no session name",
+			chatID:      `C:\Users\foo\project`,
+			wantWorkDir: `C:\Users\foo\project`,
+			wantSession: "default",
+		},
+		{
+			name:        "windows lowercase drive",
+			chatID:      `d:\dev\xbot:fix-session`,
+			wantWorkDir: `d:\dev\xbot`,
+			wantSession: "fix-session",
+		},
+		{
+			name:        "windows root with session",
+			chatID:      `C:\:Agent-test`,
+			wantWorkDir: `C:\`,
+			wantSession: "Agent-test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir, sessionName := ParseChatID(tt.chatID)
+			if workDir != tt.wantWorkDir {
+				t.Errorf("workDir = %q, want %q", workDir, tt.wantWorkDir)
+			}
+			if sessionName != tt.wantSession {
+				t.Errorf("sessionName = %q, want %q", sessionName, tt.wantSession)
+			}
+		})
+	}
+}
+
+func TestParseChatID_Invalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		chatID string
+	}{
+		{"bare string with colon", "just-a-string:foo"},
+		{"agent name only", "Agent-brave-fox"},
+		{"colon at end", "foo:"},
+		{"single colon", ":"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir, sessionName := ParseChatID(tt.chatID)
+			// Invalid chatIDs should return the original chatID as workDir and "default" as sessionName
+			if workDir != tt.chatID {
+				t.Errorf("workDir = %q, want %q (original chatID)", workDir, tt.chatID)
+			}
+			if sessionName != "default" {
+				t.Errorf("sessionName = %q, want %q", sessionName, "default")
+			}
+		})
+	}
+}
+
+// TestParseChatID_WindowsRoundTrip verifies that SessionChatID → ParseChatID round-trips correctly on Windows paths.
+func TestParseChatID_WindowsRoundTrip(t *testing.T) {
+	workDir := `C:\Users\foo\project`
+	sessionName := "Agent-brave-fox"
+
+	chatID := SessionChatID(workDir, sessionName)
+	if !strings.Contains(chatID, ":") {
+		t.Fatalf("SessionChatID(%q, %q) = %q, expected colon separator", workDir, sessionName, chatID)
+	}
+
+	gotWorkDir, gotSession := ParseChatID(chatID)
+	if gotWorkDir != workDir {
+		t.Errorf("round-trip workDir = %q, want %q", gotWorkDir, workDir)
+	}
+	if gotSession != sessionName {
+		t.Errorf("round-trip sessionName = %q, want %q", gotSession, sessionName)
+	}
+}
+
+// TestParseChatID_UnixRoundTrip verifies that SessionChatID → ParseChatID round-trips correctly on Unix paths.
+func TestParseChatID_UnixRoundTrip(t *testing.T) {
+	workDir := "/home/user/project"
+	sessionName := "my-cool-session"
+
+	chatID := SessionChatID(workDir, sessionName)
+	if !strings.Contains(chatID, ":") {
+		t.Fatalf("SessionChatID(%q, %q) = %q, expected colon separator", workDir, sessionName, chatID)
+	}
+
+	gotWorkDir, gotSession := ParseChatID(chatID)
+	if gotWorkDir != workDir {
+		t.Errorf("round-trip workDir = %q, want %q", gotWorkDir, workDir)
+	}
+	if gotSession != sessionName {
+		t.Errorf("round-trip sessionName = %q, want %q", gotSession, sessionName)
+	}
+}


### PR DESCRIPTION
## Bug

Windows xbot CLI sessions never auto-rename after the first message. The session name stays as the auto-generated `Agent-brave-fox` style name forever.

## Root Cause

`ParseChatID` in `channel/cli_session.go` splits `chatID` on the last `:` to extract `sessionName`, then validates that the `workDir` part looks like a real path. The validation (line 45) only recognized Unix path prefixes (`/`, `.`, `~`):

```go
if !strings.HasPrefix(workDir, "/") && !strings.HasPrefix(workDir, ".") && !strings.HasPrefix(workDir, "~") {
    return chatID, defaultSessionName
}
```

On Windows, `chatID` looks like `C:\Users\foo\project:Agent-brave-fox`. After splitting on the last `:`, `workDir = "C:\Users\foo\project"` — which doesn't start with `/`, `.`, or `~`, so `ParseChatID` returns `sessionName = "default"`.

The auto-rename middleware (`middleware_builtin.go:533`) checks `strings.HasPrefix(sessionName, "Agent-")` before injecting the rename hint. Since `sessionName` is always `"default"` on Windows, the hint is never injected, and the LLM never renames the session.

## Fix

1. **`isWorkDirPath()`** — new helper that recognizes both Unix (`/`, `.`, `~`) and Windows absolute paths (`C:\`, `D:/`).
2. **`isWindowsAbs()`** — extracted for reuse; detects drive-letter paths.
3. **Skip `filepath.Abs()` for Windows paths** — on Linux, `filepath.IsAbs("C:\...")` returns `false`, causing `filepath.Abs` to prepend the CWD. Windows absolute paths are now explicitly excluded from resolution.

## Tests

New file `channel/cli_session_test.go` with:
- `TestIsWorkDirPath` — 17 cases covering Unix, Windows, and invalid paths
- `TestParseChatID_Unix` — existing Unix behavior unchanged
- `TestParseChatID_Windows` — backslash, forward slash, lowercase drive, root path, no-session
- `TestParseChatID_Invalid` — bare strings, edge cases
- Round-trip tests for both Unix and Windows paths

All pre-commit checks pass: gofmt, golangci-lint, build, full test suite.