### PR TITLE
feat: sidebar section collapse/expand + per-user JSON preferences

### DIFF
--- a/channel/cli.go
+++ b/channel/cli.go
@@ -26,6 +26,7 @@ import (
 	log "xbot/logger"
 	"xbot/plugin"
 	"xbot/protocol"
+	"xbot/tools"
 	"xbot/version"
 )
 
@@ -105,6 +106,12 @@ func (c *CLIChannel) Start() error {
 	}
 	c.model.debugCaptureMs = c.config.DebugCaptureMs
 	c.model.senderID = "cli_user"
+
+	// Load per-user UI preferences (sidebar collapse state, etc.)
+	prefs := tools.LoadPreferences(c.workDir, c.model.senderID)
+	if len(prefs.SidebarCollapsed) > 0 {
+		c.model.sidebarCollapsedSections = prefs.SidebarCollapsed
+	}
 
 	// CLI-side TodoManager for persisting todos across turns and session switches.
 	// Updated by syncProgressTodos during active turns and consumed by endAgentTurn

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -15,6 +15,7 @@ import (
 	log "xbot/logger"
 	"xbot/plugin"
 	"xbot/protocol"
+	"xbot/tools"
 	"xbot/version"
 )
 
@@ -1021,14 +1022,15 @@ type cliModel struct {
 	mouseZones mouseZoneBuilder // zone tracker for mouse hit testing (rebuilt each View())
 
 	// --- Layout configuration ---
-	chatMaxWidth    int    // max content width (0 = unlimited)
-	chatCenter      bool   // center content in middle-width screens
-	layoutMode      string // "auto" / "single" / "dual"
-	sidebarEnabled  bool   // show sidebar in wide screens
-	sidebarWidth    int    // sidebar width in chars
-	sidebarPosition string // "left" / "right"
-	sidebarVisible  bool   // runtime: is sidebar currently shown (user toggled with Ctrl+B)?
-	xShift          int    // sidebar X offset for middleBlock, set during trackMainLayoutZones
+	chatMaxWidth             int             // max content width (0 = unlimited)
+	chatCenter               bool            // center content in middle-width screens
+	layoutMode               string          // "auto" / "single" / "dual"
+	sidebarEnabled           bool            // show sidebar in wide screens
+	sidebarWidth             int             // sidebar width in chars
+	sidebarPosition          string          // "left" / "right"
+	sidebarVisible           bool            // runtime: is sidebar currently shown (user toggled with Ctrl+B)?
+	sidebarCollapsedSections map[string]bool // per-section collapse state: "sessions"/"todo"/"tasks" → true=collapsed
+	xShift                   int             // sidebar X offset for middleBlock, set during trackMainLayoutZones
 
 	// Cached layout metrics (invalidated on resize / sidebar toggle).
 	// Eliminates repeated lipgloss.Render + ansi.StringWidth per chatWidth() call.
@@ -1178,16 +1180,17 @@ func newCLIModel() *cliModel {
 		senderID:        "cli_user",
 		channelName:     "cli",
 		// Layout defaults
-		chatMaxWidth:      76,
-		chatCenter:        true,
-		layoutMode:        "auto",
-		sidebarEnabled:    true,
-		sidebarVisible:    true,
-		sidebarWidth:      30,
-		sidebarPosition:   "left",
-		unreadSessions:    make(map[string]bool),
-		lastBusyStates:    make(map[string]bool),
-		liveSessionStates: make(map[string]*liveSessionState),
+		chatMaxWidth:             76,
+		chatCenter:               true,
+		layoutMode:               "auto",
+		sidebarEnabled:           true,
+		sidebarVisible:           true,
+		sidebarWidth:             30,
+		sidebarPosition:          "left",
+		sidebarCollapsedSections: make(map[string]bool),
+		unreadSessions:           make(map[string]bool),
+		lastBusyStates:           make(map[string]bool),
+		liveSessionStates:        make(map[string]*liveSessionState),
 	}
 }
 
@@ -1570,4 +1573,24 @@ func (m *cliModel) reloadMessagesFromSession() {
 			}
 		}
 	})
