### PR TITLE
feat(worktree): base new worktrees on latest remote main branch

### DIFF
--- a/docs/agent/worktree.md
+++ b/docs/agent/worktree.md
@@ -61,8 +61,8 @@ Called automatically from `processMessage` (agent/agent.go) BEFORE `buildPrompt`
 
 1. Check if workDir is a git repo (`GitRepoRoot`)
 2. If session already registered → no-op
-3. If no primary in registry → register as primary (no worktree)
-4. If primary exists → check dirty tree → `git worktree add` → register as peer
+3. Generate unique branch name from session key + timestamp
+4. `createWorktree` → fetch latest remote main branch → `git worktree add --detach <path> <remote/main-branch>` → `git checkout -b <branch>` → register as peer
 
 On success, `tenantSession.SetCurrentDir(worktreePath)` updates CWD before system prompt construction.
 
@@ -100,6 +100,7 @@ Embedded skill documenting worktree workflows: peer detection, SubAgent mode, Be
 
 - Worktree paths MUST be outside the main repo: `{repo}/../.xbot-worktrees/{role}-{instance}/`
 - Branch naming: `agent/{role}/{instance}/{task-hint}`
+- **Every new worktree starts from the latest remote main branch.** `createWorktree` calls `resolveRemoteMainBranch` which (1) fetches from the first remote, (2) detects the default branch via `refs/remotes/<remote>/HEAD` symbolic ref (falls back to checking `main`/`master`), then uses `<remote>/<main-branch>` as the start point. Falls back to local HEAD when no remote is configured.
 - `git worktree add` fails on dirty trees → AutoDetectAndInit returns nil (falls back to main project)
 - Worktree creation is serialized via `GlobalWorktreeRegistry.mu.Lock()` to prevent `.git/worktrees/` lockfile contention
 - **CWD persisted via session_cwd files.** `SetCurrentDir` writes to `~/.xbot/session_cwd/{hash}.txt`. On restart, `loadPersistedCWD` restores the CWD. `SetCWD` (terminal sync from CLI startup) only overwrites when the session has no persisted CWD (new session) or when the persisted directory no longer exists (stale). This ensures user-initiated `Cd` tool paths survive restarts even when they differ from the terminal launch dir.
@@ -136,3 +137,4 @@ Conflict resolution:
 - **Primary registration must NOT check dirty tree.** Only worktree creation requires a clean tree.
 - **AutoDetectAndInit depends on `a.workDir`**, not the session's CWD. For CLI sessions this is the repo root.
 - **`go:embed embed_skills/*`** picks up the worktree skill directory automatically — no code change needed for new embed skills.
+- **`resolveRemoteMainBranch` fetch is best-effort.** Network errors are silently ignored — cached remote refs are used instead. For repos without any remote, `createWorktree` falls back to local HEAD (same as pre-fetch behavior).

--- a/tools/worktree.go
+++ b/tools/worktree.go
@@ -119,7 +119,7 @@ func (t *WorktreeTool) executeInit(ctx *ToolContext, params WorktreeParams) (*To
 	}
 	dirtyWarning := ""
 	if dirty {
-		dirtyWarning = "\n⚠️ 主工作区有未提交更改，worktree 将从 HEAD 创建（不含未提交更改）。"
+		dirtyWarning = "\n⚠️ 主工作区有未提交更改，worktree 将从远程主分支最新状态创建（不含未提交更改）。"
 	}
 
 	branch := generateBranchName(role, instance, params.Task)

--- a/tools/worktree_registry.go
+++ b/tools/worktree_registry.go
@@ -440,9 +440,56 @@ func generateBranchName(role, instance, taskHint string) string {
 	return fmt.Sprintf("agent/%s/%s/%s", sanitize(role), sanitize(instance), task)
 }
 
