### PR TITLE
fix(worktree): pick newest remote across multiple remotes

### DIFF
--- a/tools/worktree_registry.go
+++ b/tools/worktree_registry.go
@@ -440,27 +440,76 @@ func generateBranchName(role, instance, taskHint string) string {
 	return fmt.Sprintf("agent/%s/%s/%s", sanitize(role), sanitize(instance), task)
 }
 
-// resolveRemoteMainBranch fetches the latest refs from the remote and returns
-// the remote-tracking ref for the default branch (e.g. "origin/master").
-// Returns ("", nil) when the repo has no remote or detection fails — callers
-// should fall back to using local HEAD.
+// resolveRemoteMainBranch fetches the latest refs from ALL remotes and returns
+// the remote-tracking ref for the default branch of the most up-to-date remote
+// (e.g. "origin/master"). When multiple remotes exist, picks the one whose
+// default branch has the newest commit timestamp.
+// Returns "" when the repo has no remote or detection fails — callers should
+// fall back to using local HEAD.
 func resolveRemoteMainBranch(repoPath string) string {
-	// Step 1: detect first remote (typically "origin")
+	// Step 1: list all remotes
 	remoteCmd := exec.Command("git", "-C", repoPath, "remote")
 	remoteCmd.Env = cleanGitEnv()
 	out, err := remoteCmd.Output()
 	if err != nil || len(strings.TrimSpace(string(out))) == 0 {
 		return "" // no remote configured
 	}
-	remote := strings.Fields(strings.TrimSpace(string(out)))[0]
+	remotes := strings.Fields(strings.TrimSpace(string(out)))
 
-	// Step 2: fetch latest from remote (best-effort, don't fail on network errors)
-	fetchCmd := exec.Command("git", "-C", repoPath, "fetch", remote)
-	fetchCmd.Env = cleanGitEnv()
-	_ = fetchCmd.Run() // ignore errors — use cached refs if offline
+	// Step 2: fetch all remotes (best-effort, don't fail on network errors)
+	for _, remote := range remotes {
+		fetchCmd := exec.Command("git", "-C", repoPath, "fetch", remote)
+		fetchCmd.Env = cleanGitEnv()
+		_ = fetchCmd.Run() // ignore errors — use cached refs if offline
+	}
 
-	// Step 3: detect default branch via remote HEAD symref
-	// git symbolic-ref refs/remotes/origin/HEAD → refs/remotes/origin/master
+	// Step 3: for each remote, detect its default branch and collect
+	// (remote, branch, commitDate) tuples. Pick the one with the newest commit.
+	// Among equal dates, prefer remote named "origin" as tiebreaker.
+	type remoteCandidate struct {
+		ref        string // e.g. "origin/master"
+		remote     string // e.g. "origin"
+		commitDate string // ISO date for comparison
+	}
+	var best remoteCandidate
+
+	for _, remote := range remotes {
+		branch := detectRemoteDefaultBranch(repoPath, remote)
+		if branch == "" {
+			continue
+		}
+		ref := remote + "/" + branch
+
+		// Get committer date of this remote ref
+		dateCmd := exec.Command("git", "-C", repoPath, "log", "-1", "--format=%cI", ref)
+		dateCmd.Env = cleanGitEnv()
+		dateOut, dateErr := dateCmd.Output()
+		if dateErr != nil {
+			continue
+		}
+		date := strings.TrimSpace(string(dateOut))
+
+		pick := false
+		if best.commitDate == "" {
+			pick = true
+		} else if date > best.commitDate {
+			pick = true
+		} else if date == best.commitDate && remote == "origin" && best.remote != "origin" {
+			pick = true // tiebreaker: prefer "origin"
+		}
+
+		if pick {
+			best = remoteCandidate{ref: ref, remote: remote, commitDate: date}
+		}
+	}
+
+	return best.ref
+}
+
+// detectRemoteDefaultBranch resolves the default branch name for a single remote.
+// Uses symbolic-ref first, then falls back to probing common names.
+func detectRemoteDefaultBranch(repoPath, remote string) string {
+	// Try symbolic-ref: refs/remotes/origin/HEAD → refs/remotes/origin/master
 	symRef := "refs/remotes/" + remote + "/HEAD"
 	symCmd := exec.Command("git", "-C", repoPath, "symbolic-ref", symRef)
 	symCmd.Env = cleanGitEnv()
@@ -469,7 +518,7 @@ func resolveRemoteMainBranch(repoPath string) string {
 		ref := strings.TrimSpace(string(symOut))
 		prefix := "refs/remotes/" + remote + "/"
 		if branch := strings.TrimPrefix(ref, prefix); branch != ref && branch != "" {
-			return remote + "/" + branch
+			return branch
 		}
 	}
 
@@ -479,11 +528,11 @@ func resolveRemoteMainBranch(repoPath string) string {
 			"refs/remotes/"+remote+"/"+candidate)
 		revCmd.Env = cleanGitEnv()
 		if err := revCmd.Run(); err == nil {
-			return remote + "/" + candidate
+			return candidate
 		}
 	}
 
