### PR TITLE
fix(scripts): china installer — jq syntax + curl progress + nightly fixed tag + branch testing

### DIFF
--- a/scripts/install-cn.ps1
+++ b/scripts/install-cn.ps1
@@ -29,6 +29,10 @@ $ErrorActionPreference = "Stop"
 # Default mirror candidates — ordered by reliability in mainland China
 $DefaultMirrors = @("ghfast.top", "gh-proxy.com", "ghps.cc")
 
+# GitHub ref (branch/tag) to download install.ps1 from.
+# Defaults to master; can be overridden for testing: $env:GITHUB_REF="my-branch"
+$GitHubRef = if ($env:GITHUB_REF) { $env:GITHUB_REF } else { "master" }
+
 function Write-Info  { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundColor Green }
 function Write-Warn  { param([string]$Msg) Write-Host "[WARN] $Msg" -ForegroundColor Yellow }
 function Write-Err   { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red; throw $Msg }
@@ -97,8 +101,8 @@ if ($scriptDir) {
 if (-not $installScript) {
     $tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-install.ps1"
     $urls = @(
-        "https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.ps1",
-        "https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.ps1"
+        "https://raw.githubusercontent.com/ai-pivot/xbot/${GitHubRef}/scripts/install.ps1",
+        "https://raw.githubusercontent.com/CjiW/xbot/${GitHubRef}/scripts/install.ps1"
     )
 
     # Build mirror list: selected mirror first, then defaults, then direct

--- a/scripts/install-cn.sh
+++ b/scripts/install-cn.sh
@@ -27,7 +27,11 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Mirror configuration — ordered by reliability in mainland China
 # ---------------------------------------------------------------------------
-DEFAULT_MIRRORS="ghfast.top gh-proxy.com ghps.cc"
+REPO="ai-pivot/xbot"
+FALLBACK_REPO="CjiW/xbot"
+# GitHub ref (branch/tag) to download install.sh from.
+# Defaults to master; can be overridden for testing: GITHUB_REF=my-branch
+GITHUB_REF="${GITHUB_REF:-master}"
 
 # ---------------------------------------------------------------------------
 # Colors
@@ -100,8 +104,8 @@ else
     install_sh="${tmpdir}/install.sh"
 
     urls=(
-        "https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh"
-        "https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh"
+        "https://raw.githubusercontent.com/ai-pivot/xbot/${GITHUB_REF}/scripts/install.sh"
+        "https://raw.githubusercontent.com/CjiW/xbot/${GITHUB_REF}/scripts/install.sh"
     )
 
     found=false

--- a/scripts/install-cn.sh
+++ b/scripts/install-cn.sh
@@ -29,9 +29,10 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 REPO="ai-pivot/xbot"
 FALLBACK_REPO="CjiW/xbot"
+DEFAULT_MIRRORS="ghfast.top gh-proxy.com ghps.cc"
 # GitHub ref (branch/tag) to download install.sh from.
-# Defaults to master; can be overridden for testing: GITHUB_REF=my-branch
-GITHUB_REF="${GITHUB_REF:-master}"
+# Defaults to master; can be overridden for testing: --ref=my-branch
+GITHUB_REF="master"
 
 # ---------------------------------------------------------------------------
 # Colors
@@ -84,11 +85,14 @@ echo "  ╚═══════════════════════
 echo ""
 
 # ---------------------------------------------------------------------------
-# Parse --ref argument (for testing non-master branches)
+# Parse --ref argument (for testing non-master branches) and strip it
+# so it doesn't get passed through to install.sh.
 # ---------------------------------------------------------------------------
+PASS_ARGS=()
 for arg in "$@"; do
     case "$arg" in
         --ref=*) GITHUB_REF="${arg#--ref=}" ;;
+        *) PASS_ARGS+=("$arg") ;;
     esac
 done
 
@@ -142,4 +146,4 @@ export GH_MIRROR
 info "Launching installer..."
 echo ""
 
-bash "$INSTALL_SH" "$@"
+bash "$INSTALL_SH" "${PASS_ARGS[@]+"${PASS_ARGS[@]}"}"

--- a/scripts/install-cn.sh
+++ b/scripts/install-cn.sh
@@ -83,6 +83,15 @@ echo "  ║     xbot-cli Installer (China Mirror Mode)      ║"
 echo "  ╚══════════════════════════════════════════════════╝"
 echo ""
 