+// resolveRemoteMainBranch fetches the latest refs from the remote and returns
+// the remote-tracking ref for the default branch (e.g. "origin/master").
+// Returns ("", nil) when the repo has no remote or detection fails — callers
+// should fall back to using local HEAD.
+func resolveRemoteMainBranch(repoPath string) string {
+	// Step 1: detect first remote (typically "origin")
+	remoteCmd := exec.Command("git", "-C", repoPath, "remote")
+	remoteCmd.Env = cleanGitEnv()
+	out, err := remoteCmd.Output()
+	if err != nil || len(strings.TrimSpace(string(out))) == 0 {
+		return "" // no remote configured
+	}
+	remote := strings.Fields(strings.TrimSpace(string(out)))[0]
+
+	// Step 2: fetch latest from remote (best-effort, don't fail on network errors)
+	fetchCmd := exec.Command("git", "-C", repoPath, "fetch", remote)
+	fetchCmd.Env = cleanGitEnv()
+	_ = fetchCmd.Run() // ignore errors — use cached refs if offline
+
+	// Step 3: detect default branch via remote HEAD symref
+	// git symbolic-ref refs/remotes/origin/HEAD → refs/remotes/origin/master
+	symRef := "refs/remotes/" + remote + "/HEAD"
+	symCmd := exec.Command("git", "-C", repoPath, "symbolic-ref", symRef)
+	symCmd.Env = cleanGitEnv()
+	symOut, err := symCmd.Output()
+	if err == nil {
+		ref := strings.TrimSpace(string(symOut))
+		prefix := "refs/remotes/" + remote + "/"
+		if branch := strings.TrimPrefix(ref, prefix); branch != ref && branch != "" {
+			return remote + "/" + branch
+		}
+	}
+
+	// Fallback: try common branch names against cached remote refs
+	for _, candidate := range []string{"main", "master"} {
+		revCmd := exec.Command("git", "-C", repoPath, "rev-parse", "--verify",
+			"refs/remotes/"+remote+"/"+candidate)
+		revCmd.Env = cleanGitEnv()
+		if err := revCmd.Run(); err == nil {
+			return remote + "/" + candidate
+		}
+	}
+
+	return "" // no remote main branch found
+}
+
 // createWorktree creates a git worktree and returns its path and branch.
-// Uses --detach to work even when the main repo has uncommitted changes.
-// The branch is created afterwards in the worktree via checkout -b.
+// The worktree is always based on the latest remote main branch (fetched
+// from origin before creation). Falls back to local HEAD when no remote
+// is configured.
 // Caller must hold WorktreeRegistry.mu or ensure serialization externally.
 func createWorktree(repoPath, branch string) (worktreePath string, err error) {
 	baseDir := worktreeBaseDir(repoPath)
@@ -455,9 +502,17 @@ func createWorktree(repoPath, branch string) (worktreePath string, err error) {
 		return "", fmt.Errorf("create worktree base dir: %w", err)
 	}
 
-	// Step 1: git worktree add --detach (works even on dirty trees)
+	// Resolve start point: prefer latest remote main branch over local HEAD.
+	// This ensures every new worktree starts from the freshest upstream state
+	// rather than a stale local checkout.
+	startPoint := "HEAD"
+	if remoteRef := resolveRemoteMainBranch(repoPath); remoteRef != "" {
+		startPoint = remoteRef
+	}
+
+	// Step 1: git worktree add --detach <path> <startPoint>
 	cmd := exec.Command("git", "-C", repoPath, "worktree", "add",
-		"--detach", worktreePath)
+		"--detach", worktreePath, startPoint)
 	cmd.Env = cleanGitEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/tools/worktree_registry_test.go
+++ b/tools/worktree_registry_test.go
@@ -371,3 +371,95 @@ func TestAutoDetectAndInit_IdempotentInMemory(t *testing.T) {
 	assert.Equal(t, entry1.Branch, entry2.Branch,
 		"second call should return same branch")
 }
