### PR TITLE
fix: bg task injectCLIUserMessage drops user message due to missing channel prefix

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1443,14 +1443,12 @@ func (a *Agent) injectCLIUserMessage(channelName, chatID, content string) {
 		return
 	}
 	if injector, ok := ch.(channel.UserMessageInjector); ok {
-		switch ch.(type) {
-		case *channel.CLIChannel:
-			// Local mode: chatID needs "channel:chatID" format
-			injector.InjectUserMessage(channelName+":"+chatID, content)
-		default:
-			// Remote/ChannelCli: chatID is plain chatID
-			injector.InjectUserMessage(chatID, content)
-		}
+		// All channels use "channel:chatID" format — TUI's handleInjectedUserMsg
+		// filters by m.channelName+":"+m.chatID. Without the prefix, the injected
+		// message is silently dropped in both local mode (via ChannelCliChannel→eventCh
+		// →Client→CLIChannel.asyncCh) and remote mode (via RemoteCLIChannel→WS→Client→
+		// CLIChannel.asyncCh).
+		injector.InjectUserMessage(channelName+":"+chatID, content)
 	}
 }
 

--- a/channel/web_remote_cli.go
+++ b/channel/web_remote_cli.go
@@ -93,9 +93,18 @@ func (c *RemoteCLIChannel) Stop() {}
 
 // InjectUserMessage sends an injected user message (e.g. bg task notification)
 // to the remote CLI runner via WebSocket.
+// chatID may be in "channel:chatID" format (from injectCLIUserMessage) — we strip
+// the channel prefix for the Hub subscriber lookup while preserving the full key
+// in the WSMessage so the client-side TUI session filter matches correctly.
 func (c *RemoteCLIChannel) InjectUserMessage(chatID, content string) {
+	// Hub subscribers are registered with plain chatID (e.g. "/home/user/tmp"),
+	// but callers pass "cli:/home/user/tmp" for TUI session filtering.
+	hubKey := chatID
+	if idx := strings.Index(chatID, ":"); idx >= 0 {
+		hubKey = chatID[idx+1:]
+	}
 	wsMsg := cliMsg.buildInjectUserMsg(chatID, content)
-	if !c.hub.sendToClient(chatID, wsMsg) {
+	if !c.hub.sendToClient(hubKey, wsMsg) {
 		log.WithField("chat_id", chatID).Debug("Remote CLI client offline, inject_user buffered")
 	}
 }


### PR DESCRIPTION
## Bug
Background task completion notification never appeared in TUI as a user message — only the assistant reply showed up (via progress auto-start turn). Affected both local and remote CLI modes.

## Root Cause
`injectCLIUserMessage` default branch (ChannelCliChannel / RemoteCLIChannel) passed plain `chatID` (e.g. `/home/user/tmp`) but TUI `handleInjectedUserMsg` session filter requires `channel:chatID` format (e.g. `cli:/home/user/tmp`). The injected user message was silently dropped.

## Changes
- **agent/agent.go**: Unify all channel types to use `channelName+":"+"chatID"` format — removes the type switch that only added the prefix for `*CLIChannel`
- **channel/web_remote_cli.go**: Strip channel prefix for Hub subscriber lookup (Hub keys are plain chatID) while preserving full key in WSMessage for client-side TUI session filter