### PR TITLE
fix(scripts): nightly fixed tag + BASH_SOURCE + skip CDN mirror for API

### DIFF
--- a/scripts/install-cn.sh
+++ b/scripts/install-cn.sh
@@ -88,7 +88,7 @@ fi
 echo ""
 
 # Step 2: Check for local install.sh (cloned repo)
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 if [ -f "${script_dir}/install.sh" ]; then
     INSTALL_SH="${script_dir}/install.sh"
     info "Using local install.sh from repository"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -125,18 +125,9 @@ function Get-LatestVersion {
             }
         }
         "nightly" {
-            try {
-                $releases = Invoke-RestMethod -Uri (Get-GhUrl "https://api.github.com/repos/$REPO/releases?per_page=20") -Headers $headers
-                $nightly = $releases | Where-Object { $_.tag_name -eq 'nightly' -or $_.tag_name -match '^nightly-' } | Select-Object -First 1
-                if ($nightly) { return $nightly.tag_name }
-            } catch {}
-            try {
-                Write-Warn "No nightly found on $REPO, trying fallback $FALLBACK_REPO..."
-                $releases = Invoke-RestMethod -Uri (Get-GhUrl "https://api.github.com/repos/$FALLBACK_REPO/releases?per_page=20") -Headers $headers
-                $nightly = $releases | Where-Object { $_.tag_name -eq 'nightly' -or $_.tag_name -match '^nightly-' } | Select-Object -First 1
-                if ($nightly) { return $nightly.tag_name }
-            } catch {}
-            Write-Err "No nightly release found. Set -Version explicitly."
+            # CI uses a fixed "nightly" tag — no API call needed.
+            # This avoids requiring api.github.com access from China.
+            return "nightly"
         }
         "beta" {
             try {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -49,8 +49,10 @@ $GhMirror = $env:GH_MIRROR
 
 # Proxy a GitHub URL through the configured CDN mirror (if any).
 # If $GhMirror is set, returns "https://${GhMirror}/${Url}"; otherwise returns $Url unchanged.
+# NOTE: CDN mirrors only proxy github.com / raw.githubusercontent.com,
+# NOT api.github.com — API calls always go direct.
 function Get-GhUrl([string]$Url) {
-    if ($GhMirror) { "https://${GhMirror}/${Url}" } else { $Url }
+    if ($GhMirror -and $Url -notmatch 'api\.github\.com') { "https://${GhMirror}/${Url}" } else { $Url }
 }
 
 # Env var fallback for parameters (GitHub Actions uses env vars)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -32,9 +32,11 @@ require_cmd() {
 # Usage: gh_url "https://github.com/ai-pivot/xbot/releases/download/v1.0/file"
 # If GH_MIRROR is set, returns "https://${GH_MIRROR}/https://github.com/..."
 # Otherwise returns the original URL unchanged.
+# NOTE: CDN mirrors only proxy github.com / raw.githubusercontent.com,
+# NOT api.github.com — API calls always go direct.
 gh_url() {
     local url="$1"
-    if [ -n "$GH_MIRROR" ]; then
+    if [ -n "$GH_MIRROR" ] && echo "$url" | grep -qv 'api\.github\.com'; then
         echo "https://${GH_MIRROR}/${url}"
     else
         echo "$url"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,7 +62,8 @@ detect_platform() {
 
 # Resolve version based on channel.
 # For stable: uses /releases/latest (non-prerelease).
-# For nightly: lists releases, finds latest nightly-* tag.
+# For nightly: fixed tag "nightly" (CI overwrites it each merge to master).
+#   Falls back to API lookup only if the fixed tag download fails.
 # For beta: lists releases, finds latest v*-*beta* tag.
 resolve_version() {
     if [ -n "${VERSION:-}" ]; then
@@ -82,10 +83,9 @@ resolve_version() {
             fi
             ;;
         nightly)
-            tag=$(curl -fsSL "$(gh_url "https://api.github.com/repos/${REPO}/releases?per_page=20")" 2>/dev/null | grep '"tag_name"' | grep -oE '"nightly(-[^"]*)?"' | head -1 | tr -d '"')
-            if [ -z "$tag" ]; then
-                tag=$(curl -fsSL "$(gh_url "https://api.github.com/repos/${FALLBACK_REPO}/releases?per_page=20")" 2>/dev/null | grep '"tag_name"' | grep -oE '"nightly(-[^"]*)?"' | head -1 | tr -d '"')
-            fi
+            # CI uses a fixed "nightly" tag — no API call needed.
+            # This avoids requiring api.github.com access from China.
+            tag="nightly"
             ;;
         beta)
             tag=$(curl -fsSL "$(gh_url "https://api.github.com/repos/${REPO}/releases?per_page=20")" 2>/dev/null | grep '"tag_name"' | grep -o '"v[^"]*-beta\.[0-9]*"' | head -1 | tr -d '"')


### PR DESCRIPTION
## Problems

China installer has three remaining issues:

1. **`BASH_SOURCE[0]` unbound** in `curl | bash` mode (`set -u`)
2. **CDN mirrors don't proxy `api.github.com`** — they return garbage for API calls, breaking nightly/beta version resolution
3. **Nightly channel doesn't need API** — CI uses a fixed tag `nightly` (overwritten each merge to master), so `resolve_version` / `Get-LatestVersion` can just return `"nightly"` directly

## Fixes

| File | Change |
|------|--------|
| `install-cn.sh` | `${BASH_SOURCE[0]:-$0}` fallback for pipe mode |
| `install.sh` `gh_url()` | Skip CDN mirror for URLs containing `api.github.com` |
| `install.sh` `resolve_version()` | Nightly channel: return fixed tag `"nightly"` — no API call |
| `install.ps1` `Get-GhUrl` | Same: skip mirror for `api.github.com` |
| `install.ps1` `Get-LatestVersion` | Same: nightly channel returns `"nightly"` directly |

## Testing

```bash
curl -fsSL https://ghfast.top/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.sh | bash
# Select nightly → should download without API call
```