### PR TITLE
refactor(settings): unified GetEffectiveSetting — prevent user settings being ignored

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -13,8 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"xbot/config"
-
 	"xbot/agent/hooks"
 	"xbot/bus"
 	"xbot/channel"
@@ -2317,10 +2315,18 @@ func (a *Agent) buildPrompt(ctx context.Context, msg bus.InboundMessage, tenantS
 	// Peer awareness / auto worktree: register this session for collaboration.
 	// When auto_worktree is enabled, every session gets its own git worktree (no primary).
 	// When disabled, RegisterPeer provides lightweight in-memory session tracking.
-	// Uses config.json (master authority) — changes take effect on restart.
+	// Reads from user_settings DB (per-user scope) — same source as engine_wire.go
+	// and the /settings panel. No fallback to global config.json.
 	// AutoDetectAndInit is idempotent: returns existing entry if session already registered.
-	cfgPath := filepath.Join(a.xbotHome, "config.json")
-	if cfg := config.LoadFromFile(cfgPath); cfg != nil && cfg.Agent.Experimental.AutoWorktree {
+	autoWorktree := false
+	if a.settingsSvc != nil {
+		if vals, err := a.settingsSvc.GetSettings(msg.Channel, msg.SenderID); err == nil {
+			if v, ok := vals["auto_worktree"]; ok {
+				autoWorktree = strings.EqualFold(v, "true") || v == "1"
+			}
+		}
+	}
+	if autoWorktree {
 		if tools.GlobalWorktreeRegistry.GetBySession(sessKey) == nil {
 			if entry, created := tools.AutoDetectAndInit(detectDir, sessKey); entry != nil && entry.WorktreeDir != "" {
 				// Only override CWD for brand new worktrees (first creation).

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -231,9 +231,6 @@ type Agent struct {
 	// SubAgent 深度控制
 	maxSubAgentDepth int
 
-	// autoWorktree enables automatic git worktree creation for peer sessions.
-	autoWorktree bool
-
 	// Cron service and scheduler
 	cronSvc *sqlite.CronService
 	cronSch *cron.Scheduler
@@ -1030,7 +1027,6 @@ func New(cfg Config) (*Agent, error) {
 		directWorkspace:    cfg.DirectWorkspace,
 		globalSkillDirs:    resolveGlobalSkillsDirs(cfg.SkillsDir),
 		maxSubAgentDepth:   cfg.MaxSubAgentDepth,
-		autoWorktree:       cfg.AutoWorktree,
 		// NOTE: .xbot is the server-side config directory; not accessible in user sandbox
 		agentsDir: filepath.Join(cfg.WorkDir, ".xbot", "agents"),
 		xbotHome:  cfg.XbotHome,
@@ -2315,18 +2311,9 @@ func (a *Agent) buildPrompt(ctx context.Context, msg bus.InboundMessage, tenantS
 	// Peer awareness / auto worktree: register this session for collaboration.
 	// When auto_worktree is enabled, every session gets its own git worktree (no primary).
 	// When disabled, RegisterPeer provides lightweight in-memory session tracking.
-	// Reads from user_settings DB (per-user scope) — same source as engine_wire.go
-	// and the /settings panel. No fallback to global config.json.
+	// Uses GetEffectiveSetting — the single correct read path for user-scoped settings.
 	// AutoDetectAndInit is idempotent: returns existing entry if session already registered.
-	autoWorktree := false
-	if a.settingsSvc != nil {
-		if vals, err := a.settingsSvc.GetSettings(msg.Channel, msg.SenderID); err == nil {
-			if v, ok := vals["auto_worktree"]; ok {
-				autoWorktree = strings.EqualFold(v, "true") || v == "1"
-			}
-		}
-	}
-	if autoWorktree {
+	if a.settingsSvc.GetEffectiveSettingBool(msg.Channel, msg.SenderID, "auto_worktree") {
 		if tools.GlobalWorktreeRegistry.GetBySession(sessKey) == nil {
 			if entry, created := tools.AutoDetectAndInit(detectDir, sessKey); entry != nil && entry.WorktreeDir != "" {
 				// Only override CWD for brand new worktrees (first creation).

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -141,8 +141,9 @@ func (a *Agent) buildBaseRunConfig(
 		MaxIterations:   a.getMaxIterations(),
 		MaxOutputTokens: a.llmFactory.GetMaxOutputTokens(senderID),
 
-		// Auto worktree: read from user_settings dynamically so runtime changes
-		// take effect without restart. Fallback to startup config value.
+		// Auto worktree: read from user_settings DB (per-user scope).
+		// Same source as /settings panel and agent.go buildPrompt.
+		// No fallback to global config — auto_worktree is a user-level setting.
 		AutoWorktreeEnabled: func() bool {
 			if a.settingsSvc != nil {
 				if vals, err := a.settingsSvc.GetSettings(channel, senderID); err == nil {
@@ -151,7 +152,7 @@ func (a *Agent) buildBaseRunConfig(
 					}
 				}
 			}
-			return a.autoWorktree
+			return false
 		}(),
 
 		// Session

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -141,19 +141,9 @@ func (a *Agent) buildBaseRunConfig(
 		MaxIterations:   a.getMaxIterations(),
 		MaxOutputTokens: a.llmFactory.GetMaxOutputTokens(senderID),
 
-		// Auto worktree: read from user_settings DB (per-user scope).
-		// Same source as /settings panel and agent.go buildPrompt.
-		// No fallback to global config — auto_worktree is a user-level setting.
-		AutoWorktreeEnabled: func() bool {
-			if a.settingsSvc != nil {
-				if vals, err := a.settingsSvc.GetSettings(channel, senderID); err == nil {
-					if v, ok := vals["auto_worktree"]; ok {
-						return strings.EqualFold(v, "true") || v == "1"
-					}
-				}
-			}
-			return false
-		}(),
+		// Auto worktree: read via GetEffectiveSetting — the single correct
+		// read path for user-scoped settings. Same source as /settings panel.
+		AutoWorktreeEnabled: a.settingsSvc.GetEffectiveSettingBool(channel, senderID, "auto_worktree"),
 
 		// Session
 		SessionKey: sessionKey,

--- a/agent/setting_runtime.go
+++ b/agent/setting_runtime.go
@@ -87,12 +87,6 @@ var SettingHandlerRegistry = map[string]SettingHandler{
 		ApplyConfig: func(cfg *config.Config, value string) {
 			cfg.Agent.Experimental.AutoWorktree = strings.ToLower(value) == "true"
 		},
-		ApplyAgent: func(ag *Agent, senderID, chatID, value string) {
-			if ag == nil {
-				return
-			}
-			ag.autoWorktree = channel.ParseSettingBool(value)
-		},
 	},
 
 	// --- Runtime state settings (config + agent side-effects) ---

--- a/agent/settings.go
+++ b/agent/settings.go
@@ -61,6 +61,43 @@ func (s *SettingsService) GetPermUsers(channelName, senderID string) *PermUsersC
 	return config
 }
 
+// GetEffectiveSetting returns the current effective value for a setting key.
+// This is the SINGLE correct way to read a user-scoped setting from agent code.
+//
+// Resolution order:
+//  1. user_settings DB (settingsSvc) — the live per-user value
+//  2. DefaultValue from AllSettingDefs schema — the declared default
+//
+// No fallback to config.json, Agent struct fields, or any other source.
+// This ensures the read path matches the write path (/settings panel → DB).
+func (s *SettingsService) GetEffectiveSetting(channelName, senderID, key string) string {
+	if s != nil && s.store != nil {
+		if vals, err := s.store.Get(channelName, senderID); err == nil {
+			if v, ok := vals[key]; ok {
+				return v
+			}
+		}
+	}
+	return channel.GetSettingDefaultValue(key)
+}
+
+// GetEffectiveSettingBool returns the effective value parsed as bool.
+// Returns false for "", "false", "0", "no" (case-insensitive). All other values → true.
+func (s *SettingsService) GetEffectiveSettingBool(channelName, senderID, key string) bool {
+	v := s.GetEffectiveSetting(channelName, senderID, key)
+	return ParseSettingBool(v)
+}
+
+// ParseSettingBool parses a setting value as bool.
+func ParseSettingBool(v string) bool {
+	switch strings.ToLower(v) {
+	case "", "false", "0", "no":
+		return false
+	default:
+		return true
+	}
+}
+
 // SetSetting sets a single setting value.
 func (s *SettingsService) SetSetting(channelName, senderID, key, value string) error {
 	if s == nil || s.store == nil {

--- a/agent/settings_test.go
+++ b/agent/settings_test.go
@@ -88,3 +88,93 @@ func TestSettingsServiceSubmitSettingsTextMode(t *testing.T) {
 		t.Error("expected error for invalid format")
 	}
 }
+
+func TestGetEffectiveSetting(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	store := sqlite.NewUserSettingsService(db)
+	svc := NewSettingsService(store)
+
+	// Case 1: No value in DB → returns schema default
+	got := svc.GetEffectiveSetting("cli", "user1", "auto_worktree")
+	if got != "false" {
+		t.Errorf("expected default 'false', got %q", got)
+	}
+
+	// Case 2: Value set in DB → returns DB value
+	if err := svc.SetSetting("cli", "user1", "auto_worktree", "true"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got = svc.GetEffectiveSetting("cli", "user1", "auto_worktree")
+	if got != "true" {
+		t.Errorf("expected 'true', got %q", got)
+	}
+
+	// Case 3: Different user → no DB value, returns default
+	got = svc.GetEffectiveSetting("cli", "user2", "auto_worktree")
+	if got != "false" {
+		t.Errorf("expected default 'false' for user2, got %q", got)
+	}
+
+	// Case 4: Unknown key → returns "" (no default)
+	got = svc.GetEffectiveSetting("cli", "user1", "nonexistent_key_xyz")
+	if got != "" {
+		t.Errorf("expected empty for unknown key, got %q", got)
+	}
+}
+
+func TestGetEffectiveSettingBool(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	store := sqlite.NewUserSettingsService(db)
+	svc := NewSettingsService(store)
+
+	// Default: "false" → bool false
+	if svc.GetEffectiveSettingBool("cli", "user1", "auto_worktree") {
+		t.Error("expected false for default auto_worktree")
+	}
+
+	// Set to "true"
+	svc.SetSetting("cli", "user1", "auto_worktree", "true")
+	if !svc.GetEffectiveSettingBool("cli", "user1", "auto_worktree") {
+		t.Error("expected true after setting auto_worktree=true")
+	}
+
+	// Various falsy values
+	for _, v := range []string{"", "false", "False", "0", "no"} {
+		svc.SetSetting("cli", "user1", "auto_worktree", v)
+		if svc.GetEffectiveSettingBool("cli", "user1", "auto_worktree") {
+			t.Errorf("expected false for value %q", v)
+		}
+	}
+
+	// Truthy: "1"
+	svc.SetSetting("cli", "user1", "auto_worktree", "1")
+	if !svc.GetEffectiveSettingBool("cli", "user1", "auto_worktree") {
+		t.Error("expected true for value '1'")
+	}
+}
+
+func TestGetEffectiveSetting_NilService(t *testing.T) {
+	var svc *SettingsService
+	// Nil service should return schema default, not panic
+	got := svc.GetEffectiveSetting("cli", "user1", "auto_worktree")
+	if got != "false" {
+		t.Errorf("expected default 'false' from nil service, got %q", got)
+	}
+	if svc.GetEffectiveSettingBool("cli", "user1", "auto_worktree") {
+		t.Error("expected false from nil service")
+	}
+}

--- a/channel/setting_keys.go
+++ b/channel/setting_keys.go
@@ -106,7 +106,6 @@ var AllSettingDefs = []SettingDef{
 	{Key: "max_concurrency", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Max parallel LLM calls", ValidValues: "1-100", DefaultValue: "5"},
 	{Key: "max_context_tokens", Scope: ScopeSubscription, Source: SourceLLMConfig, Runtime: true, Permission: PermPersistent, AIDescription: "Target context window size for compression (per subscription+model)", ValidValues: "any positive integer"},
 	{Key: "enable_auto_compress", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Legacy alias for context_mode=auto (deprecated)", ValidValues: "true|false"},
-	{Key: "auto_worktree", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Automatically create git worktree for each session in the same repo", ValidValues: "true|false", DefaultValue: "false"},
 	{Key: "runner_server", Scope: ScopeUser, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Remote sandbox server address", ValidValues: "host:port or URL"},
 	{Key: "runner_token", Scope: ScopeUser, Source: SourceUserDB, Permission: PermManual, Sensitive: true, AIDescription: "Auth token for remote runner (masked)", ValidValues: "any valid token"},
 	{Key: "runner_workspace", Scope: ScopeUser, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Workspace dir on remote runner", ValidValues: "any valid path"},
@@ -145,6 +144,24 @@ func init() {
 func GetSettingDef(key string) (SettingDef, bool) {
 	d, ok := allSettingDefsMap[key]
 	return d, ok
+}
+
+// GetSettingDefaultValue returns the DefaultValue for a key from AllSettingDefs.
+// Returns "" for unknown keys or keys with no default.
+func GetSettingDefaultValue(key string) string {
+	if d, ok := allSettingDefsMap[key]; ok {
+		return d.DefaultValue
+	}
+	return ""
+}
+
+// IsUserDBSetting returns true if the key's Source is SourceUserDB
+// (stored in user_settings table, readable via settingsSvc).
+func IsUserDBSetting(key string) bool {
+	if d, ok := allSettingDefsMap[key]; ok {
+		return d.Source == SourceUserDB
+	}
+	return false
 }
 
 // SettingScopeOf returns the scope of a setting key. Returns ("unknown") for unrecognized keys.

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -6120,12 +6121,21 @@ func TestWidgetRegistry_RenderZoneForContext_EmptyZone(t *testing.T) {
 func TestScriptPlugin_OnWorkDirChanged_PendingDirs(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	script := filepath.Join(dir, "test.sh")
-	os.WriteFile(script, []byte("#!/bin/bash\necho \"ok|test\"\n"), 0o755)
+
+	var entry string
+	if runtime.GOOS == "windows" {
+		script := filepath.Join(dir, "test.bat")
+		os.WriteFile(script, []byte("@echo ok|test"), 0o644)
+		entry = script
+	} else {
+		script := filepath.Join(dir, "test.sh")
+		os.WriteFile(script, []byte("#!/bin/sh\necho \"ok|test\"\n"), 0o755)
+		entry = "sh " + script
+	}
 
 	m := testManifest()
 	m.Runtime = "script"
-	m.Entry = "bash test.sh"
+	m.Entry = entry
 	m.Contributes = &PluginContributes{
 		UI: []UISlotContribution{
 			{ID: "w1", Slot: "infoBar", Priority: 10},

--- a/plugin/script_runtime_test.go
+++ b/plugin/script_runtime_test.go
@@ -389,18 +389,29 @@ func TestScriptPlugin_EnvInjection(t *testing.T) {
 	dir := t.TempDir()
 	workDir := t.TempDir() // must exist — cmd.Dir = workDir
 
-	// Write a small script that prints env vars injected by runScript
-	script := filepath.Join(dir, "env.sh")
-	os.WriteFile(script, []byte(`#!/bin/bash
+	// Write a script that prints env vars injected by runScript.
+	// Cross-platform: Windows uses .bat with %VAR% syntax, Unix uses /bin/sh.
+	var scriptPath, entry string
+	if runtime.GOOS == "windows" {
+		scriptPath = filepath.Join(dir, "env.bat")
+		os.WriteFile(scriptPath, []byte(
+			"@echo WORKDIR=%XBOT_WORK_DIR% TOOL=%XBOT_TOOL_NAME% OUTPUT=%XBOT_TOOL_OUTPUT% INPUT=%XBOT_TOOL_INPUT%",
+		), 0o644)
+		entry = scriptPath
+	} else {
+		scriptPath = filepath.Join(dir, "env.sh")
+		os.WriteFile(scriptPath, []byte(`#!/bin/sh
 echo "WORKDIR=$XBOT_WORK_DIR TOOL=$XBOT_TOOL_NAME OUTPUT=$XBOT_TOOL_OUTPUT INPUT=$XBOT_TOOL_INPUT"
 `), 0o755)
+		entry = "sh " + scriptPath
+	}
 
 	m := PluginManifest{
 		ID:          "com.test.env",
 		Name:        "env-test",
 		Version:     "1.0.0",
 		Runtime:     RuntimeScript,
-		Entry:       "bash env.sh",
+		Entry:       entry,
 		Permissions: []string{PermUIContribute},
 		Contributes: &PluginContributes{
 			UI: []UISlotContribution{


### PR DESCRIPTION
## Summary

Fix critical bug + architectural refactor: user-scoped settings were read from wrong sources, causing settings toggled in `/settings` to have no effect.

## Root Cause

There were **3 independent ways** to read a setting value, and consumers had to know which source to use:

| Read Pattern | Source | Used By |
|---|---|---|
| `config.LoadFromFile()` | config.json | ❌ agent.go buildPrompt (old) |
| `a.someField` (Agent struct) | In-memory cache | engine_wire.go (old fallback) |
| `settingsSvc.GetSettings()` | user_settings DB | ✅ Correct |

When consumers picked the wrong source (e.g. `auto_worktree` read from config.json), the `/settings` panel wrote to DB but the agent kept reading from config.json → setting appeared stuck.

## Fix: Unified Read Path

### `SettingsService.GetEffectiveSetting(channel, senderID, key)` — the SINGLE correct way to read user-scoped settings

```
Read: user_settings DB → schema default from AllSettingDefs
Never: config.json, Agent struct fields, or any other source
```

### `SettingsService.GetEffectiveSettingBool(channel, senderID, key)` — bool convenience wrapper

## Changes (6 files, +150 / -35)

| File | Change |
|------|--------|
| `agent/settings.go` | Add `GetEffectiveSetting`, `GetEffectiveSettingBool`, `ParseSettingBool` |
| `agent/settings_test.go` | 3 new tests: effective value, bool parsing, nil service safety |
| `agent/agent.go` | buildPrompt: use `GetEffectiveSettingBool("auto_worktree")`; remove dead `a.autoWorktree` field |
| `agent/engine_wire.go` | ToolContext: use `GetEffectiveSettingBool("auto_worktree")`; remove IIFE fallback |
| `agent/setting_runtime.go` | Remove dead `ApplyAgent` handler for `auto_worktree` (wrote to removed field) |
| `channel/setting_keys.go` | Add `GetSettingDefaultValue`, `IsUserDBSetting`; remove duplicate `auto_worktree` entry |

## Audit Results (other user-scoped settings)

| Key | Read Source | Risk |
|-----|-----------|------|
| `auto_worktree` | ✅ `GetEffectiveSettingBool` | **Fixed** |
| `language` | ✅ `settingsSvc` directly | Clean |
| `enable_stream` | ✅ `settingsSvc` directly | Clean |
| `enable_masking` | ✅ `settingsSvc` directly | Clean |
| `tavily_api_key` | ✅ `settingsSvc` + config fallback | Clean |
| `max_iterations` | ⚠️ Cached `a.maxIterations` + write-back | Medium (works, but fragile) |
| `max_concurrency` | ⚠️ Cached `a.maxConcurrency` + write-back | Medium (works, but fragile) |
| `compression_threshold` | ⚠️ Cached `a.contextManagerConfig` + write-back | Medium (works, but fragile) |
| `context_mode` | ⚠️ Cached `a.contextManagerConfig` + write-back | Medium (works, but fragile) |

The cached+write-back settings work correctly today because `ApplyRuntimeSetting` keeps them in sync. They're architecturally fragile (new code paths bypassing write-back = stale values) but not broken. Can be migrated to `GetEffectiveSetting` incrementally.

All pre-commit checks passed (gofmt, lint, build, test).
