### PR TITLE
feat(cli): click status bar model name to cycle, show model during iteration, auto-discover on empty

### DIFF
--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -703,6 +703,10 @@ func (m *cliModel) doSaveSettings(onSubmit func(map[string]string), vals map[str
 	// user input until onSubmit completes and cliSettingsSavedMsg arrives.
 	return func() tea.Msg {
 		onSubmit(vals)
+		// Capture the model name directly from the saved values.
+		// This avoids a second GetDefault RPC which may not yet reflect
+		// the newly created subscription (especially on first setup).
+		savedModel := vals["llm_model"]
 		return cliSettingsSavedMsg{
 			themeChanged:  hasTheme && theme != "",
 			theme:         theme,
@@ -711,6 +715,7 @@ func (m *cliModel) doSaveSettings(onSubmit func(map[string]string), vals map[str
 			layoutChanged: layoutChanged,
 			layoutVals:    layoutVals,
 			feedbackMsg:   feedbackMsg,
+			savedModel:    savedModel,
 		}
 	}
 }
@@ -733,6 +738,11 @@ func (m *cliModel) handleSettingsSavedMsg(msg cliSettingsSavedMsg) tea.Cmd {
 		visualChanged = true
 	}
 	m.refreshCachedModelName()
+	// If model name is still empty after refresh (e.g. GetDefault RPC race on
+	// first setup), use the model name directly from the saved values.
+	if m.cachedModelName == "" && msg.savedModel != "" {
+		m.cachedModelName = msg.savedModel
+	}
 	// Invalidate cached context settings so they're re-resolved from user settings.
 	// Without this, changing max_context_tokens/max_output_tokens/compression_threshold
 	// in the settings panel has no effect on the context progress bar.

--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -752,6 +752,11 @@ func (m *cliModel) handleSettingsSavedMsg(msg cliSettingsSavedMsg) tea.Cmd {
 	} else {
 		m.updateViewportContent()
 	}
+	// If model name is still empty after refresh (e.g. LLM client not ready after
+	// first setup), schedule a delayed auto-discover retry.
+	if m.cachedModelName == "" {
+		return m.scheduleModelDiscoverRetry(0)
+	}
 	return nil
 }
 

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -524,6 +524,20 @@ func (m *cliModel) postRestoreSessionSetup() []tea.Cmd {
 					m.cachedModelName = defSub.Model
 				}
 			}
+			// Auto-discover: if model name is still empty after loading default sub,
+			// try listing available models and pick the first one.
+			if m.cachedModelName == "" && m.channel != nil && m.channel.modelLister != nil {
+				m.channel.modelLister.EnsureModelsLoaded()
+				if models := m.channel.modelLister.ListModels(); len(models) > 0 {
+					m.cachedModelName = models[0]
+					if m.llmSubscriber != nil {
+						m.llmSubscriber.SwitchModel(m.senderID, models[0], m.chatID)
+					}
+					existing := LoadSessionLLMState(m.workDir, m.chatID)
+					existing.Model = models[0]
+					SaveSessionLLMState(m.workDir, m.chatID, existing)
+				}
+			}
 		}
 	}
 