+
+// newTestGitRepoWithRemote creates a local git repo ("origin") and a clone
+// of it. Returns (originPath, clonePath). The clone has a remote "origin"
+// pointing to the local origin repo, and the symbolic-ref HEAD is set up.
+func newTestGitRepoWithRemote(t *testing.T) (originPath, clonePath string) {
+	t.Helper()
+	run := func(dir, name string, args ...string) {
+		cmd := exec.Command(name, args...)
+		cmd.Dir = dir
+		cmd.Env = append(cleanGitEnv(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s %v: %s", name, args, out)
+	}
+
+	// Create the "origin" repo
+	originDir := t.TempDir()
+	run(originDir, "git", "init", "-b", "master")
+	_ = os.RemoveAll(filepath.Join(originDir, ".git", "hooks"))
+	run(originDir, "git", "commit", "--allow-empty", "-m", "initial commit on master")
+
+	// Normalize origin path
+	out, err := exec.Command("git", "-C", originDir, "rev-parse", "--show-toplevel").Output()
+	require.NoError(t, err)
+	originPath = strings.TrimSpace(string(out))
+
+	// Clone it — this sets up the remote HEAD symref properly
+	cloneDir := t.TempDir()
+	run("", "git", "clone", originPath, cloneDir)
+	_ = os.RemoveAll(filepath.Join(cloneDir, ".git", "hooks"))
+
+	// Normalize clone path
+	out, err = exec.Command("git", "-C", cloneDir, "rev-parse", "--show-toplevel").Output()
+	require.NoError(t, err)
+	clonePath = strings.TrimSpace(string(out))
+
+	return originPath, clonePath
+}
+
+func TestResolveRemoteMainBranch_WithRemote(t *testing.T) {
+	_, clonePath := newTestGitRepoWithRemote(t)
+
+	// The clone should detect "origin/master"
+	ref := resolveRemoteMainBranch(clonePath)
+	assert.Equal(t, "origin/master", ref, "should detect remote main branch")
+}
+
+func TestResolveRemoteMainBranch_NoRemote(t *testing.T) {
+	repoPath := newTestGitRepo(t)
+
+	// No remote configured — should return ""
+	ref := resolveRemoteMainBranch(repoPath)
+	assert.Equal(t, "", ref, "repo without remote should return empty")
+}
+
+func TestCreateWorktree_BasedOnRemoteMain(t *testing.T) {
+	originPath, clonePath := newTestGitRepoWithRemote(t)
+
+	// Add a commit on master in origin AFTER clone
+	run := func(dir, name string, args ...string) {
+		cmd := exec.Command(name, args...)
+		cmd.Dir = dir
+		cmd.Env = append(cleanGitEnv(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s %v: %s", name, args, out)
+	}
+
+	// Create a file in origin and commit
+	testFile := filepath.Join(originPath, "new-file.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("from remote"), 0644))
+	run(originPath, "git", "add", "new-file.txt")
+	run(originPath, "git", "commit", "-m", "add new-file on remote master")
+
+	// Now create a worktree from the clone — should fetch and get the new commit
+	reg := newTestRegistry()
+	entry, created := autoDetectAndInitInto(clonePath, "cli:repo:session-test", reg)
+	require.NotNil(t, entry, "AutoDetectAndInit should succeed")
+	require.True(t, created, "should create a new worktree")
+
+	// The worktree should contain new-file.txt (fetched from remote)
+	data, err := os.ReadFile(filepath.Join(entry.WorktreeDir, "new-file.txt"))
+	require.NoError(t, err, "worktree should contain file from remote main branch")
+	assert.Equal(t, "from remote", string(data))
+
+	// Clean up
+	reg.CleanupSession("cli:repo:session-test")
+}


### PR DESCRIPTION
## Summary

Every new worktree now starts from the **freshest upstream state** instead of stale local HEAD.

## Problem

Previously `createWorktree` ran `git worktree add --detach <path>` which based new worktrees on local HEAD — potentially stale if master hadn't been pulled recently. Multi-agent worktrees could diverge from upstream from the start.

## Changes

### Core: `resolveRemoteMainBranch()` (`tools/worktree_registry.go`)
3-step detection strategy:
1. `git remote` → find first remote (typically "origin")
2. `git fetch origin` → pull latest refs (best-effort, ignores network errors)
3. `git symbolic-ref refs/remotes/origin/HEAD` → resolve default branch, falling back to probing `main`/`master`

Returns `""` when no remote is configured → falls back to local HEAD (same as before).

### Modified: `createWorktree()`
Now uses `origin/<main-branch>` as the start point:
```
git worktree add --detach <path> origin/master
```

### Tests: 3 new (`tools/worktree_registry_test.go`)
| Test | Validates |
|------|-----------|
| `TestResolveRemoteMainBranch_WithRemote` | Returns `"origin/master"` for cloned repo |
| `TestResolveRemoteMainBranch_NoRemote` | Returns `""` for repo without remotes |
| `TestCreateWorktree_BasedOnRemoteMain` | E2E: adds commit to origin after clone, verifies worktree contains it |

All 17 worktree tests pass, zero regressions.

### Docs: `docs/agent/worktree.md`
Updated Git Constraints, AutoDetectAndInit flow, and Gotchas sections.

## Files Changed (4 files, +156 / -7)
- `tools/worktree_registry.go` — +63 lines
- `tools/worktree_registry_test.go` — +92 lines
- `tools/worktree.go` — message update
- `docs/agent/worktree.md` — doc update
