### PR TITLE
fix: sort MCP tool required array for deterministic prefix caching

### DIFF
--- a/llm/openai.go
+++ b/llm/openai.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -523,6 +524,11 @@ func toOpenAITools(tools []ToolDefinition) []openai.ChatCompletionToolUnionParam
 				required = append(required, p.Name)
 			}
 		}
+		// Sort required array for deterministic JSON serialization.
+		// MCP tool parameters come from map iteration (non-deterministic order),
+		// which produces different "required" arrays across requests,
+		// breaking API-side prefix caching.
+		slices.Sort(required)
 		params := map[string]any{
 			"type":       "object",
 			"properties": properties,


### PR DESCRIPTION
## Problem

MCP tool `required` array has non-deterministic ordering across requests, causing API-side prefix cache miss rate to spike (cache rate dropped from ~80%+ to ~32%).

## Root Cause

MCP tool parameters are derived from JSON Schema `properties` (`map[string]any`), which has non-deterministic iteration order in Go. The `required` array (a `[]string` slice) gets built from map iteration, producing different orderings each time `toOpenAITools()` is called.

API-side prefix caching (GLM, DeepSeek, etc.) matches cached prefixes by exact byte comparison. When the `tools` JSON parameter differs between requests, the entire prefix cache is invalidated.

Built-in tools are unaffected because their `Parameters()` returns a hardcoded `[]ToolParam` slice with fixed source-level ordering.

## Fix

Sort the `required` array alphabetically in `toOpenAITools()` via `slices.Sort(required)` — one line change.

## Verification

Before fix: dump diff showed 3 MCP tools (#46-#48 from `zai-mcp-server`) with different `required` orderings between consecutive requests.

After fix: dump diff showed 0 tool differences across consecutive requests. Cache rate recovered to normal levels.

```
diff: "required": ["image_source", "prompt"]  vs  "required": ["prompt", "image_source"]
```

## Files Changed

- `llm/openai.go` — added `slices.Sort(required)` in `toOpenAITools()`