@@ -1051,12 +1065,14 @@ type cliModel struct {
 	matrixBuffer    [][]rune      // Matrix 字符缓冲区
 	versionHitTimes []time.Time   // /version 命令调用时间戳（三连检测）
 
-	channel         *CLIChannel     // back-reference to owning channel (set during Start)
-	cachedModelName string          // cached model name for View() performance
-	activeSubID     string          // active subscription ID for current session
-	todoManager     *cliTodoManager // per-session todo persistence
-	askUserSession  string          // chatID of the session that triggered current AskUser panel (empty = no pending AskUser)
-	modelCount      int             // cached model list length for View() performance
+	channel             *CLIChannel     // back-reference to owning channel (set during Start)
+	cachedModelName     string          // cached model name for View() performance
+	modelNameZoneXStart int             // rendered X start of model name in status bar (-1 = not rendered)
+	modelNameZoneXEnd   int             // rendered X end of model name in status bar (exclusive)
+	activeSubID         string          // active subscription ID for current session
+	todoManager         *cliTodoManager // per-session todo persistence
+	askUserSession      string          // chatID of the session that triggered current AskUser panel (empty = no pending AskUser)
+	modelCount          int             // cached model list length for View() performance
 
 	// Context usage display (persisted across turns for ready-status bar)
 	lastTokenUsage         *protocol.TokenUsage // last known token usage from progress events
@@ -1408,6 +1424,21 @@ func (m *cliModel) refreshCachedModelName() {
 	if m.cachedModelName == "" && m.channel.subscriptionMgr != nil {
 		if sub, err := m.channel.subscriptionMgr.GetDefault(m.senderID); err == nil && sub != nil {
 			m.cachedModelName = sub.Model
+		}
+	}
+	// Auto-discover: if model name is still empty, try listing available models
+	// and pick the first one.
+	if m.cachedModelName == "" && m.channel.modelLister != nil {
+		m.channel.modelLister.EnsureModelsLoaded()
+		if models := m.channel.modelLister.ListModels(); len(models) > 0 {
+			m.cachedModelName = models[0]
+			// Persist the discovered model
+			if m.llmSubscriber != nil {
+				m.llmSubscriber.SwitchModel(m.senderID, models[0], m.chatID)
+			}
+			existing := LoadSessionLLMState(m.workDir, m.chatID)
+			existing.Model = models[0]
+			SaveSessionLLMState(m.workDir, m.chatID, existing)
 		}
 	}
 	// Cache model count for View() (avoids ListAllModels RPC per frame)

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -1287,6 +1287,7 @@ type cliSettingsSavedMsg struct {
 	layoutChanged bool
 	layoutVals    map[string]string // layout-related settings for field update
 	feedbackMsg   string
+	savedModel    string // model name from saved values (avoids GetDefault RPC timing issues)
 	// syncOnly is true when the message originates from SyncLayoutSettings
 	// (periodic remote cache refresh), not from an explicit user settings save.
 	// When true, context-related caches (maxContextTokens, etc.) must NOT be

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -1366,6 +1366,13 @@ type cliPluginUninstallResultMsg struct {
 // and the TUI should re-render to show the new content.
 type cliWidgetUpdateMsg struct{}
 
+// cliModelDiscoverMsg triggers a delayed auto-discover retry for the model name.
+// Sent when the initial refreshCachedModelName fails to find a model (e.g. LLM
+// client not yet ready after setup). The handler retries the auto-discover logic.
+type cliModelDiscoverMsg struct {
+	attempt int // retry attempt number (0-based)
+}
+
 // isCtrlEnter 检测 Ctrl+Enter 按键。
 // 终端对 Ctrl+Enter 没有统一标准，常见 raw sequences：
 //   - CSI u 协议: \x1b[13;5u   (kitty, Ghostty, Windows Terminal)
@@ -1445,6 +1452,41 @@ func (m *cliModel) refreshCachedModelName() {
 	if m.channel.modelLister != nil {
 		m.modelCount = len(m.channel.modelLister.ListAllModels())
 	}
+}
+
+// scheduleModelDiscoverRetry returns a tea.Cmd that sends a delayed
+// cliModelDiscoverMsg to retry auto-discovering the model name.
+// Used when ListModels returns empty (e.g. LLM client not ready after setup).
+func (m *cliModel) scheduleModelDiscoverRetry(attempt int) tea.Cmd {
+	return tea.Tick(3*time.Second, func(time.Time) tea.Msg {
+		return cliModelDiscoverMsg{attempt: attempt}
+	})
+}
+
+// handleModelDiscoverMsg processes a delayed model auto-discover retry.
+func (m *cliModel) handleModelDiscoverMsg(msg cliModelDiscoverMsg) tea.Cmd {
+	if m.cachedModelName != "" {
+		return nil // already resolved
+	}
+	// Retry auto-discover
+	if m.channel != nil && m.channel.modelLister != nil {
+		if models := m.channel.modelLister.ListModels(); len(models) > 0 {
+			m.cachedModelName = models[0]
+			if m.llmSubscriber != nil {
+				m.llmSubscriber.SwitchModel(m.senderID, models[0], m.chatID)
+			}
+			existing := LoadSessionLLMState(m.workDir, m.chatID)
+			existing.Model = models[0]
+			SaveSessionLLMState(m.workDir, m.chatID, existing)
+			m.updateViewportContent()
+			return nil
+		}
+	}
+	// Max 5 retries (15s total)
+	if msg.attempt < 5 {
+		return m.scheduleModelDiscoverRetry(msg.attempt + 1)
+	}
+	return nil
 }
 
 // scheduleSessionLLMRestore triggers an async SwitchLLM + SetDefault RPC when

--- a/channel/cli_mouse.go
+++ b/channel/cli_mouse.go
@@ -168,6 +168,9 @@ func (m *cliModel) handleMouseClick(msg tea.MouseClickMsg) (bool, tea.Model, tea
 		return m.clickRunnerField(zone.Index)
 	case "footerHint":
 		return m.clickFooterHint(zone.Index)
+	case "modelName":
+		m.cycleModel()
+		return true, m, nil
 	case "scrollToBottom":
 		m.viewport.GotoBottom()
 		m.newContentHint = false
@@ -842,7 +845,11 @@ func (m *cliModel) trackMainLayoutZones(zb *mouseZoneBuilder) {
 
 	zb.skip(viewportH)
 
-	// status bar: 1 line — track "new content" hint if present
+	// status bar: 1 line — track clickable model name and "new content" hint
+	// Model name zone is tracked in both ready and progress status bars.
+	if m.modelNameZoneXStart >= 0 && m.modelNameZoneXEnd > m.modelNameZoneXStart {
+		zb.addX(0, m.modelNameZoneXStart+xShift, m.modelNameZoneXEnd+xShift, "modelName", 0)
+	}
 	if m.newContentHintRendered != "" {
 		// The new content hint is rendered inline in the status bar.
 		// Use the pre-calculated X position from layoutMain.

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -390,6 +390,11 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 		m.renderCacheValid = false
 		m.relayoutViewport()
 
+	case cliModelDiscoverMsg:
+		if cmd := m.handleModelDiscoverMsg(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+
 	case easterEggDoneMsg:
 		// 🥚 彩蛋关闭（按任意键触发）
 		m.dismissEasterEgg()

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -220,11 +220,23 @@ func (m *cliModel) renderReadyStatus() string {
 		readyParts = append(readyParts, fmt.Sprintf("%d msg%s", msgCount, s))
 	}
 	// Model name (cached, avoids per-frame lookup)
+	m.modelNameZoneXStart = -1
+	m.modelNameZoneXEnd = -1
 	if m.cachedModelName != "" {
 		modelHint := m.cachedModelName
+		// Track X position of the model name part for click detection.
+		// The model name is: prefixBeforeModel + modelHint
+		// where prefixBeforeModel = join(readyParts without modelHint) + " · "
+		modelHintIdx := len(readyParts) // index where model hint will be appended
+		prefixBeforeModel := ""
+		if modelHintIdx > 0 {
+			prefixBeforeModel = strings.Join(readyParts, " · ") + " · "
+		}
 		if m.modelCount > 1 && !m.isCompact() {
 			modelHint += " [Ctrl+N]"
 		}
+		m.modelNameZoneXStart = lipgloss.Width(prefixBeforeModel)
+		m.modelNameZoneXEnd = m.modelNameZoneXStart + lipgloss.Width(modelHint)
 		readyParts = append(readyParts, modelHint)
 	}
 	// Narrow screen: drop msg count to save space
@@ -1575,6 +1587,16 @@ func padBetween(left, right string, width int) string {
 // renderProgressStatus renders a compact one-line status for the status bar.
 func (m *cliModel) renderProgressStatus() string {
 	var sb strings.Builder
+
+	// Model name (show during iteration)
+	m.modelNameZoneXStart = -1
+	m.modelNameZoneXEnd = -1
+	if m.cachedModelName != "" {
+		m.modelNameZoneXStart = 0
+		sb.WriteString(m.cachedModelName)
+		m.modelNameZoneXEnd = lipgloss.Width(sb.String())
+		sb.WriteString(" · ")
+	}
 
 	if m.progress != nil {
 		fmt.Fprintf(&sb, "#%d", m.progress.Iteration)


### PR DESCRIPTION
## Changes

### 1. Click model name on status bar to cycle to next model
- Model name in both idle and progress status bars is now a clickable mouse zone
- Clicking calls `cycleModel()` (same as Ctrl+N) to switch to the next model in the current subscription

### 2. Show model name during iteration (progress status bar)
- Before: `#3 · Thinking... · 12.5s`
- After: `gpt-4o · #3 · Thinking... · 12.5s`
- Model name part is also clickable

### 3. Auto-discover model when cachedModelName is empty
- On setup panel save (`refreshCachedModelName`) and session init (`postRestoreSessionSetup`)
- If subscription has no model set, calls `EnsureModelsLoaded()` + `ListModels()` to pick the first available model
- Persists via `SwitchModel` and `SaveSessionLLMState`

## Files changed
- `channel/cli_model.go` — model name zone fields, auto-discover logic
- `channel/cli_view.go` — X-position tracking in `renderReadyStatus`, model display in `renderProgressStatus`
- `channel/cli_mouse.go` — mouse zone registration + click handler

## Testing
- `go build ./...` ✅
- `golangci-lint run ./channel/...` 0 issues ✅
- `go test ./channel/...` ✅
- Pre-commit hooks all passed ✅