### PR TITLE
fix(scripts): china installer — stdout pollution + download validation

### DIFF
--- a/scripts/install-cn.ps1
+++ b/scripts/install-cn.ps1
@@ -80,7 +80,12 @@ function Find-InstallScript {
         Write-Info "Trying to download install.ps1 from $proxiedUrl..."
         try {
             Invoke-WebRequest -Uri $proxiedUrl -OutFile $tmpFile -TimeoutSec 30 -UseBasicParsing
-            return $tmpFile
+            # Verify the download is a real PowerShell script (not an error page)
+            $firstLine = Get-Content $tmpFile -TotalCount 1 -ErrorAction SilentlyContinue
+            if ($firstLine -and $firstLine.TrimStart().StartsWith("<#")) {
+                return $tmpFile
+            }
+            Write-Warn "Downloaded file is not a valid PowerShell script, trying next source..."
         } catch {}
     }
 

--- a/scripts/install-cn.sh
+++ b/scripts/install-cn.sh
@@ -75,7 +75,6 @@ find_install_sh() {
     # 2. Download install.sh through the selected mirror
     local tmpdir
     tmpdir=$(mktemp -d)
-    # trap cleanup in the caller (main) so tmpdir lives until install.sh finishes
 
     local install_sh="${tmpdir}/install.sh"
     local urls=(
@@ -90,11 +89,17 @@ find_install_sh() {
         else
             proxied_url="$raw_url"
         fi
-        info "Trying to download install.sh from ${proxied_url}..."
+        # NOTE: redirect to stderr so these messages don't pollute
+        # the stdout capture in:  INSTALL_SH=$(find_install_sh)
+        info "Trying to download install.sh from ${proxied_url}..." >&2
         if curl -fsSL --connect-timeout 10 --max-time 30 -o "$install_sh" "$proxied_url" 2>/dev/null; then
-            chmod +x "$install_sh"
-            echo "$install_sh"
-            return
+            # Verify the download is a real shell script (not an empty/error page)
+            if [ -s "$install_sh" ] && head -1 "$install_sh" 2>/dev/null | grep -qE '^#!'; then
+                chmod +x "$install_sh"
+                echo "$install_sh"
+                return
+            fi
+            warn "Downloaded file is not a valid shell script, trying next source..." >&2
         fi
     done
 


### PR DESCRIPTION
## Bug

`install-cn.sh` crashes when run via `curl | bash`:

```
bash: [INFO] Trying to download install.sh from https://ghps.cc/...
/tmp/tmp.jLA9qNBmRz/install.sh: No such file or directory
```

## Root Cause

### Bug 1: stdout pollution (install-cn.sh)

`find_install_sh()` used `info()` (writes to **stdout**) for log messages, but the function is called via:

```bash
INSTALL_SH=$(find_install_sh)   # captures ALL stdout
```

The captured `[INFO]` text polluted the path variable, so `bash "$INSTALL_SH"` received a multi-line string instead of a clean file path.

**Fix:** Redirect `info`/`warn` to stderr (`>&2`) inside `find_install_sh()`.

### Bug 2: No download validation (both .sh and .ps1)

CDN mirrors may return HTTP 200 with an HTML error page instead of the actual script. The script tries to execute garbage content.

**Fix:**
- `.sh`: Verify downloaded file is non-empty and starts with `#!` (shebang)
- `.ps1`: Verify first line starts with `<#` (PowerShell comment block)

## Files Changed

- `scripts/install-cn.sh` — stderr redirect + shebang validation
- `scripts/install-cn.ps1` — PowerShell script content validation