-	return "" // no remote main branch found
+	return ""
 }
 
 // createWorktree creates a git worktree and returns its path and branch.

--- a/tools/worktree_registry_test.go
+++ b/tools/worktree_registry_test.go
@@ -463,3 +463,68 @@ func TestCreateWorktree_BasedOnRemoteMain(t *testing.T) {
 	// Clean up
 	reg.CleanupSession("cli:repo:session-test")
 }
+
+// TestResolveRemoteMainBranch_PicksNewestMultiRemote verifies that when a repo
+// has multiple remotes (e.g. "gl" and "origin"), resolveRemoteMainBranch picks
+// the remote whose default branch has the newest commit — not just the first
+// one alphabetically.
+func TestResolveRemoteMainBranch_PicksNewestMultiRemote(t *testing.T) {
+	run := func(dir, name string, args ...string) {
+		cmd := exec.Command(name, args...)
+		cmd.Dir = dir
+		cmd.Env = append(cleanGitEnv(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s %v: %s", name, args, out)
+	}
+
+	// Create two bare "origin" repos
+	upstreamDir := t.TempDir()
+	run("", "git", "init", "--bare", upstreamDir)
+	// Create a working repo, push initial commit, then clone twice
+	workDir := t.TempDir()
+	run(workDir, "git", "clone", upstreamDir, ".")
+	_ = os.RemoveAll(filepath.Join(workDir, ".git", "hooks"))
+	run(workDir, "git", "commit", "--allow-empty", "-m", "init")
+	run(workDir, "git", "push", "origin", "master")
+	// Set HEAD so symbolic-ref works
+	run(upstreamDir, "git", "symbolic-ref", "HEAD", "refs/heads/master")
+
+	// Now create the test clone
+	cloneDir := t.TempDir()
+	run("", "git", "clone", upstreamDir, cloneDir)
+	_ = os.RemoveAll(filepath.Join(cloneDir, ".git", "hooks"))
+
+	// Normalize
+	out, err := exec.Command("git", "-C", cloneDir, "rev-parse", "--show-toplevel").Output()
+	require.NoError(t, err)
+	clonePath := strings.TrimSpace(string(out))
+
+	// Add a second remote (simulating "gl") that points to a STALE bare repo
+	staleDir := t.TempDir()
+	run("", "git", "init", "--bare", staleDir)
+	run(staleDir, "git", "symbolic-ref", "HEAD", "refs/heads/master")
+	// Push the initial commit to the stale remote too
+	run(clonePath, "git", "remote", "add", "gl", staleDir)
+	run(clonePath, "git", "push", "gl", "master")
+
+	// Now add a NEW commit on the origin remote (simulate upstream advancing)
+	run(workDir, "git", "commit", "--allow-empty", "-m", "newer commit on origin")
+	run(workDir, "git", "push", "origin", "master")
+
+	// Fetch origin (not gl) so origin has the newer commit
+	run(clonePath, "git", "fetch", "origin")
+
+	// Verify: gl/master is older, origin/master is newer
+	glDate, _ := exec.Command("git", "-C", clonePath, "log", "-1", "--format=%cI", "gl/master").Output()
+	originDate, _ := exec.Command("git", "-C", clonePath, "log", "-1", "--format=%cI", "origin/master").Output()
+	assert.True(t, strings.TrimSpace(string(originDate)) >= strings.TrimSpace(string(glDate)),
+		"origin/master should be at least as new as gl/master")
+
+	// resolveRemoteMainBranch should pick origin/master (newer), NOT gl/master
+	ref := resolveRemoteMainBranch(clonePath)
+	assert.Equal(t, "origin/master", ref,
+		"should pick the remote with the newest default branch commit, not first alphabetically")
+}


### PR DESCRIPTION
## Summary

Fix critical bug: `resolveRemoteMainBranch` picked the first remote alphabetically (`gl` before `origin`), causing worktrees to be based on a stale upstream hundreds of commits behind.

## Root Cause

`git remote` returns remotes in alphabetical order. The code used `strings.Fields(...)[0]` which picked `gl` instead of `origin`. In the xbot repo, `gl/master` was 178 commits behind `origin/master`.

## Fix

- Fetch **all** remotes (not just the first one)
- Compare default branch commit dates (`%cI`) across all remotes, pick the **newest**
- Tiebreaker: among equal dates, prefer remote named `origin`
- Extract `detectRemoteDefaultBranch()` as reusable helper per remote

## Test

| Test | Validates |
|------|-----------|
| `TestResolveRemoteMainBranch_PicksNewestMultiRemote` | Repo with `gl` (stale) + `origin` (fresh) → picks `origin/master` |
| All 17 existing worktree tests | Zero regressions |

## Files Changed (2 files, +129 / -15)
- `tools/worktree_registry.go` — multi-remote comparison logic
- `tools/worktree_registry_test.go` — new test covering the bug