+}
+
+// toggleSidebarSection toggles the collapse state of a sidebar section and persists to preferences.
+func (m *cliModel) toggleSidebarSection(section string) {
+	if m.sidebarCollapsedSections[section] {
+		delete(m.sidebarCollapsedSections, section)
+	} else {
+		m.sidebarCollapsedSections[section] = true
+	}
+	m.saveSidebarCollapsedPrefs()
+}
+
+// saveSidebarCollapsedPrefs persists the current sidebar section collapse state to preferences.json.
+func (m *cliModel) saveSidebarCollapsedPrefs() {
+	if m.workDir == "" {
+		return
+	}
+	prefs := tools.LoadPreferences(m.workDir, m.senderID)
+	prefs.SidebarCollapsed = m.sidebarCollapsedSections
+	_ = tools.SavePreferences(m.workDir, m.senderID, prefs)
 }

--- a/channel/cli_mouse.go
+++ b/channel/cli_mouse.go
@@ -158,6 +158,8 @@ func (m *cliModel) handleMouseClick(msg tea.MouseClickMsg) (bool, tea.Model, tea
 		return m.clickSidebarNewSession()
 	case "sidebarBgTask":
 		return m.clickSidebarBgTask(zone.Index)
+	case "sidebarSectionHeader":
+		return m.clickSidebarSectionHeader(zone.ID)
 	case "bgtaskItem":
 		return m.clickBgTasksItem(zone.Index)
 	case "dangerItem":
@@ -172,6 +174,10 @@ func (m *cliModel) handleMouseClick(msg tea.MouseClickMsg) (bool, tea.Model, tea
 		m.viewport.GotoBottom()
 		m.newContentHint = false
 		return true, m, nil
+	}
+	// Handle prefixed zone IDs (e.g. "sidebarSectionHeader:sessions")
+	if strings.HasPrefix(zone.ID, "sidebarSectionHeader:") {
+		return m.clickSidebarSectionHeader(zone.ID)
 	}
 	return false, m, nil
 }
