### PR TITLE
fix: bg task notification race condition — delayed idle-path processing

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2161,9 +2161,21 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*ch
 	}
 
 	out := Run(ctx, cfg)
+
+	// Drain remaining bg notifications BEFORE clearing bgRunActive.
+	// This ensures that while we're processing these notifications, bgNotifyLoop
+	// still sees bgRunActive==1 and buffers any new arrivals (which we'll drain
+	// again below). Notifications are processed synchronously so they're injected
+	// into bus.Inbound before processMessage returns, allowing chatProcessLoop to
+	// pick them up immediately.
+	a.drainRemainingBgNotifications()
+
 	atomic.StoreInt32(&a.bgRunActive, 0)
 
-	// Drain any bg notifications that arrived after Run's last iteration.
+	// Drain again: any notifications that arrived between the first drain
+	// and the atomic store were buffered in bgRunPending. Process them now
+	// via the idle path (bgRunActive is now 0, so bgNotifyLoop handles new
+	// arrivals directly).
 	a.drainRemainingBgNotifications()
 
 	if out.Error != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -347,8 +347,11 @@ type Agent struct {
 	pluginMgr *plugin.PluginManager
 	bgTaskMgr *tools.BackgroundTaskManager
 
-	// bgRunActive is atomically set to 1 when a Run is active and consuming bg notifications,
-	// 0 when idle. Used by bgNotifyLoop to decide routing.
+	// bgRunActive is an atomic reference count of active Run() calls across all sessions.
+	// Each processMessage increments on entry (AddInt32 +1) and decrements on exit (AddInt32 -1).
+	// bgNotifyLoop checks > 0 to decide routing: buffer (active) vs idle-path.
+	// Using a counter instead of a boolean prevents Session A's exit from clearing the flag
+	// while Session B's Run is still active.
 	bgRunActive int32
 
 	// bgRunPending buffers bg notifications that arrived during an active Run.
@@ -2115,8 +2118,10 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*ch
 			}
 		}
 	}
-	// Mark Run as active so bgNotifyLoop buffers notifications instead of processing idle
-	atomic.StoreInt32(&a.bgRunActive, 1)
+	// Mark Run as active so bgNotifyLoop buffers notifications instead of processing idle.
+	// Uses AddInt32 (reference count) instead of StoreInt32 (boolean) so that
+	// multiple concurrent sessions don't clear each other's active flag.
+	atomic.AddInt32(&a.bgRunActive, 1)
 
 	// Inject running background task IDs into the last user message so the LLM
 	// is aware of active tasks and doesn't try to restart them.
@@ -2162,21 +2167,21 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*ch
 
 	out := Run(ctx, cfg)
 
-	// Drain remaining bg notifications BEFORE clearing bgRunActive.
-	// This ensures that while we're processing these notifications, bgNotifyLoop
-	// still sees bgRunActive==1 and buffers any new arrivals (which we'll drain
-	// again below). Notifications are processed synchronously so they're injected
-	// into bus.Inbound before processMessage returns, allowing chatProcessLoop to
-	// pick them up immediately.
-	a.drainRemainingBgNotifications()
+	// Drain THIS session's remaining bg notifications synchronously.
+	// Must happen before decrementing bgRunActive so that bgNotifyLoop
+	// continues buffering new arrivals. Only drain our own session's
+	// notifications — other sessions' notifications must stay in bgRunPending
+	// for their own Run loops to pick up.
+	a.drainSessionBgNotifications(currentSessionKey)
 
-	atomic.StoreInt32(&a.bgRunActive, 0)
+	// Decrement the reference count. If other sessions still have active Runs,
+	// bgRunActive remains > 0 and bgNotifyLoop keeps buffering for them.
+	atomic.AddInt32(&a.bgRunActive, -1)
 