+# ---------------------------------------------------------------------------
+# Parse --ref argument (for testing non-master branches)
+# ---------------------------------------------------------------------------
+for arg in "$@"; do
+    case "$arg" in
+        --ref=*) GITHUB_REF="${arg#--ref=}" ;;
+    esac
+done
+
 # Step 1: Determine mirror
 if [ -z "${GH_MIRROR:-}" ]; then
     GH_MIRROR="ghfast.top"

--- a/scripts/install-cn.sh
+++ b/scripts/install-cn.sh
@@ -8,9 +8,11 @@
 #
 #   # Option 1: via ghfast.top (default)
 #   curl -fsSL https://ghfast.top/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.sh | bash
+#   source ~/.bashrc  # reload PATH
 #
 #   # Option 2: via gh-proxy.com
 #   curl -fsSL https://gh-proxy.com/https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install-cn.sh | bash
+#   source ~/.bashrc
 #
 #   # Option 3: clone and run locally
 #   git clone https://ghfast.top/https://github.com/ai-pivot/xbot.git

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -332,9 +332,9 @@ download_web_dist() {
     local dist_url="https://github.com/${REPO}/releases/download/${version}/xbot-web-dist.tar.gz"
     info "Downloading Web UI frontend..."
     mkdir -p "$target_dir"
-    if curl -fSL --progress-bar "$(gh_url "$dist_url")" | tar xzf - -C "$target_dir" 2>/dev/null; then
+    if curl -fSL "$(gh_url "$dist_url")" | tar xzf - -C "$target_dir" 2>/dev/null; then
         info "Web UI installed to ${target_dir} ✓"
-    elif curl -fSL --progress-bar "$(gh_url "https://github.com/${FALLBACK_REPO}/releases/download/${version}/xbot-web-dist.tar.gz")" | tar xzf - -C "$target_dir" 2>/dev/null; then
+    elif curl -fSL "$(gh_url "https://github.com/${FALLBACK_REPO}/releases/download/${version}/xbot-web-dist.tar.gz")" | tar xzf - -C "$target_dir" 2>/dev/null; then
         warn "Web UI downloaded from fallback repo ${FALLBACK_REPO}"
         info "Web UI installed to ${target_dir} ✓"
     else
@@ -523,11 +523,11 @@ main() {
     trap 'rm -rf "$TMPDIR"' EXIT
     # Try new repo first; fall back to old repo if release not found
     # (during migration from CjiW/xbot → ai-pivot/xbot)
-    if ! curl -fSL --progress-bar -o "${TMPDIR}/${BINARY}" "$(gh_url "$DOWNLOAD_URL")"; then
+    if ! curl -fSL -o "${TMPDIR}/${BINARY}" "$(gh_url "$DOWNLOAD_URL")"; then
         FALLBACK_URL="https://github.com/${FALLBACK_REPO}/releases/download/${VERSION}/xbot-cli-${PLATFORM}"
         warn "Release not found on ${REPO}, trying fallback ${FALLBACK_REPO}..."
         DOWNLOAD_URL="$FALLBACK_URL"
-        if ! curl -fSL --progress-bar -o "${TMPDIR}/${BINARY}" "$(gh_url "$DOWNLOAD_URL")"; then
+        if ! curl -fSL -o "${TMPDIR}/${BINARY}" "$(gh_url "$DOWNLOAD_URL")"; then
             error "Download failed from both repos. Check the version and platform."
         fi
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -220,7 +220,7 @@ write_config_jq() {
     fi
 
     # Ensure top-level sections exist
-    jq '{server: .server // {}, web: .web // {}, cli: .cli // {}, admin: .admin // {}, agent: .agent // {}} * .' \
+    jq '{server: (.server // {}), web: (.web // {}), cli: (.cli // {}), admin: (.admin // {}), agent: (.agent // {})} * .' \
         "$CONFIG_PATH" > "${CONFIG_PATH}.tmp" && mv "${CONFIG_PATH}.tmp" "$CONFIG_PATH"
 
     _set_if_missing() {
@@ -332,13 +332,9 @@ download_web_dist() {
     local dist_url="https://github.com/${REPO}/releases/download/${version}/xbot-web-dist.tar.gz"
     info "Downloading Web UI frontend..."
     mkdir -p "$target_dir"
-    local curl_progress=""
-    if [ -t 2 ]; then
-        curl_progress="--progress-bar"
-    fi
-    if curl -fSL ${curl_progress} "$(gh_url "$dist_url")" | tar xzf - -C "$target_dir" 2>/dev/null; then
+    if curl -fSL --progress-bar "$(gh_url "$dist_url")" | tar xzf - -C "$target_dir" 2>/dev/null; then
         info "Web UI installed to ${target_dir} ✓"
-    elif curl -fSL ${curl_progress} "$(gh_url "https://github.com/${FALLBACK_REPO}/releases/download/${version}/xbot-web-dist.tar.gz")" | tar xzf - -C "$target_dir" 2>/dev/null; then
+    elif curl -fSL --progress-bar "$(gh_url "https://github.com/${FALLBACK_REPO}/releases/download/${version}/xbot-web-dist.tar.gz")" | tar xzf - -C "$target_dir" 2>/dev/null; then
         warn "Web UI downloaded from fallback repo ${FALLBACK_REPO}"
         info "Web UI installed to ${target_dir} ✓"
     else
@@ -525,17 +521,13 @@ main() {
     info "Downloading..."
     TMPDIR=$(mktemp -d)
     trap 'rm -rf "$TMPDIR"' EXIT
-    local curl_progress=""
-    if [ -t 2 ]; then
-        curl_progress="--progress-bar"
-    fi
     # Try new repo first; fall back to old repo if release not found
     # (during migration from CjiW/xbot → ai-pivot/xbot)
-    if ! curl -fSL ${curl_progress} -o "${TMPDIR}/${BINARY}" "$(gh_url "$DOWNLOAD_URL")" 2>/dev/null; then
+    if ! curl -fSL --progress-bar -o "${TMPDIR}/${BINARY}" "$(gh_url "$DOWNLOAD_URL")"; then
         FALLBACK_URL="https://github.com/${FALLBACK_REPO}/releases/download/${VERSION}/xbot-cli-${PLATFORM}"
         warn "Release not found on ${REPO}, trying fallback ${FALLBACK_REPO}..."
         DOWNLOAD_URL="$FALLBACK_URL"
-        if ! curl -fSL ${curl_progress} -o "${TMPDIR}/${BINARY}" "$(gh_url "$DOWNLOAD_URL")"; then
+        if ! curl -fSL --progress-bar -o "${TMPDIR}/${BINARY}" "$(gh_url "$DOWNLOAD_URL")"; then
             error "Download failed from both repos. Check the version and platform."
         fi
     fi
@@ -620,7 +612,8 @@ main() {
     if ! command -v "$BINARY" >/dev/null 2>&1; then
         echo ""
         warn "Note: ${INSTALL_PATH} is not yet in your shell PATH."
-        warn "  Restart your shell or run: export PATH=\"${INSTALL_PATH}:\$PATH\""
+        warn "  Run: source ~/.bashrc"
+        warn "  Or restart your shell."
     fi
     echo ""
 }


### PR DESCRIPTION
## Fixes (on top of already-merged PRs #88 #89 #91)

| Issue | Fix |
|-------|-----|
| jq `//` syntax error on old jq (1.5) | Wrap in parens: `(.server // {})` |
| curl progress not showing in pipe mode | Remove `--progress-bar`, use curl default |
| `DEFAULT_MIRRORS` unbound variable | Restored accidentally deleted variable |
| `BASH_SOURCE[0]` unbound in `curl\|bash` | `${BASH_SOURCE[0]:-$0}` fallback |
| `--ref=` argument forwarded to install.sh | Strip it before forwarding |
| `GITHUB_REF` env var unreachable in pipe | Added `--ref=` CLI arg for branch testing |

## Files Changed

- `scripts/install.sh` — jq fix, curl progress, nightly fixed tag, gh_url skips API
- `scripts/install.ps1` — Get-GhUrl skips API, nightly fixed tag
- `scripts/install-cn.sh` — DEFAULT_MIRRORS, BASH_SOURCE, --ref arg, source hint
- `scripts/install-cn.ps1` — GITHUB_REF support, download validation

## Testing

```bash
# Direct from branch (bypass CDN cache):
curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/wt/calm-zephyr/20260520-131724/scripts/install-cn.sh | bash -s -- --ref=wt/calm-zephyr/20260520-131724

# Via CDN mirror:
curl -fsSL https://ghfast.top/https://raw.githubusercontent.com/ai-pivot/xbot/wt/calm-zephyr/20260520-131724/scripts/install-cn.sh | bash -s -- --ref=wt/calm-zephyr/20260520-131724
```