@@ -787,11 +793,21 @@ func (m *cliModel) trackMainLayoutZones(zb *mouseZoneBuilder) {
 		sbBorderLeftVisW := lipgloss.Width(lipgloss.RoundedBorder().Left)
 		sidebarContentOffset := sbBorderLeftVisW + sbStyle.GetPaddingLeft()
 		sbVisW := m.sidebarRenderedWidth() // actual visual width (accounts for EASTASIAN etc.)
+
+		// Helper to register section header zones
+		registerSectionHeaders := func(xStart, xEnd int, borderOffset int) {
+			for section, relY := range sidebarSectionHeaders {
+				zoneID := "sidebarSectionHeader:" + section
+				zb.addX(relY+borderOffset, xStart, xEnd, zoneID, 0)
+			}
+		}
+
 		if m.sidebarPosition == "right" {
 			// sidebar on right: middleBlock starts at 0, sidebar starts at chatWidth
 			sbXStart := m.chatWidth()
 			sbXEnd := m.width
 			borderOffset := 1 // RoundedBorder top edge
+			registerSectionHeaders(sbXStart, sbXEnd, borderOffset)
 			for relY, sessionIdx := range sidebarSessionLines {
 				if sessionIdx >= 0 {
 					zb.addX(relY+borderOffset, sbXStart, sbXEnd, "sidebarSession", sessionIdx)
@@ -815,6 +831,7 @@ func (m *cliModel) trackMainLayoutZones(zb *mouseZoneBuilder) {
 		} else {
 			// sidebar on left: middleBlock starts at sbVisW
 			borderOffset := 1 // RoundedBorder top edge
+			registerSectionHeaders(0, sbVisW, borderOffset)
 			for relY, sessionIdx := range sidebarSessionLines {
 				if sessionIdx >= 0 {
 					zb.addX(relY+borderOffset, 0, sbVisW, "sidebarSession", sessionIdx)
@@ -1465,6 +1482,18 @@ func (m *cliModel) clickSidebarDeleteSession(index int) (bool, tea.Model, tea.Cm
 	}
 	cmd := m.deleteLocalSession(entry)
 	return true, m, cmd
+}
+
+// clickSidebarSectionHeader handles clicking a sidebar section header to toggle collapse.
+// The zoneID format is "sidebarSectionHeader:<section>" where section is "sessions", "todo", or "tasks".
+func (m *cliModel) clickSidebarSectionHeader(zoneID string) (bool, tea.Model, tea.Cmd) {
+	const prefix = "sidebarSectionHeader:"
+	if !strings.HasPrefix(zoneID, prefix) {
+		return false, m, nil
+	}
+	section := strings.TrimPrefix(zoneID, prefix)
+	m.toggleSidebarSection(section)
+	return true, m, nil
 }
 
 // clickSidebarBgTask handles clicking a background task item in the sidebar.

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -450,33 +450,46 @@ func (m *cliModel) renderSidebarForBlock(block string, availableH int) string {
 
 	contentW := sw - m.styles.SidebarBg.GetHorizontalFrameSize() // Width(sw) includes border+padding; content = sw - frame
 
+	// Reset section header tracking for click-to-collapse
+	sidebarSectionHeaders = make(map[string]int)
+
 	// Only render sections that have real content
 	var blocks []string
 
 	// --- Sessions (always shown, clickable) ---
-	blocks = append(blocks, m.renderSidebarSessions(contentW))
+	sidebarSectionHeaders["sessions"] = 0
+	if m.sidebarCollapsedSections["sessions"] {
+		blocks = append(blocks, m.renderSidebarSectionHeader("Sessions", true))
+	} else {
+		blocks = append(blocks, m.renderSidebarSessions(contentW))
+	}
 
 	// --- Todo (when sidebar is visible, todo moves here from main view) ---
 	if len(m.todos) > 0 {
-		if st := m.renderSidebarTodo(contentW); st != "" {
-			blocks = append(blocks, st)
+		if m.sidebarCollapsedSections["todo"] {
+			sidebarSectionHeaders["todo"] = countBlockLines(blocks)
+			blocks = append(blocks, m.renderSidebarSectionHeader("Todo", true))
+		} else {
+			if st := m.renderSidebarTodo(contentW); st != "" {
+				sidebarSectionHeaders["todo"] = countBlockLines(blocks)
+				blocks = append(blocks, st)
+			}
 		}
 	}
 
 	// --- Active tasks (only when something is running) ---
 	if m.bgTaskCount > 0 || m.agentCount > 0 {
-		// Calculate line offset of the Active section within the sidebar content.
-		// Each block contributes its line count, and blocks are separated by "\n\n" (1 extra line).
-		sidebarActiveSectionOffset = 0
-		for i, blk := range blocks {
-			if i > 0 {
-				sidebarActiveSectionOffset++ // separator "\n\n" adds 1 line
-			}
-			sidebarActiveSectionOffset += strings.Count(blk, "\n") + 1
+		if m.sidebarCollapsedSections["tasks"] {
+			sidebarSectionHeaders["tasks"] = countBlockLines(blocks)
+			blocks = append(blocks, m.renderSidebarSectionHeader("Tasks", true))
+			sidebarActiveSectionOffset = -1
+		} else {
+			// Calculate line offset of the Active section within the sidebar content.
+			// Each block contributes its line count, and blocks are separated by "\n\n" (1 extra line).
+			sidebarActiveSectionOffset = countBlockLines(blocks)
+			sidebarSectionHeaders["tasks"] = sidebarActiveSectionOffset
+			blocks = append(blocks, m.renderSidebarActive(contentW))
 		}
-		// The "\n\n" separator before the Active block itself adds 1 more line.
-		sidebarActiveSectionOffset++
-		blocks = append(blocks, m.renderSidebarActive(contentW))
 	} else {
 		sidebarActiveSectionOffset = -1
 	}
@@ -487,6 +500,29 @@ func (m *cliModel) renderSidebarForBlock(block string, availableH int) string {
 		Width(sw).
 		Height(h).
 		Render(content)
+}
+
+// renderSidebarSectionHeader renders a collapsed section header with a ▸ indicator.
+// Clicking it will expand the section.
+func (m *cliModel) renderSidebarSectionHeader(label string, collapsed bool) string {
+	indicator := "▾" // expanded
+	if collapsed {
+		indicator = "▸"
+	}
+	return m.styles.SidebarHeader.Render(indicator + " " + label)
+}
+
+// countBlockLines returns the total number of visual lines consumed by the blocks so far,
+// accounting for "\n\n" separators between blocks.
+func countBlockLines(blocks []string) int {
+	n := 0
+	for i, blk := range blocks {
+		if i > 0 {
+			n++ // separator "\n\n" adds 1 line
+		}
+		n += strings.Count(blk, "\n") + 1
+	}
+	return n
 }
 
 func (m *cliModel) renderSidebarSessions(w int) string {
@@ -501,7 +537,7 @@ func (m *cliModel) renderSidebarSessions(w int) string {
 	currentIdx := m.sidebarCurrentIdx()
 
 	var b strings.Builder
-	b.WriteString(m.styles.SidebarHeader.Render("Sessions"))
+	b.WriteString(m.renderSidebarSectionHeader("Sessions", false))
 	sidebarSessionLines = append(sidebarSessionLines, -1) // header line
 	sidebarDeleteXStart = append(sidebarDeleteXStart, -1)
 	sidebarDeleteXEnd = append(sidebarDeleteXEnd, -1)
@@ -643,7 +679,7 @@ func (m *cliModel) renderSidebarActive(w int) string {
 	sidebarBgTaskLines = nil
 
 	var b strings.Builder
-	b.WriteString(m.styles.SidebarHeader.Render("Tasks"))
+	b.WriteString(m.renderSidebarSectionHeader("Tasks", false))
 
 	if m.bgTaskCount > 0 {
 		// List individual bg tasks so user can click to view log
@@ -723,8 +759,8 @@ func (m *cliModel) renderSidebarTodo(w int) string {
 	s := &m.styles
 
 	var sb strings.Builder
-	// Header: "Todo N/M" + progress bar, padded to full width
-	headerLabel := s.SidebarHeader.Render("Todo")
+	// Header: "▾ Todo N/M" + progress bar, padded to full width
+	headerLabel := m.renderSidebarSectionHeader("Todo", false)
 	fmt.Fprintf(&sb, "%s %d/%d", headerLabel, done, total)
 	sb.WriteString(" ")
 	barWidth := 10
@@ -1412,6 +1448,14 @@ var sidebarBgTaskLines []int
 // within the sidebar content. Used by trackMainLayoutZones to register bg task zones.
 // -1 means not rendered.
 var sidebarActiveSectionOffset int
+
+// sidebarSectionHeaders tracks Y-offsets of each section header for click-to-collapse.
+// Key = section name ("sessions", "todo", "tasks"), Value = Y line offset within sidebar content.
+var sidebarSectionHeaders map[string]int
+
+func init() {
+	sidebarSectionHeaders = make(map[string]int)
+}
 
 // renderFooter 渲染底部快捷键提示条。
 // 根据当前状态动态显示最相关的快捷键，避免信息过载。

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -459,6 +459,13 @@ func (m *cliModel) renderSidebarForBlock(block string, availableH int) string {
 	// --- Sessions (always shown, clickable) ---
 	sidebarSectionHeaders["sessions"] = 0
 	if m.sidebarCollapsedSections["sessions"] {
+		// Must reset tracking vars even when collapsed, otherwise stale
+		// zone data from the previous frame causes wrong click targets.
+		sidebarSessionLines = nil
+		sidebarDeleteXStart = nil
+		sidebarDeleteXEnd = nil
+		sidebarNewSessionY = -1
+		m.sidebarHasBusySessions = false
 		blocks = append(blocks, m.renderSidebarSectionHeader("Sessions", true))
 	} else {
 		blocks = append(blocks, m.renderSidebarSessions(contentW))
@@ -483,6 +490,7 @@ func (m *cliModel) renderSidebarForBlock(block string, availableH int) string {
 			sidebarSectionHeaders["tasks"] = nextBlockOffset(blocks)
 			blocks = append(blocks, m.renderSidebarSectionHeader("Tasks", true))
 			sidebarActiveSectionOffset = -1
+			sidebarBgTaskLines = nil // clear stale zone data
 		} else {
 			sidebarActiveSectionOffset = nextBlockOffset(blocks)
 			sidebarSectionHeaders["tasks"] = sidebarActiveSectionOffset

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -467,11 +467,11 @@ func (m *cliModel) renderSidebarForBlock(block string, availableH int) string {
 	// --- Todo (when sidebar is visible, todo moves here from main view) ---
 	if len(m.todos) > 0 {
 		if m.sidebarCollapsedSections["todo"] {
-			sidebarSectionHeaders["todo"] = countBlockLines(blocks)
+			sidebarSectionHeaders["todo"] = nextBlockOffset(blocks)
 			blocks = append(blocks, m.renderSidebarSectionHeader("Todo", true))
 		} else {
 			if st := m.renderSidebarTodo(contentW); st != "" {
-				sidebarSectionHeaders["todo"] = countBlockLines(blocks)
+				sidebarSectionHeaders["todo"] = nextBlockOffset(blocks)
 				blocks = append(blocks, st)
 			}
 		}
@@ -480,13 +480,11 @@ func (m *cliModel) renderSidebarForBlock(block string, availableH int) string {
 	// --- Active tasks (only when something is running) ---
 	if m.bgTaskCount > 0 || m.agentCount > 0 {
 		if m.sidebarCollapsedSections["tasks"] {
-			sidebarSectionHeaders["tasks"] = countBlockLines(blocks)
+			sidebarSectionHeaders["tasks"] = nextBlockOffset(blocks)
 			blocks = append(blocks, m.renderSidebarSectionHeader("Tasks", true))
 			sidebarActiveSectionOffset = -1
 		} else {
-			// Calculate line offset of the Active section within the sidebar content.
-			// Each block contributes its line count, and blocks are separated by "\n\n" (1 extra line).
-			sidebarActiveSectionOffset = countBlockLines(blocks)
+			sidebarActiveSectionOffset = nextBlockOffset(blocks)
 			sidebarSectionHeaders["tasks"] = sidebarActiveSectionOffset
 			blocks = append(blocks, m.renderSidebarActive(contentW))
 		}
@@ -523,6 +521,16 @@ func countBlockLines(blocks []string) int {
 		n += strings.Count(blk, "\n") + 1
 	}
 	return n
+}
+
+// nextBlockOffset returns the Y-offset where the NEXT block would start
+// if appended via strings.Join(append(blocks, ...), "\n\n").
+// It accounts for the extra "\n\n" separator that precedes the new block.
+func nextBlockOffset(blocks []string) int {
+	if len(blocks) == 0 {
+		return 0
+	}
+	return countBlockLines(blocks) + 1 // +1 for the separator before the next block
 }
 
 func (m *cliModel) renderSidebarSessions(w int) string {

--- a/tools/preferences.go
+++ b/tools/preferences.go
@@ -1,0 +1,92 @@
+package tools
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// UserPreferences holds per-user UI preferences stored as a JSON file.
+// New fields should be added here — the file uses a JSON merge strategy
+// so unknown fields are preserved across read-modify-write cycles.
+type UserPreferences struct {
+	// Sidebar section collapse state. Key = section name ("sessions", "todo", "tasks"),
+	// Value = true means collapsed. Sections not in the map are expanded by default.
+	SidebarCollapsed map[string]bool `json:"sidebar_collapsed,omitempty"`
+}
+
+// preferencesMu guards concurrent file access per user path.
+var preferencesMu sync.Mutex
+
+// LoadPreferences reads per-user preferences from the JSON file.
+// Returns a zero-value UserPreferences if the file does not exist or cannot be parsed.
+func LoadPreferences(workDir, senderID string) UserPreferences {
+	path := UserPreferencesPath(workDir, senderID)
+
+	preferencesMu.Lock()
+	defer preferencesMu.Unlock()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return UserPreferences{}
+	}
+
+	var p UserPreferences
+	if err := json.Unmarshal(data, &p); err != nil {
+		return UserPreferences{}
+	}
+	return p
+}
+
+// SavePreferences writes per-user preferences to the JSON file.
+// Uses deep JSON merge to preserve unknown fields from newer versions.
+func SavePreferences(workDir, senderID string, p UserPreferences) error {
+	path := UserPreferencesPath(workDir, senderID)
+
+	preferencesMu.Lock()
+	defer preferencesMu.Unlock()
+
+	// Ensure directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	// Deep merge: read existing file first to preserve unknown fields
+	var existing map[string]any
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &existing)
+	}
+
+	var incoming map[string]any
+	raw, _ := json.Marshal(p)
+	_ = json.Unmarshal(raw, &incoming)
+
+	merged := deepMerge(existing, incoming)
+
+	data, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// deepMerge recursively merges src into dst. Keys in src override dst.
+func deepMerge(dst, src map[string]any) map[string]any {
+	if dst == nil {
+		dst = make(map[string]any)
+	}
+	for k, sv := range src {
+		if dv, ok := dst[k]; ok {
+			if srcMap, ok := sv.(map[string]any); ok {
+				if dstMap, ok := dv.(map[string]any); ok {
+					dst[k] = deepMerge(dstMap, srcMap)
+					continue
+				}
+			}
+		}
+		dst[k] = sv
+	}
+	return dst
+}

--- a/tools/preferences.go
+++ b/tools/preferences.go
@@ -13,7 +13,7 @@ import (
 type UserPreferences struct {
 	// Sidebar section collapse state. Key = section name ("sessions", "todo", "tasks"),
 	// Value = true means collapsed. Sections not in the map are expanded by default.
-	SidebarCollapsed map[string]bool `json:"sidebar_collapsed,omitempty"`
+	SidebarCollapsed map[string]bool `json:"sidebar_collapsed"`
 }
 
 // preferencesMu guards concurrent file access per user path.
@@ -53,7 +53,11 @@ func SavePreferences(workDir, senderID string, p UserPreferences) error {
 		return err
 	}
 
-	// Deep merge: read existing file first to preserve unknown fields
+	// Deep merge: read existing file first to preserve unknown fields.
+	// For map-valued fields that we own entirely (like sidebar_collapsed),
+	// delete them from existing before merge so they get replaced wholesale
+	// instead of recursively merged — otherwise removing keys from the map
+	// (e.g. un-collapsing a section) is silently lost.
 	var existing map[string]any
 	if data, err := os.ReadFile(path); err == nil {
 		_ = json.Unmarshal(data, &existing)
@@ -62,6 +66,14 @@ func SavePreferences(workDir, senderID string, p UserPreferences) error {
 	var incoming map[string]any
 	raw, _ := json.Marshal(p)
 	_ = json.Unmarshal(raw, &incoming)
+
+	// Keys present in incoming that are maps — remove from existing first
+	// so deepMerge replaces them wholesale rather than recursing.
+	for k, sv := range incoming {
+		if _, isMap := sv.(map[string]any); isMap {
+			delete(existing, k)
+		}
+	}
 
 	merged := deepMerge(existing, incoming)
 

--- a/tools/workspace_scope.go
+++ b/tools/workspace_scope.go
@@ -50,6 +50,12 @@ func UserMCPConfigPath(workDir, senderID string) string {
 	return filepath.Join(UserRoot(workDir, senderID), "mcp.json")
 }
 
+// UserPreferencesPath returns the per-user UI preferences JSON path:
+// {workDir}/.xbot/users/{sender}/preferences.json
+func UserPreferencesPath(workDir, senderID string) string {
+	return filepath.Join(UserRoot(workDir, senderID), "preferences.json")
+}
+
 // UserAgentsRoot returns the user-private agents directory.
 func UserAgentsRoot(workDir, senderID string) string {
 	return filepath.Join(UserWorkspaceRoot(workDir, senderID), "agents")


### PR DESCRIPTION
## Summary

- **Sidebar section collapse/expand**: Each sidebar section (Sessions, Todo, Tasks) now has a clickable header with ▸/▾ indicators. Click to collapse, click again to expand.
- **Per-user JSON preferences**: New `preferences.json` file at `{workDir}/.xbot/users/{sender}/preferences.json` for storing UI preferences. Uses deep JSON merge to preserve unknown fields across versions.
- **Fully backward-compatible**: Existing `user_settings` DB is untouched. The preferences JSON is optional and auto-created on first toggle.

## Files Changed

| File | Change |
|------|--------|
| `tools/preferences.go` | **New**: `UserPreferences` struct, `LoadPreferences`/`SavePreferences` with deep merge |
| `tools/workspace_scope.go` | Added `UserPreferencesPath()` |
| `channel/cli_model.go` | Added `sidebarCollapsedSections` field, `toggleSidebarSection`/`saveSidebarCollapsedPrefs` methods |
| `channel/cli_view.go` | Collapsed section rendering, `renderSidebarSectionHeader`, `countBlockLines`, section header tracking |
| `channel/cli_mouse.go` | Mouse click zones for section headers, `clickSidebarSectionHeader` handler |
| `channel/cli.go` | Load preferences on startup |

## Test Plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Pre-commit hooks (gofmt → lint → build → test) all pass