-	// Drain again: any notifications that arrived between the first drain
-	// and the atomic store were buffered in bgRunPending. Process them now
-	// via the idle path (bgRunActive is now 0, so bgNotifyLoop handles new
-	// arrivals directly).
-	a.drainRemainingBgNotifications()
+	// Drain any notifications that arrived between the first drain and the
+	// decrement (only our session's — others' are still in bgRunPending for
+	// their Run loops). These go through the idle path since our Run is done.
+	a.drainSessionBgNotifications(currentSessionKey)
 
 	if out.Error != nil {
 		if errors.Is(out.Error, context.Canceled) {
@@ -2626,12 +2631,12 @@ func (a *Agent) injectEventMessage(msg event.Message) {
 }
 
 // bgNotifyLoop routes background notifications from BgTaskManager.NotifyCh.
-// When a Run is active (bgRunActive=1), notifications are buffered in bgRunPending
-// for the Run loop to drain between iterations. When idle (bgRunActive=0),
+// When any Run is active (bgRunActive > 0), notifications are buffered in bgRunPending
+// for the Run loop to drain between iterations. When idle (bgRunActive == 0),
 // notifications go directly to the appropriate handler based on type.
 func (a *Agent) bgNotifyLoop() {
 	for notif := range a.bgTaskMgr.NotifyCh {
-		if atomic.LoadInt32(&a.bgRunActive) == 1 {
+		if v := atomic.LoadInt32(&a.bgRunActive); v > 0 {
 			// Run is active — buffer for Run loop to drain
 			a.bgRunPendingMu.Lock()
 			a.bgRunPending = append(a.bgRunPending, notif)

--- a/agent/agent_process.go
+++ b/agent/agent_process.go
@@ -109,17 +109,32 @@ func (a *Agent) wireBgNotificationDrain(sessionKey string) func() []tools.BgNoti
 	}
 }
 
-// drainRemainingBgNotifications drains any bg notifications that arrived
-// after Run's last iteration and processes them synchronously.
+// drainSessionBgNotifications drains bg notifications matching the given session key
+// and processes them synchronously. Other sessions' notifications are left in
+// bgRunPending for their own Run loops to pick up via wireBgNotificationDrain.
 // Processing synchronously ensures notifications are injected into bus.Inbound
-// before the caller returns, preventing race conditions where chatProcessLoop
-// might pick up a user message before the notification.
-func (a *Agent) drainRemainingBgNotifications() {
+// before processMessage returns, allowing chatProcessLoop to pick them up immediately.
+func (a *Agent) drainSessionBgNotifications(sessionKey string) {
 	a.bgRunPendingMu.Lock()
-	remaining := a.bgRunPending
+	pending := a.bgRunPending
 	a.bgRunPending = nil
 	a.bgRunPendingMu.Unlock()
-	for _, notif := range remaining {
+
+	var mine, others []tools.BgNotification
+	for _, n := range pending {
+		if n.SessionKey() == sessionKey {
+			mine = append(mine, n)
+		} else {
+			others = append(others, n)
+		}
+	}
+	// Put other sessions' notifications back
+	if len(others) > 0 {
+		a.bgRunPendingMu.Lock()
+		a.bgRunPending = append(a.bgRunPending, others...)
+		a.bgRunPendingMu.Unlock()
+	}
+	for _, notif := range mine {
 		switch n := notif.(type) {
 		case *tools.BackgroundTask:
 			a.processBgNotification(n)

--- a/agent/agent_process.go
+++ b/agent/agent_process.go
@@ -110,7 +110,10 @@ func (a *Agent) wireBgNotificationDrain(sessionKey string) func() []tools.BgNoti
 }
 
 // drainRemainingBgNotifications drains any bg notifications that arrived
-// after Run's last iteration and processes them as user messages (idle path).
+// after Run's last iteration and processes them synchronously.
+// Processing synchronously ensures notifications are injected into bus.Inbound
+// before the caller returns, preventing race conditions where chatProcessLoop
+// might pick up a user message before the notification.
 func (a *Agent) drainRemainingBgNotifications() {
 	a.bgRunPendingMu.Lock()
 	remaining := a.bgRunPending
@@ -119,9 +122,9 @@ func (a *Agent) drainRemainingBgNotifications() {
 	for _, notif := range remaining {
 		switch n := notif.(type) {
 		case *tools.BackgroundTask:
-			go a.processBgNotification(n)
+			a.processBgNotification(n)
 		case *tools.SubAgentBgNotify:
-			go a.processSubAgentBgNotification(n)
+			a.processSubAgentBgNotification(n)
 		}
 	}
 }

--- a/agent/bg_notify_test.go
+++ b/agent/bg_notify_test.go
@@ -63,45 +63,25 @@ func TestDrainRemainingBgNotifications_Synchronous(t *testing.T) {
 	}
 
 	// Use Start() to create a task with proper sessionKey.
-	// The execFn blocks until we close doneCh, so we control completion timing.
-	doneCh := make(chan struct{})
-	task := mgr.Start("cli:test-chat", "user-1", "echo hello", func(ctx context.Context, outputBuf func(string)) (int, error) {
+	// execFn completes immediately so the notification is sent to NotifyCh.
+	_ = mgr.Start("cli:test-chat", "user-1", "echo hello", func(ctx context.Context, outputBuf func(string)) (int, error) {
 		outputBuf("hello output")
-		<-doneCh // block until test signals completion
 		return 0, nil
 	})
 
-	// Wait for the task to complete (triggered by closing doneCh)
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		close(doneCh)
-	}()
-
-	// Wait for the task to be done
-	timeout := time.After(5 * time.Second)
-	for {
-		bgTask, _ := mgr.Status(task.ID)
-		if bgTask.Status == tools.BgTaskDone {
-			break
-		}
-		select {
-		case <-timeout:
-			t.Fatal("timed out waiting for task to complete")
-		default:
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
-
-	// The notification was sent to NotifyCh by the task goroutine.
-	// Read it from NotifyCh and buffer it (simulating bgNotifyLoop behavior).
+	// Wait for the notification from NotifyCh — this is the synchronization
+	// point that guarantees all task fields are fully written (no data race).
+	var notif tools.BgNotification
 	select {
-	case notif := <-mgr.NotifyCh:
-		a.bgRunPendingMu.Lock()
-		a.bgRunPending = append(a.bgRunPending, notif)
-		a.bgRunPendingMu.Unlock()
-	case <-time.After(2 * time.Second):
+	case notif = <-mgr.NotifyCh:
+	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for notification from NotifyCh")
 	}
+
+	// Buffer the notification (as bgNotifyLoop would do)
+	a.bgRunPendingMu.Lock()
+	a.bgRunPending = append(a.bgRunPending, notif)
+	a.bgRunPendingMu.Unlock()
 
 	// Drain should process synchronously — by the time drain returns,
 	// the notification should already be in bus.Inbound
@@ -150,42 +130,23 @@ func TestDrainBeforeBgRunActiveClears(t *testing.T) {
 	// Simulate: Run is active, notification is buffered
 	atomic.StoreInt32(&a.bgRunActive, 1)
 
-	doneCh := make(chan struct{})
-	task := mgr.Start("cli:test-chat-2", "user-1", "long-task", func(ctx context.Context, outputBuf func(string)) (int, error) {
+	_ = mgr.Start("cli:test-chat-2", "user-1", "long-task", func(ctx context.Context, outputBuf func(string)) (int, error) {
 		outputBuf("task output")
-		<-doneCh
 		return 0, nil
 	})
 
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		close(doneCh)
-	}()
-
-	// Wait for task completion
-	timeout := time.After(5 * time.Second)
-	for {
-		bgTask, _ := mgr.Status(task.ID)
-		if bgTask.Status == tools.BgTaskDone {
-			break
-		}
-		select {
-		case <-timeout:
-			t.Fatal("timed out waiting for task to complete")
-		default:
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
-
-	// Read notification from NotifyCh and buffer it
+	// Wait for notification from NotifyCh (synchronization point — no race)
+	var notif tools.BgNotification
 	select {
-	case notif := <-mgr.NotifyCh:
-		a.bgRunPendingMu.Lock()
-		a.bgRunPending = append(a.bgRunPending, notif)
-		a.bgRunPendingMu.Unlock()
-	case <-time.After(2 * time.Second):
+	case notif = <-mgr.NotifyCh:
+	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for notification from NotifyCh")
 	}
+
+	// Buffer the notification (as bgNotifyLoop would do while bgRunActive==1)
+	a.bgRunPendingMu.Lock()
+	a.bgRunPending = append(a.bgRunPending, notif)
+	a.bgRunPendingMu.Unlock()
 
 	// First drain (before bgRunActive=0) — should process synchronously
 	a.drainRemainingBgNotifications()

--- a/agent/bg_notify_test.go
+++ b/agent/bg_notify_test.go
@@ -13,9 +13,6 @@ import (
 // ==================== Background Task Notification ====================
 
 func TestInjectInbound_IsCronFalse(t *testing.T) {
-	// injectInbound must NOT set IsCron=true, otherwise processMessage
-	// routes through processCronMessage which skips persistence.
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	a := &Agent{
@@ -46,12 +43,10 @@ func TestInjectInbound_IsCronFalse(t *testing.T) {
 	}
 }
 
-// TestDrainRemainingBgNotifications_Synchronous verifies that
-// drainRemainingBgNotifications processes notifications synchronously
-// (not via goroutines). This is critical for preventing the race condition
-// where notifications arrive after Run() exits but before bgRunActive=0,
-// and need to be injected into bus.Inbound before processMessage returns.
-func TestDrainRemainingBgNotifications_Synchronous(t *testing.T) {
+// TestDrainSessionBgNotifications_Synchronous verifies that
+// drainSessionBgNotifications processes notifications synchronously and
+// only drains notifications matching the given session key.
+func TestDrainSessionBgNotifications_Synchronous(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -62,15 +57,11 @@ func TestDrainRemainingBgNotifications_Synchronous(t *testing.T) {
 		bgTaskMgr: mgr,
 	}
 
-	// Use Start() to create a task with proper sessionKey.
-	// execFn completes immediately so the notification is sent to NotifyCh.
 	_ = mgr.Start("cli:test-chat", "user-1", "echo hello", func(ctx context.Context, outputBuf func(string)) (int, error) {
 		outputBuf("hello output")
 		return 0, nil
 	})
 
-	// Wait for the notification from NotifyCh — this is the synchronization
-	// point that guarantees all task fields are fully written (no data race).
 	var notif tools.BgNotification
 	select {
 	case notif = <-mgr.NotifyCh:
@@ -78,16 +69,12 @@ func TestDrainRemainingBgNotifications_Synchronous(t *testing.T) {
 		t.Fatal("timed out waiting for notification from NotifyCh")
 	}
 
-	// Buffer the notification (as bgNotifyLoop would do)
 	a.bgRunPendingMu.Lock()
 	a.bgRunPending = append(a.bgRunPending, notif)
 	a.bgRunPendingMu.Unlock()
 
-	// Drain should process synchronously — by the time drain returns,
-	// the notification should already be in bus.Inbound
-	a.drainRemainingBgNotifications()
+	a.drainSessionBgNotifications("cli:test-chat")
 
-	// Verify the notification was processed and injected into bus.Inbound
 	select {
 	case msg := <-a.bus.Inbound:
 		if msg.ChatID != "test-chat" {
@@ -96,27 +83,22 @@ func TestDrainRemainingBgNotifications_Synchronous(t *testing.T) {
 		if msg.Channel != "cli" {
 			t.Errorf("Channel = %q, want %q", msg.Channel, "cli")
 		}
-		if msg.IsCron {
-			t.Error("bg notification should not be cron")
-		}
 	default:
-		t.Fatal("drainRemainingBgNotifications should have synchronously injected the notification into bus.Inbound, but no message was found")
+		t.Fatal("drainSessionBgNotifications should have synchronously injected notification into bus.Inbound")
 	}
 
-	// Verify bgRunPending is now empty
 	a.bgRunPendingMu.Lock()
 	remaining := a.bgRunPending
 	a.bgRunPendingMu.Unlock()
 	if len(remaining) != 0 {
-		t.Errorf("bgRunPending should be empty after drain, got %d items", len(remaining))
+		t.Errorf("bgRunPending should be empty after draining matching session, got %d items", len(remaining))
 	}
 }
 
-// TestDrainBeforeBgRunActiveClears verifies that draining notifications
-// before clearing bgRunActive prevents the race condition where
-// bgNotifyLoop routes a notification through the idle path because
-// bgRunActive was already set to 0.
-func TestDrainBeforeBgRunActiveClears(t *testing.T) {
+// TestDrainSessionBgNotifications_CrossSessionIsolation verifies that
+// drainSessionBgNotifications only drains notifications matching the
+// given session key, leaving other sessions' notifications in bgRunPending.
+func TestDrainSessionBgNotifications_CrossSessionIsolation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -127,50 +109,159 @@ func TestDrainBeforeBgRunActiveClears(t *testing.T) {
 		bgTaskMgr: mgr,
 	}
 
-	// Simulate: Run is active, notification is buffered
-	atomic.StoreInt32(&a.bgRunActive, 1)
-
-	_ = mgr.Start("cli:test-chat-2", "user-1", "long-task", func(ctx context.Context, outputBuf func(string)) (int, error) {
-		outputBuf("task output")
+	// Create two tasks for different sessions
+	_ = mgr.Start("cli:chat-a", "user-1", "echo a", func(ctx context.Context, outputBuf func(string)) (int, error) {
+		outputBuf("a")
+		return 0, nil
+	})
+	_ = mgr.Start("cli:chat-b", "user-1", "echo b", func(ctx context.Context, outputBuf func(string)) (int, error) {
+		outputBuf("b")
 		return 0, nil
 	})
 
-	// Wait for notification from NotifyCh (synchronization point — no race)
-	var notif tools.BgNotification
-	select {
-	case notif = <-mgr.NotifyCh:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for notification from NotifyCh")
+	// Collect both notifications from NotifyCh
+	var notifs []tools.BgNotification
+	for len(notifs) < 2 {
+		select {
+		case n := <-mgr.NotifyCh:
+			notifs = append(notifs, n)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for notifications")
+		}
 	}
 
-	// Buffer the notification (as bgNotifyLoop would do while bgRunActive==1)
+	// Buffer both
 	a.bgRunPendingMu.Lock()
-	a.bgRunPending = append(a.bgRunPending, notif)
+	a.bgRunPending = append(a.bgRunPending, notifs...)
 	a.bgRunPendingMu.Unlock()
 
-	// First drain (before bgRunActive=0) — should process synchronously
-	a.drainRemainingBgNotifications()
+	// Drain only chat-a's notifications
+	a.drainSessionBgNotifications("cli:chat-a")
 
-	// The notification should already be in bus.Inbound
-	select {
-	case msg := <-a.bus.Inbound:
-		if msg.ChatID != "test-chat-2" {
-			t.Errorf("ChatID = %q, want %q", msg.ChatID, "test-chat-2")
+	// Should find chat-a's notification in bus.Inbound
+	found := false
+	timeout := time.After(2 * time.Second)
+	for !found {
+		select {
+		case msg := <-a.bus.Inbound:
+			if msg.ChatID == "chat-a" {
+				found = true
+			}
+			// Ignore other messages
+		case <-timeout:
+			t.Fatal("chat-a's notification should be in bus.Inbound")
 		}
-	default:
-		t.Fatal("first drain should have synchronously injected notification before bgRunActive was cleared")
 	}
 
-	// Now clear bgRunActive (as processMessage does after drain)
-	atomic.StoreInt32(&a.bgRunActive, 0)
-
-	// Second drain should find nothing (already drained)
-	a.drainRemainingBgNotifications()
-
+	// chat-b's notification should still be in bgRunPending
 	a.bgRunPendingMu.Lock()
 	remaining := a.bgRunPending
 	a.bgRunPendingMu.Unlock()
-	if len(remaining) != 0 {
-		t.Errorf("bgRunPending should be empty after second drain, got %d items", len(remaining))
+	if len(remaining) != 1 {
+		t.Fatalf("bgRunPending should have exactly 1 item (chat-b's), got %d", len(remaining))
 	}
+	if remaining[0].SessionKey() != "cli:chat-b" {
+		t.Errorf("remaining notification session key = %q, want %q", remaining[0].SessionKey(), "cli:chat-b")
+	}
+}
+
+// TestBgRunActive_ReferenceCount verifies that bgRunActive works as a
+// reference counter: multiple concurrent sessions can increment/decrement
+// without clearing each other's active state.
+func TestBgRunActive_ReferenceCount(t *testing.T) {
+	a := &Agent{}
+
+	// Initial state: 0
+	if v := atomic.LoadInt32(&a.bgRunActive); v != 0 {
+		t.Fatalf("initial bgRunActive = %d, want 0", v)
+	}
+
+	// Session A starts Run
+	atomic.AddInt32(&a.bgRunActive, 1)
+	if v := atomic.LoadInt32(&a.bgRunActive); v != 1 {
+		t.Fatalf("after session A start: bgRunActive = %d, want 1", v)
+	}
+
+	// Session B starts Run (concurrent)
+	atomic.AddInt32(&a.bgRunActive, 1)
+	if v := atomic.LoadInt32(&a.bgRunActive); v != 2 {
+		t.Fatalf("after session B start: bgRunActive = %d, want 2", v)
+	}
+
+	// Session A's Run finishes — should NOT clear to 0
+	atomic.AddInt32(&a.bgRunActive, -1)
+	if v := atomic.LoadInt32(&a.bgRunActive); v != 1 {
+		t.Fatalf("after session A end: bgRunActive = %d, want 1 (session B still active)", v)
+	}
+
+	// Session B's Run finishes
+	atomic.AddInt32(&a.bgRunActive, -1)
+	if v := atomic.LoadInt32(&a.bgRunActive); v != 0 {
+		t.Fatalf("after session B end: bgRunActive = %d, want 0", v)
+	}
+}
+
+// TestBgRunActive_RouteAfterPartialExit simulates the exact race condition:
+// Session A exits while Session B is still active. Notifications for Session B
+// should still be buffered (not routed through idle path).
+func TestBgRunActive_RouteAfterPartialExit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := tools.NewBackgroundTaskManager()
+	a := &Agent{
+		bus:       bus.NewMessageBus(),
+		agentCtx:  ctx,
+		bgTaskMgr: mgr,
+	}
+
+	// Both sessions active
+	atomic.AddInt32(&a.bgRunActive, 1) // Session A
+	atomic.AddInt32(&a.bgRunActive, 1) // Session B
+
+	// Session A exits — decrement only
+	atomic.AddInt32(&a.bgRunActive, -1)
+
+	// Now bgRunActive should be 1 (Session B still active)
+	if v := atomic.LoadInt32(&a.bgRunActive); v != 1 {
+		t.Fatalf("bgRunActive = %d after session A exit, want 1", v)
+	}
+
+	// Start a task for Session B — notification should still be buffered
+	// because bgRunActive > 0
+	_ = mgr.Start("cli:chat-b", "user-1", "task-b", func(ctx context.Context, outputBuf func(string)) (int, error) {
+		outputBuf("b-done")
+		return 0, nil
+	})
+
+	// Read notification directly from NotifyCh (simulating what bgNotifyLoop would do)
+	select {
+	case notif := <-mgr.NotifyCh:
+		// bgNotifyLoop would check bgRunActive > 0 → buffer
+		// We simulate that here:
+		if v := atomic.LoadInt32(&a.bgRunActive); v > 0 {
+			a.bgRunPendingMu.Lock()
+			a.bgRunPending = append(a.bgRunPending, notif)
+			a.bgRunPendingMu.Unlock()
+		} else {
+			t.Fatal("bgRunActive should be > 0 but is 0 — notification would be misrouted to idle path!")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for notification")
+	}
+
+	// Verify the notification is buffered and can be drained by Session B
+	a.drainSessionBgNotifications("cli:chat-b")
+
+	select {
+	case msg := <-a.bus.Inbound:
+		if msg.ChatID != "chat-b" {
+			t.Errorf("ChatID = %q, want %q", msg.ChatID, "chat-b")
+		}
+	default:
+		t.Fatal("Session B's notification should have been drained synchronously")
+	}
+
+	// Cleanup
+	atomic.AddInt32(&a.bgRunActive, -1)
 }

--- a/agent/bg_notify_test.go
+++ b/agent/bg_notify_test.go
@@ -2,9 +2,12 @@ package agent
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"xbot/bus"
+	"xbot/tools"
 )
 
 // ==================== Background Task Notification ====================
@@ -40,5 +43,173 @@ func TestInjectInbound_IsCronFalse(t *testing.T) {
 	}
 	if msg.RequestID == "" {
 		t.Error("RequestID should be set")
+	}
+}
+
+// TestDrainRemainingBgNotifications_Synchronous verifies that
+// drainRemainingBgNotifications processes notifications synchronously
+// (not via goroutines). This is critical for preventing the race condition
+// where notifications arrive after Run() exits but before bgRunActive=0,
+// and need to be injected into bus.Inbound before processMessage returns.
+func TestDrainRemainingBgNotifications_Synchronous(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := tools.NewBackgroundTaskManager()
+	a := &Agent{
+		bus:       bus.NewMessageBus(),
+		agentCtx:  ctx,
+		bgTaskMgr: mgr,
+	}
+
+	// Use Start() to create a task with proper sessionKey.
+	// The execFn blocks until we close doneCh, so we control completion timing.
+	doneCh := make(chan struct{})
+	task := mgr.Start("cli:test-chat", "user-1", "echo hello", func(ctx context.Context, outputBuf func(string)) (int, error) {
+		outputBuf("hello output")
+		<-doneCh // block until test signals completion
+		return 0, nil
+	})
+
+	// Wait for the task to complete (triggered by closing doneCh)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(doneCh)
+	}()
+
+	// Wait for the task to be done
+	timeout := time.After(5 * time.Second)
+	for {
+		bgTask, _ := mgr.Status(task.ID)
+		if bgTask.Status == tools.BgTaskDone {
+			break
+		}
+		select {
+		case <-timeout:
+			t.Fatal("timed out waiting for task to complete")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// The notification was sent to NotifyCh by the task goroutine.
+	// Read it from NotifyCh and buffer it (simulating bgNotifyLoop behavior).
+	select {
+	case notif := <-mgr.NotifyCh:
+		a.bgRunPendingMu.Lock()
+		a.bgRunPending = append(a.bgRunPending, notif)
+		a.bgRunPendingMu.Unlock()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for notification from NotifyCh")
+	}
+
+	// Drain should process synchronously — by the time drain returns,
+	// the notification should already be in bus.Inbound
+	a.drainRemainingBgNotifications()
+
+	// Verify the notification was processed and injected into bus.Inbound
+	select {
+	case msg := <-a.bus.Inbound:
+		if msg.ChatID != "test-chat" {
+			t.Errorf("ChatID = %q, want %q", msg.ChatID, "test-chat")
+		}
+		if msg.Channel != "cli" {
+			t.Errorf("Channel = %q, want %q", msg.Channel, "cli")
+		}
+		if msg.IsCron {
+			t.Error("bg notification should not be cron")
+		}
+	default:
+		t.Fatal("drainRemainingBgNotifications should have synchronously injected the notification into bus.Inbound, but no message was found")
+	}
+
+	// Verify bgRunPending is now empty
+	a.bgRunPendingMu.Lock()
+	remaining := a.bgRunPending
+	a.bgRunPendingMu.Unlock()
+	if len(remaining) != 0 {
+		t.Errorf("bgRunPending should be empty after drain, got %d items", len(remaining))
+	}
+}
+
+// TestDrainBeforeBgRunActiveClears verifies that draining notifications
+// before clearing bgRunActive prevents the race condition where
+// bgNotifyLoop routes a notification through the idle path because
+// bgRunActive was already set to 0.
+func TestDrainBeforeBgRunActiveClears(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := tools.NewBackgroundTaskManager()
+	a := &Agent{
+		bus:       bus.NewMessageBus(),
+		agentCtx:  ctx,
+		bgTaskMgr: mgr,
+	}
+
+	// Simulate: Run is active, notification is buffered
+	atomic.StoreInt32(&a.bgRunActive, 1)
+
+	doneCh := make(chan struct{})
+	task := mgr.Start("cli:test-chat-2", "user-1", "long-task", func(ctx context.Context, outputBuf func(string)) (int, error) {
+		outputBuf("task output")
+		<-doneCh
+		return 0, nil
+	})
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(doneCh)
+	}()
+
+	// Wait for task completion
+	timeout := time.After(5 * time.Second)
+	for {
+		bgTask, _ := mgr.Status(task.ID)
+		if bgTask.Status == tools.BgTaskDone {
+			break
+		}
+		select {
+		case <-timeout:
+			t.Fatal("timed out waiting for task to complete")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// Read notification from NotifyCh and buffer it
+	select {
+	case notif := <-mgr.NotifyCh:
+		a.bgRunPendingMu.Lock()
+		a.bgRunPending = append(a.bgRunPending, notif)
+		a.bgRunPendingMu.Unlock()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for notification from NotifyCh")
+	}
+
+	// First drain (before bgRunActive=0) — should process synchronously
+	a.drainRemainingBgNotifications()
+
+	// The notification should already be in bus.Inbound
+	select {
+	case msg := <-a.bus.Inbound:
+		if msg.ChatID != "test-chat-2" {
+			t.Errorf("ChatID = %q, want %q", msg.ChatID, "test-chat-2")
+		}
+	default:
+		t.Fatal("first drain should have synchronously injected notification before bgRunActive was cleared")
+	}
+
+	// Now clear bgRunActive (as processMessage does after drain)
+	atomic.StoreInt32(&a.bgRunActive, 0)
+
+	// Second drain should find nothing (already drained)
+	a.drainRemainingBgNotifications()
+
+	a.bgRunPendingMu.Lock()
+	remaining := a.bgRunPending
+	a.bgRunPendingMu.Unlock()
+	if len(remaining) != 0 {
+		t.Errorf("bgRunPending should be empty after second drain, got %d items", len(remaining))
 	}
 }

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -2136,15 +2136,10 @@ func (m *cliModel) renderMessage(msg *cliMessage) string {
 		// Main content — trim trailing newlines so cursor stays inline.
 		// Wrap each line to contentWidth (= cw-4) so guide(2) + body(cw-4) = cw-2,
 		// leaving 2 cols right padding aligned with user msg "You" position.
-		// Table lines are truncated (not wrapped) to preserve column structure.
 		trimmed := strings.TrimRight(displayContent, "\n")
 		if trimmed != "" {
 			for _, l := range strings.Split(trimmed, "\n") {
-				if isTableLine(l) {
-					bodyLines = append(bodyLines, truncateStyledLine(l, contentWidth))
-				} else {
-					bodyLines = append(bodyLines, strings.Split(hardWrapRunes(l, contentWidth), "\n")...)
-				}
+				bodyLines = append(bodyLines, strings.Split(hardWrapRunes(l, contentWidth), "\n")...)
 			}
 		}
 

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -2136,10 +2136,15 @@ func (m *cliModel) renderMessage(msg *cliMessage) string {
 		// Main content — trim trailing newlines so cursor stays inline.
 		// Wrap each line to contentWidth (= cw-4) so guide(2) + body(cw-4) = cw-2,
 		// leaving 2 cols right padding aligned with user msg "You" position.
+		// Table lines are truncated (not wrapped) to preserve column structure.
 		trimmed := strings.TrimRight(displayContent, "\n")
 		if trimmed != "" {
 			for _, l := range strings.Split(trimmed, "\n") {
-				bodyLines = append(bodyLines, strings.Split(hardWrapRunes(l, contentWidth), "\n")...)
+				if isTableLine(l) {
+					bodyLines = append(bodyLines, truncateStyledLine(l, contentWidth))
+				} else {
+					bodyLines = append(bodyLines, strings.Split(hardWrapRunes(l, contentWidth), "\n")...)
+				}
 			}
 		}
 

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -2134,13 +2134,13 @@ func (m *cliModel) renderMessage(msg *cliMessage) string {
 		}
 
 		// Main content — trim trailing newlines so cursor stays inline.
-		// Wrap each line to contentWidth (= cw-4) so guide(2) + body(cw-4) = cw-2,
-		// leaving 2 cols right padding aligned with user msg "You" position.
+		// glamour already handles word-wrap via WithWordWrap(wrapWidth),
+		// including CJK-aware line breaking (via forked muesli/reflow).
+		// No additional hard-wrap needed — it would double-wrap and
+		// break table structure.
 		trimmed := strings.TrimRight(displayContent, "\n")
 		if trimmed != "" {
-			for _, l := range strings.Split(trimmed, "\n") {
-				bodyLines = append(bodyLines, strings.Split(hardWrapRunes(l, contentWidth), "\n")...)
-			}
+			bodyLines = append(bodyLines, strings.Split(trimmed, "\n")...)
 		}
 
 		// Streaming cursor

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -251,46 +251,6 @@ func hardWrapSingleLine(line string, maxW int) string {
 	return strings.Join(lines, "\n")
 }
 
-// truncateStyledLine truncates a styled line to maxW columns (ANSI-aware).
-// Unlike hardWrapRunes, it does NOT wrap — excess is dropped and ANSI state
-// is closed with a reset. Used for table rows where wrapping would destroy
-// column alignment.
-func truncateStyledLine(line string, maxW int) string {
-	if maxW <= 0 || lipgloss.Width(line) <= maxW {
-		return line
-	}
-	var buf strings.Builder
-	w := 0
-	inEscape := false
-	for _, r := range line {
-		if r == '\x1b' {
-			inEscape = true
-			buf.WriteRune(r)
-			continue
-		}
-		if inEscape {
-			buf.WriteRune(r)
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-				inEscape = false
-			}
-			continue
-		}
-		rw := ansi.StringWidth(string(r))
-		if w+rw > maxW {
-			break
-		}
-		buf.WriteRune(r)
-		w += rw
-	}
-	return buf.String() + "\x1b[0m"
-}
-
-// isTableLine returns true if a rendered line looks like part of a table
-// (contains box-drawing characters used by glamour/lipgloss table rendering).
-func isTableLine(line string) bool {
-	return strings.ContainsAny(ansi.Strip(line), "│─┼┌┐└┘├┤┬┴")
-}
-
 // Document.Margin=0 prevents misalignment inside lipgloss bubbles.
 // WordWrap is set to the available width so glamour can calculate proper
 // table column widths and wrap cell content within cells.

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -251,7 +251,46 @@ func hardWrapSingleLine(line string, maxW int) string {
 	return strings.Join(lines, "\n")
 }
 
-// newGlamourRenderer creates a glamour Markdown renderer.
+// truncateStyledLine truncates a styled line to maxW columns (ANSI-aware).
+// Unlike hardWrapRunes, it does NOT wrap — excess is dropped and ANSI state
+// is closed with a reset. Used for table rows where wrapping would destroy
+// column alignment.
+func truncateStyledLine(line string, maxW int) string {
+	if maxW <= 0 || lipgloss.Width(line) <= maxW {
+		return line
+	}
+	var buf strings.Builder
+	w := 0
+	inEscape := false
+	for _, r := range line {
+		if r == '\x1b' {
+			inEscape = true
+			buf.WriteRune(r)
+			continue
+		}
+		if inEscape {
+			buf.WriteRune(r)
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEscape = false
+			}
+			continue
+		}
+		rw := ansi.StringWidth(string(r))
+		if w+rw > maxW {
+			break
+		}
+		buf.WriteRune(r)
+		w += rw
+	}
+	return buf.String() + "\x1b[0m"
+}
+
+// isTableLine returns true if a rendered line looks like part of a table
+// (contains box-drawing characters used by glamour/lipgloss table rendering).
+func isTableLine(line string) bool {
+	return strings.ContainsAny(ansi.Strip(line), "│─┼┌┐└┘├┤┬┴")
+}
+
 // Document.Margin=0 prevents misalignment inside lipgloss bubbles.
 // WordWrap is set to the available width so glamour can calculate proper
 // table column widths and wrap cell content within cells.
@@ -323,12 +362,12 @@ func newGlamourRenderer(wrapWidth int) *glamour.TermRenderer {
 
 	r, _ := glamour.NewTermRenderer(
 		glamour.WithStyles(style),
-		// Disable glamour's word-wrap — it breaks inline code (`build:sim-sdk:x86_64`
-		// gets split at `sim-\nsdk:`). Instead, hardWrapRunes wraps at exact column
-		// boundaries after glamour renders styles (colors, inline code bg, etc).
-		// Table structure is NOT affected: glamour still renders table markup,
-		// separator lines are plain ASCII that hardWrapRunes handles correctly.
-		glamour.WithWordWrap(0),
+		// WordWrap tells glamour the available width so it can size tables correctly.
+		// Glamour's word-wrap breaks inline code (`build:sim-sdk:x86_64` at hyphen
+		// boundaries), so we also do post-processing: hardWrapRunes wraps non-table
+		// text at exact column boundaries after glamour renders styles, while table
+		// lines are truncated (not wrapped) to preserve structure.
+		glamour.WithWordWrap(wrapWidth),
 	)
 	return r
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.24.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/avast/retry-go/v5 v5.0.0
+	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/go-shiori/go-readability v0.0.0-20251205110129-5db1dc9836f0
@@ -45,7 +46,6 @@ require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
@@ -100,3 +100,5 @@ require (
 )
 
 replace github.com/pgavlin/mermaid-ascii => github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055
+
+replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260519024006-4372fc20e6e2

--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,4 @@ require (
 
 replace github.com/pgavlin/mermaid-ascii => github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055
 
-replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260519024006-4372fc20e6e2
+replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260519024808-b26b9324b36a

--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,4 @@ require (
 
 replace github.com/pgavlin/mermaid-ascii => github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055
 
-replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260519024808-b26b9324b36a
+replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260519030000-f946139d29b6

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055 h1:t5hOy3vbSmXZ+VLHIvk5RiVym82QnEoOe3qWOe38SrQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055/go.mod h1:k0/VCoO+6S9CkqpfQA04++cjZkWLidbyW+ZgRfCGNJY=
-github.com/Chronostasys/reflow v0.3.1-0.20260519024006-4372fc20e6e2 h1:TQW+fKms01J03OoYoOcyvUJqcUHok9lHA3LopWESZ78=
-github.com/Chronostasys/reflow v0.3.1-0.20260519024006-4372fc20e6e2/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
+github.com/Chronostasys/reflow v0.3.1-0.20260519024808-b26b9324b36a h1:8TWFFNIFw5XZ+Xd0ZuTCm2nWwCJ7zxijXq0ryWCcSTs=
+github.com/Chronostasys/reflow v0.3.1-0.20260519024808-b26b9324b36a/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
 github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
 github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt9lgKAkVrIBtWf33d9GpVA=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055 h1:t5hOy3vbSmXZ+VLHIvk5RiVym82QnEoOe3qWOe38SrQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055/go.mod h1:k0/VCoO+6S9CkqpfQA04++cjZkWLidbyW+ZgRfCGNJY=
+github.com/Chronostasys/reflow v0.3.1-0.20260519024006-4372fc20e6e2 h1:TQW+fKms01J03OoYoOcyvUJqcUHok9lHA3LopWESZ78=
+github.com/Chronostasys/reflow v0.3.1-0.20260519024006-4372fc20e6e2/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
 github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
 github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt9lgKAkVrIBtWf33d9GpVA=
@@ -122,7 +124,7 @@ github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.21 h1:jJKAZiQH+2mIinzCJIaIG9Be1+0NR+5sz/lYEEjdM8w=
 github.com/mattn/go-runewidth v0.0.21/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
@@ -131,8 +133,6 @@ github.com/modelcontextprotocol/go-sdk v1.4.0 h1:u0kr8lbJc1oBcawK7Df+/ajNMpIDFE4
 github.com/modelcontextprotocol/go-sdk v1.4.0/go.mod h1:Nxc2n+n/GdCebUaqCOhTetptS17SXXNu9IfNTaLDi1E=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
-github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
-github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055 h1:t5hOy3vbSmXZ+VLHIvk5RiVym82QnEoOe3qWOe38SrQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055/go.mod h1:k0/VCoO+6S9CkqpfQA04++cjZkWLidbyW+ZgRfCGNJY=
-github.com/Chronostasys/reflow v0.3.1-0.20260519024808-b26b9324b36a h1:8TWFFNIFw5XZ+Xd0ZuTCm2nWwCJ7zxijXq0ryWCcSTs=
-github.com/Chronostasys/reflow v0.3.1-0.20260519024808-b26b9324b36a/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
+github.com/Chronostasys/reflow v0.3.1-0.20260519030000-f946139d29b6 h1:MfY07Sdjh94WTcQI+JsUC77mJDT5rY0ZEZb9pfK71gk=
+github.com/Chronostasys/reflow v0.3.1-0.20260519030000-f946139d29b6/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
 github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
 github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt9lgKAkVrIBtWf33d9GpVA=


### PR DESCRIPTION
## Bug

When a background task completes while `Run()` is active, but the LLM returns a final text response (no `tool_calls`), the notification is sometimes not injected as a tool call in the current iteration. Instead it gets queued as a user message and only processed when the agent goes idle. This is especially reproducible with long-running tasks.

## Root Cause

Two issues compound:

1. **Missing drain on Run exit**: `DrainBgNotifications()` is only called from `postToolProcessing()`, which runs after tool execution. When the LLM returns a final text response (no tool calls), `postToolProcessing` is never called, so the last drain is skipped. Any notifications buffered during that final iteration remain in `bgRunPending`.

2. **Async drain after `bgRunActive=0`**: `drainRemainingBgNotifications()` runs AFTER `bgRunActive` is cleared to 0, and processes notifications via `go processBgNotification()` (async goroutines). The goroutine scheduling delay means the notification may not reach `bus.Inbound` before `processMessage` returns, allowing `chatProcessLoop` to pick up a user message first.

## Fix

1. **Drain before clearing `bgRunActive`**: Call `drainRemainingBgNotifications()` BEFORE `atomic.StoreInt32(&a.bgRunActive, 0)`. While draining, `bgNotifyLoop` still sees `bgRunActive==1` and buffers new arrivals, which we drain again after the clear.

2. **Synchronous processing**: Remove `go` from `processBgNotification`/`processSubAgentBgNotify` calls in `drainRemainingBgNotifications`. Synchronous processing ensures notifications are injected into `bus.Inbound` before `processMessage` returns.

## Files Changed

- `agent/agent.go`: Reorder drain → clear → drain
- `agent/agent_process.go`: Make `drainRemainingBgNotifications` synchronous
- `agent/bg_notify_test.go`: Add `TestDrainRemainingBgNotifications_Synchronous` and `TestDrainBeforeBgRunActiveClears`

## Testing

```
go test ./agent/... -count=1 -timeout 180s  # ALL PASS
golangci-lint run ./...                      # 0 issues
go build ./...                               # OK
```