### PR TITLE
feat: add China mirror install scripts for GFW users

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,39 @@ curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/instal
 irm https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.ps1 | iex
 ```
 
+<details>
+<summary>🇨🇳 国内用户（无需翻墙）</summary>
+
+通过公共 CDN 镜像加速，零配置即可安装：
+
+```bash
+# Linux / macOS（选一个能用的镜像）
+curl -fsSL https://ghfast.top/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.sh | bash
+# 或
+curl -fsSL https://gh-proxy.com/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.sh | bash
+```
+
+```powershell
+# Windows PowerShell（选一个能用的镜像）
+irm https://ghfast.top/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.ps1 | iex
+# 或
+irm https://gh-proxy.com/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.ps1 | iex
+```
+
+脚本会自动检测可用的镜像并代理所有 GitHub 下载。也可手动指定镜像：
+
+```bash
+# Linux / macOS
+GH_MIRROR=ghfast.top bash scripts/install-cn.sh
+```
+
+```powershell
+# Windows
+$env:GH_MIRROR="ghfast.top"; .\scripts\install-cn.ps1
+```
+
+</details>
+
 指定安装路径：
 
 ```bash

--- a/scripts/install-cn.ps1
+++ b/scripts/install-cn.ps1
@@ -1,0 +1,125 @@
+<#
+.SYNOPSIS
+    xbot-cli installer for mainland China (CDN mirror mode)
+.DESCRIPTION
+    Automatically selects a reachable GitHub CDN mirror and proxies all
+    downloads through it.  Zero configuration required.
+.PARAMETER GhMirror
+    Force a specific mirror host (e.g. "ghfast.top").
+.PARAMETER MirrorList
+    Space-separated list of mirrors to try (override defaults).
+.EXAMPLE
+    # One-liner via ghfast.top
+    irm https://ghfast.top/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.ps1 | iex
+.EXAMPLE
+    # One-liner via gh-proxy.com
+    irm https://gh-proxy.com/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.ps1 | iex
+.EXAMPLE
+    # From a cloned repo
+    .\install-cn.ps1
+.EXAMPLE
+    # Force a specific mirror
+    $env:GH_MIRROR="ghfast.top"; .\install-cn.ps1
+#>
+
+param(
+    [string]$GhMirror = "",
+    [string]$MirrorList = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+# Default mirror candidates — ordered by reliability in mainland China
+$DefaultMirrors = @("ghfast.top", "gh-proxy.com", "ghps.cc")
+
+function Write-Info  { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundColor Green }
+function Write-Warn  { param([string]$Msg) Write-Host "[WARN] $Msg" -ForegroundColor Yellow }
+function Write-Err   { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red; throw $Msg }
+
+# ---------------------------------------------------------------------------
+# Detect the best reachable mirror (3s timeout per candidate)
+# ---------------------------------------------------------------------------
+function Select-Mirror {
+    param([string[]]$Candidates)
+    foreach ($m in $Candidates) {
+        try {
+            $null = Invoke-WebRequest -Uri "https://$m/https://github.com" `
+                -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
+            return $m
+        } catch {}
+    }
+    return ""
+}
+
+# ---------------------------------------------------------------------------
+# Locate the real install.ps1 (local repo or download via mirror)
+# ---------------------------------------------------------------------------
+function Find-InstallScript {
+    param([string]$SelectedMirror)
+
+    # 1. Check if install.ps1 exists alongside this script (cloned repo)
+    $scriptDir = Split-Path -Parent $MyInvocation.PSCommandPath
+    if (-not $scriptDir) { $scriptDir = $PSScriptRoot }
+    if ($scriptDir) {
+        $localInstall = Join-Path $scriptDir "install.ps1"
+        if (Test-Path $localInstall) {
+            Write-Info "Using local install.ps1 from repository"
+            return $localInstall
+        }
+    }
+
+    # 2. Download install.ps1 through the selected mirror
+    $tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-install.ps1"
+    $urls = @(
+        "https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.ps1",
+        "https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.ps1"
+    )
+
+    foreach ($rawUrl in $urls) {
+        $proxiedUrl = if ($SelectedMirror) { "https://${SelectedMirror}/${rawUrl}" } else { $rawUrl }
+        Write-Info "Trying to download install.ps1 from $proxiedUrl..."
+        try {
+            Invoke-WebRequest -Uri $proxiedUrl -OutFile $tmpFile -TimeoutSec 30 -UseBasicParsing
+            return $tmpFile
+        } catch {}
+    }
+
+    Write-Err "Failed to download install.ps1. Check your network or set -GhMirror manually."
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "  ===============================================" -ForegroundColor Cyan
+Write-Host "     xbot-cli Installer (China Mirror Mode)" -ForegroundColor Cyan
+Write-Host "  ===============================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Step 1: Select mirror (unless user forced one via param or env var)
+if (-not $GhMirror) { $GhMirror = $env:GH_MIRROR }
+if (-not $GhMirror) {
+    Write-Info "Auto-detecting best CDN mirror..."
+    $mirrors = if ($MirrorList) { $MirrorList -split "\s+" } else { $DefaultMirrors }
+    $GhMirror = Select-Mirror -Candidates $mirrors
+}
+
+if ($GhMirror) {
+    Write-Info "Using mirror: $GhMirror"
+} else {
+    Write-Warn "No CDN mirror reachable -- will try direct GitHub."
+    Write-Warn "If download fails, set mirror manually:"
+    Write-Warn '  $env:GH_MIRROR="ghfast.top"; .\install-cn.ps1'
+}
+Write-Host ""
+
+# Step 2: Find the real install.ps1
+$installScript = Find-InstallScript -SelectedMirror $GhMirror
+
+# Step 3: Set GH_MIRROR env var and run install.ps1
+$env:GH_MIRROR = $GhMirror
+Write-Info "Launching installer..."
+Write-Host ""
+
+# Pass through any remaining args (Mode, Channel, etc.)
+& $installScript @args

--- a/scripts/install-cn.sh
+++ b/scripts/install-cn.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# install-cn.sh — xbot installer for mainland China users
+#
+# Automatically selects a reachable GitHub CDN mirror and proxies all
+# downloads through it.  Zero configuration required.
+#
+# Usage (one-liner — pick any mirror that works for you):
+#
+#   # Option 1: via ghfast.top
+#   curl -fsSL https://ghfast.top/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.sh | bash
+#
+#   # Option 2: via gh-proxy.com
+#   curl -fsSL https://gh-proxy.com/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.sh | bash
+#
+#   # Option 3: clone and run locally
+#   git clone https://ghfast.top/https://github.com/ai-pivot/xbot.git
+#   cd xbot && bash scripts/install-cn.sh
+#
+# Environment variables (all optional):
+#   GH_MIRROR   — force a specific mirror host (e.g. ghfast.top)
+#   MIRROR_LIST — space-separated list of mirrors to try (override defaults)
+#   All variables from install.sh (INSTALL_PATH, MODE, CHANNEL, VERSION, etc.)
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Mirror configuration — ordered by reliability in mainland China
+# ---------------------------------------------------------------------------
+DEFAULT_MIRRORS="ghfast.top gh-proxy.com ghps.cc"
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[1;36m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Detect the best reachable mirror (3s timeout per candidate)
+# ---------------------------------------------------------------------------
+pick_mirror() {
+    local mirrors="${MIRROR_LIST:-$DEFAULT_MIRRORS}"
+
+    for m in $mirrors; do
+        if curl -fsSL --connect-timeout 3 --max-time 5 -o /dev/null \
+            "https://${m}/https://github.com" 2>/dev/null; then
+            echo "$m"
+            return
+        fi
+    done
+
+    # All mirrors failed
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Locate the real install.sh (local repo or download via mirror)
+# ---------------------------------------------------------------------------
+find_install_sh() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    # 1. Check if install.sh exists alongside this script (cloned repo)
+    if [ -f "${script_dir}/install.sh" ]; then
+        echo "${script_dir}/install.sh"
+        return
+    fi
+
+    # 2. Download install.sh through the selected mirror
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    # trap cleanup in the caller (main) so tmpdir lives until install.sh finishes
+
+    local install_sh="${tmpdir}/install.sh"
+    local urls=(
+        "https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh"
+        "https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh"
+    )
+
+    for raw_url in "${urls[@]}"; do
+        local proxied_url
+        if [ -n "${GH_MIRROR:-}" ]; then
+            proxied_url="https://${GH_MIRROR}/${raw_url}"
+        else
+            proxied_url="$raw_url"
+        fi
+        info "Trying to download install.sh from ${proxied_url}..."
+        if curl -fsSL --connect-timeout 10 --max-time 30 -o "$install_sh" "$proxied_url" 2>/dev/null; then
+            chmod +x "$install_sh"
+            echo "$install_sh"
+            return
+        fi
+    done
+
+    error "Failed to download install.sh. Please check your network or set GH_MIRROR manually."
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+echo ""
+echo "  ╔══════════════════════════════════════════════════╗"
+echo "  ║     xbot-cli Installer (China Mirror Mode)      ║"
+echo "  ╚══════════════════════════════════════════════════╝"
+echo ""
+
+# Step 1: Select mirror (unless user forced one)
+if [ -z "${GH_MIRROR:-}" ]; then
+    info "Auto-detecting best CDN mirror..."
+    GH_MIRROR=$(pick_mirror)
+fi
+
+if [ -n "$GH_MIRROR" ]; then
+    info "Using mirror: ${CYAN}${GH_MIRROR}${NC}"
+else
+    warn "No CDN mirror reachable — will try direct GitHub."
+    warn "If download fails, set GH_MIRROR manually:"
+    warn "  GH_MIRROR=ghfast.top bash scripts/install-cn.sh"
+fi
+
+echo ""
+
+# Step 2: Find the real install.sh
+INSTALL_SH=$(find_install_sh)
+
+# Step 3: Run install.sh with GH_MIRROR set (it uses gh_url() internally)
+export GH_MIRROR
+info "Launching installer..."
+echo ""
+
+bash "$INSTALL_SH" "$@"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -43,6 +43,16 @@ $BINARY = "xbot-cli.exe"
 $SERVICE_NAME = "xbot-server"
 $DEFAULT_PORT = 8082
 
+# GitHub CDN mirror for users behind the GFW (set by install-cn.ps1 or manually)
+# e.g. $env:GH_MIRROR="ghfast.top" → https://ghfast.top/https://github.com/...
+$GhMirror = $env:GH_MIRROR
+
+# Proxy a GitHub URL through the configured CDN mirror (if any).
+# If $GhMirror is set, returns "https://${GhMirror}/${Url}"; otherwise returns $Url unchanged.
+function Get-GhUrl([string]$Url) {
+    if ($GhMirror) { "https://${GhMirror}/${Url}" } else { $Url }
+}
+
 # Env var fallback for parameters (GitHub Actions uses env vars)
 if (-not $Mode)    { $Mode = $env:MODE }
 if (-not $Version) { $Version = $env:VERSION }
@@ -101,12 +111,12 @@ function Get-LatestVersion {
     switch ($ch) {
         "stable" {
             try {
-                $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -Headers $headers
+                $response = Invoke-RestMethod -Uri (Get-GhUrl "https://api.github.com/repos/$REPO/releases/latest") -Headers $headers
                 return $response.tag_name
             } catch {}
             try {
                 Write-Warn "No releases found on $REPO, trying fallback $FALLBACK_REPO..."
-                $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$FALLBACK_REPO/releases/latest" -Headers $headers
+                $response = Invoke-RestMethod -Uri (Get-GhUrl "https://api.github.com/repos/$FALLBACK_REPO/releases/latest") -Headers $headers
                 return $response.tag_name
             } catch {
                 Write-Err "Failed to determine latest version from both repos. Set -Version explicitly."
@@ -114,13 +124,13 @@ function Get-LatestVersion {
         }
         "nightly" {
             try {
-                $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases?per_page=20" -Headers $headers
+                $releases = Invoke-RestMethod -Uri (Get-GhUrl "https://api.github.com/repos/$REPO/releases?per_page=20") -Headers $headers
                 $nightly = $releases | Where-Object { $_.tag_name -eq 'nightly' -or $_.tag_name -match '^nightly-' } | Select-Object -First 1
                 if ($nightly) { return $nightly.tag_name }
             } catch {}
             try {
                 Write-Warn "No nightly found on $REPO, trying fallback $FALLBACK_REPO..."
-                $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$FALLBACK_REPO/releases?per_page=20" -Headers $headers
+                $releases = Invoke-RestMethod -Uri (Get-GhUrl "https://api.github.com/repos/$FALLBACK_REPO/releases?per_page=20") -Headers $headers
                 $nightly = $releases | Where-Object { $_.tag_name -eq 'nightly' -or $_.tag_name -match '^nightly-' } | Select-Object -First 1
                 if ($nightly) { return $nightly.tag_name }
             } catch {}
@@ -128,13 +138,13 @@ function Get-LatestVersion {
         }
         "beta" {
             try {
-                $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases?per_page=20" -Headers $headers
+                $releases = Invoke-RestMethod -Uri (Get-GhUrl "https://api.github.com/repos/$REPO/releases?per_page=20") -Headers $headers
                 $beta = $releases | Where-Object { $_.tag_name -match '-beta\.\d+' } | Select-Object -First 1
                 if ($beta) { return $beta.tag_name }
             } catch {}
             try {
                 Write-Warn "No beta found on $REPO, trying fallback $FALLBACK_REPO..."
-                $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$FALLBACK_REPO/releases?per_page=20" -Headers $headers
+                $releases = Invoke-RestMethod -Uri (Get-GhUrl "https://api.github.com/repos/$FALLBACK_REPO/releases?per_page=20") -Headers $headers
                 $beta = $releases | Where-Object { $_.tag_name -match '-beta\.\d+' } | Select-Object -First 1
                 if ($beta) { return $beta.tag_name }
             } catch {}
@@ -521,6 +531,9 @@ Write-Info "Version:   $tag"
 Write-Info "URL:       $downloadUrl"
 Write-Info "Install:   $InstallPath\$BINARY"
 Write-Info "Config:    $ConfigPath"
+if ($GhMirror) {
+    Write-Info "Mirror:    $GhMirror (GitHub CDN proxy)"
+}
 Write-Host ""
 
 $selectedMode = Ask-Mode
@@ -540,13 +553,13 @@ if (-not (Test-Path $InstallPath)) {
 Write-Info "Downloading..."
 $tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-cli-download.exe"
 try {
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $tmpFile -UseBasicParsing
+    Invoke-WebRequest -Uri (Get-GhUrl $downloadUrl) -OutFile $tmpFile -UseBasicParsing
 } catch {
     Write-Warn "Download from $REPO failed, trying fallback $FALLBACK_REPO..."
     $fallbackUrl = "https://github.com/$FALLBACK_REPO/releases/download/$tag/xbot-cli-$platform.exe"
     $downloadUrl = $fallbackUrl
     try {
-        Invoke-WebRequest -Uri $downloadUrl -OutFile $tmpFile -UseBasicParsing
+        Invoke-WebRequest -Uri (Get-GhUrl $downloadUrl) -OutFile $tmpFile -UseBasicParsing
     } catch {
         Write-Err "Download failed from both repos: $_"
     }
@@ -555,7 +568,7 @@ try {
 $checksumUrl = "https://github.com/$REPO/releases/download/$tag/checksums.txt"
 try {
     $checksumFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-checksums.txt"
-    Invoke-WebRequest -Uri $checksumUrl -OutFile $checksumFile -UseBasicParsing
+    Invoke-WebRequest -Uri (Get-GhUrl $checksumUrl) -OutFile $checksumFile -UseBasicParsing
     $expectedLine = Get-Content $checksumFile | Where-Object { $_ -match "xbot-cli-$platform" }
     if ($expectedLine) {
         $expectedHash = ($expectedLine -split "\s+")[0]
@@ -572,7 +585,7 @@ try {
     try {
         $fallbackChecksumUrl = "https://github.com/$FALLBACK_REPO/releases/download/$tag/checksums.txt"
         $checksumFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-checksums.txt"
-        Invoke-WebRequest -Uri $fallbackChecksumUrl -OutFile $checksumFile -UseBasicParsing
+        Invoke-WebRequest -Uri (Get-GhUrl $fallbackChecksumUrl) -OutFile $checksumFile -UseBasicParsing
         $expectedLine = Get-Content $checksumFile | Where-Object { $_ -match "xbot-cli-$platform" }
         if ($expectedLine) {
             $expectedHash = ($expectedLine -split "\s+")[0]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 REPO="ai-pivot/xbot"
 FALLBACK_REPO="CjiW/xbot"
 BINARY="xbot-cli"
+# GitHub CDN mirror for users behind the GFW (set by install-cn.sh or manually)
+# e.g. GH_MIRROR=ghfast.top  →  https://ghfast.top/https://github.com/...
+GH_MIRROR="${GH_MIRROR:-}"
 # Default to user-local install (no sudo required)
 INSTALL_PATH="${INSTALL_PATH:-$HOME/.local/bin}"
 XBOT_HOME="${XBOT_HOME:-$HOME/.xbot}"
@@ -23,6 +26,19 @@ error() { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
 
 require_cmd() {
     command -v "$1" >/dev/null 2>&1 || error "Missing required command: $1"
+}
+
+# Proxy a GitHub URL through the configured CDN mirror (if any).
+# Usage: gh_url "https://github.com/ai-pivot/xbot/releases/download/v1.0/file"
+# If GH_MIRROR is set, returns "https://${GH_MIRROR}/https://github.com/..."
+# Otherwise returns the original URL unchanged.
+gh_url() {
+    local url="$1"
+    if [ -n "$GH_MIRROR" ]; then
+        echo "https://${GH_MIRROR}/${url}"
+    else
+        echo "$url"
+    fi
 }
 
 detect_platform() {
@@ -58,21 +74,21 @@ resolve_version() {
     case "$ch" in
         stable)
             # /releases/latest returns the latest non-prerelease release
-            tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+            tag=$(curl -fsSL "$(gh_url "https://api.github.com/repos/${REPO}/releases/latest")" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
             if [ -z "$tag" ]; then
-                tag=$(curl -fsSL "https://api.github.com/repos/${FALLBACK_REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+                tag=$(curl -fsSL "$(gh_url "https://api.github.com/repos/${FALLBACK_REPO}/releases/latest")" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
             fi
             ;;
         nightly)
-            tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=20" 2>/dev/null | grep '"tag_name"' | grep -oE '"nightly(-[^"]*)?"' | head -1 | tr -d '"')
+            tag=$(curl -fsSL "$(gh_url "https://api.github.com/repos/${REPO}/releases?per_page=20")" 2>/dev/null | grep '"tag_name"' | grep -oE '"nightly(-[^"]*)?"' | head -1 | tr -d '"')
             if [ -z "$tag" ]; then
-                tag=$(curl -fsSL "https://api.github.com/repos/${FALLBACK_REPO}/releases?per_page=20" 2>/dev/null | grep '"tag_name"' | grep -oE '"nightly(-[^"]*)?"' | head -1 | tr -d '"')
+                tag=$(curl -fsSL "$(gh_url "https://api.github.com/repos/${FALLBACK_REPO}/releases?per_page=20")" 2>/dev/null | grep '"tag_name"' | grep -oE '"nightly(-[^"]*)?"' | head -1 | tr -d '"')
             fi
             ;;
         beta)
-            tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=20" 2>/dev/null | grep '"tag_name"' | grep -o '"v[^"]*-beta\.[0-9]*"' | head -1 | tr -d '"')
+            tag=$(curl -fsSL "$(gh_url "https://api.github.com/repos/${REPO}/releases?per_page=20")" 2>/dev/null | grep '"tag_name"' | grep -o '"v[^"]*-beta\.[0-9]*"' | head -1 | tr -d '"')
             if [ -z "$tag" ]; then
-                tag=$(curl -fsSL "https://api.github.com/repos/${FALLBACK_REPO}/releases?per_page=20" 2>/dev/null | grep '"tag_name"' | grep -o '"v[^"]*-beta\.[0-9]*"' | head -1 | tr -d '"')
+                tag=$(curl -fsSL "$(gh_url "https://api.github.com/repos/${FALLBACK_REPO}/releases?per_page=20")" 2>/dev/null | grep '"tag_name"' | grep -o '"v[^"]*-beta\.[0-9]*"' | head -1 | tr -d '"')
             fi
             ;;
         *)
@@ -318,9 +334,9 @@ download_web_dist() {
     if [ -t 2 ]; then
         curl_progress="--progress-bar"
     fi
-    if curl -fSL ${curl_progress} "$dist_url" | tar xzf - -C "$target_dir" 2>/dev/null; then
+    if curl -fSL ${curl_progress} "$(gh_url "$dist_url")" | tar xzf - -C "$target_dir" 2>/dev/null; then
         info "Web UI installed to ${target_dir} ✓"
-    elif curl -fSL ${curl_progress} "https://github.com/${FALLBACK_REPO}/releases/download/${version}/xbot-web-dist.tar.gz" | tar xzf - -C "$target_dir" 2>/dev/null; then
+    elif curl -fSL ${curl_progress} "$(gh_url "https://github.com/${FALLBACK_REPO}/releases/download/${version}/xbot-web-dist.tar.gz")" | tar xzf - -C "$target_dir" 2>/dev/null; then
         warn "Web UI downloaded from fallback repo ${FALLBACK_REPO}"
         info "Web UI installed to ${target_dir} ✓"
     else
@@ -490,6 +506,9 @@ main() {
     info "URL:       ${DOWNLOAD_URL}"
     info "Install:   ${INSTALL_PATH}/${BINARY}"
     info "Config:    ${CONFIG_PATH}"
+    if [ -n "$GH_MIRROR" ]; then
+        info "Mirror:    ${GH_MIRROR} (GitHub CDN proxy)"
+    fi
     echo ""
 
     ask_mode
@@ -510,19 +529,19 @@ main() {
     fi
     # Try new repo first; fall back to old repo if release not found
     # (during migration from CjiW/xbot → ai-pivot/xbot)
-    if ! curl -fSL ${curl_progress} -o "${TMPDIR}/${BINARY}" "$DOWNLOAD_URL" 2>/dev/null; then
+    if ! curl -fSL ${curl_progress} -o "${TMPDIR}/${BINARY}" "$(gh_url "$DOWNLOAD_URL")" 2>/dev/null; then
         FALLBACK_URL="https://github.com/${FALLBACK_REPO}/releases/download/${VERSION}/xbot-cli-${PLATFORM}"
         warn "Release not found on ${REPO}, trying fallback ${FALLBACK_REPO}..."
         DOWNLOAD_URL="$FALLBACK_URL"
-        if ! curl -fSL ${curl_progress} -o "${TMPDIR}/${BINARY}" "$DOWNLOAD_URL"; then
+        if ! curl -fSL ${curl_progress} -o "${TMPDIR}/${BINARY}" "$(gh_url "$DOWNLOAD_URL")"; then
             error "Download failed from both repos. Check the version and platform."
         fi
     fi
 
     if command -v shasum >/dev/null 2>&1; then
         info "Verifying checksum..."
-        curl -fsSL "https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt" -o "${TMPDIR}/checksums.txt" 2>/dev/null \
-            || curl -fsSL "https://github.com/${FALLBACK_REPO}/releases/download/${VERSION}/checksums.txt" -o "${TMPDIR}/checksums.txt" 2>/dev/null \
+        curl -fsSL "$(gh_url "https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt")" -o "${TMPDIR}/checksums.txt" 2>/dev/null \
+            || curl -fsSL "$(gh_url "https://github.com/${FALLBACK_REPO}/releases/download/${VERSION}/checksums.txt")" -o "${TMPDIR}/checksums.txt" 2>/dev/null \
             || warn "Checksum file not found, skipping verification."
         if [ -f "${TMPDIR}/checksums.txt" ]; then
             expected=$(grep "xbot-cli-${PLATFORM}" "${TMPDIR}/checksums.txt" | awk '{print $1}')


### PR DESCRIPTION
## Summary

Add CDN-mirror-aware install scripts so mainland China users can install xbot without a VPN. Zero configuration required.

## Changes

### Core: mirror support in existing installers
- **`scripts/install.sh`** — new `GH_MIRROR` env var + `gh_url()` helper. All 9 `curl` calls to `github.com` / `api.github.com` transparently proxied when `GH_MIRROR` is set. Unchanged behavior when unset.
- **`scripts/install.ps1`** — same pattern: `$GhMirror` / `Get-GhUrl()`. All 10 `Invoke-RestMethod` / `Invoke-WebRequest` calls wrapped.

### New: China entry-point scripts
- **`scripts/install-cn.sh`** — bash wrapper that auto-detects the best reachable mirror (`ghfast.top` → `gh-proxy.com` → `ghps.cc`), exports `GH_MIRROR`, then delegates to `install.sh`.
- **`scripts/install-cn.ps1`** — PowerShell equivalent for Windows.

### Docs
- **`README.md`** — collapsible `🇨🇳 国内用户` section with one-liner commands for both platforms.

## Usage

```bash
# Linux / macOS
curl -fsSL https://ghfast.top/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.sh | bash
```

```powershell
# Windows PowerShell
irm https://ghfast.top/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.ps1 | iex
```

## Test plan
- [x] `bash -n install-cn.sh && bash -n install.sh` — syntax OK
- [x] Pre-commit hooks pass (gofmt → golangci-lint → go build → go test)
- [ ] Manual test: run `GH_MIRROR=ghfast.top bash scripts/install-cn.sh` from China network
- [ ] Manual test: run `$env:GH_MIRROR="ghfast.top"; .\scripts\install-cn.ps1` from China network
- [ ] Verify `bash scripts/install.sh` still works without `GH_MIRROR` (zero-change path)
