### PR TITLE
feat(tui): add LaTeX math formula rendering for terminal display

### DIFF
--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -1866,6 +1866,7 @@ func (m *cliModel) renderMessage(msg *cliMessage) string {
 		preprocessed := msg.content
 		if msg.role == "assistant" {
 			preprocessed = renderMermaidBlocks(msg.content, m.chatWidth()-4)
+			preprocessed = renderMathBlocks(preprocessed, m.chatWidth()-4)
 		}
 		var err error
 		rendered, err = m.renderer.Render(preprocessed)

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -186,6 +186,8 @@ func hardWrapRunes(line string, maxW int) string {
 }
 
 // hardWrapSingleLine wraps a single line (no \n) at maxW columns.
+// It prefers breaking at word boundaries (spaces) and CJK character boundaries
+// over hard-cutting in the middle of a word. ANSI escape sequences are preserved.
 func hardWrapSingleLine(line string, maxW int) string {
 	if maxW <= 0 {
 		return line
@@ -193,62 +195,164 @@ func hardWrapSingleLine(line string, maxW int) string {
 	if lipgloss.Width(line) <= maxW {
 		return line
 	}
+
+	segs := tokenizeLine(line)
+
 	var lines []string
 	var buf strings.Builder
 	w := 0
-	inEscape := false
 
-	// Track active ANSI state so we can replay it on continuation lines.
-	// We record all escape sequences since the last SGR reset (\x1b[0m).
-	var ansiState strings.Builder // accumulated SGR sequences since last reset
-	haveAnsiState := false
-
-	for _, r := range line {
-		if r == '\x1b' {
-			inEscape = true
-			buf.WriteRune(r)
-			ansiState.WriteRune(r)
-			continue
-		}
-		if inEscape {
-			buf.WriteRune(r)
-			ansiState.WriteRune(r)
-			if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
-				inEscape = false
-				// Detect SGR reset: \x1b[0m or \x1b[m
-				s := ansiState.String()
-				if strings.HasSuffix(s, "[0m") || strings.HasSuffix(s, "[m") {
-					ansiState.Reset()
-					haveAnsiState = false
-				} else if strings.HasSuffix(s, "m") {
-					haveAnsiState = true
+	for _, seg := range segs {
+		switch seg.kind {
+		case segANSI:
+			buf.WriteString(seg.s)
+		case segSpace:
+			// Spaces are treated like regular characters — hard-break at column boundary
+			for _, r := range seg.s {
+				rw := ansi.StringWidth(string(r))
+				if w+rw > maxW && buf.Len() > 0 {
+					lines = append(lines, buf.String())
+					buf.Reset()
+					w = 0
+					if seg.ansiState != "" {
+						buf.WriteString(seg.ansiState)
+					}
 				}
+				buf.WriteRune(r)
+				w += rw
 			}
-			continue
-		}
-		rw := ansi.StringWidth(string(r))
-		// Safety: zero-width runes don't block wrapping.
-		if rw == 0 {
-			buf.WriteRune(r)
-			continue
-		}
-
-		if w+rw > maxW {
-			// Hard break at column boundary
-			lines = append(lines, buf.String())
-			buf.Reset()
-			w = 0
-			if haveAnsiState {
-				buf.WriteString(ansiState.String())
+		case segCJK:
+			for _, r := range seg.s {
+				rw := ansi.StringWidth(string(r))
+				if w+rw > maxW && buf.Len() > 0 {
+					lines = append(lines, buf.String())
+					buf.Reset()
+					w = 0
+					if seg.ansiState != "" {
+						buf.WriteString(seg.ansiState)
+					}
+				}
+				buf.WriteRune(r)
+				w += rw
+			}
+		default: // segOther: latin, digits, punctuation — hard-break rune by rune
+			for _, r := range seg.s {
+				rw := ansi.StringWidth(string(r))
+				if w+rw > maxW && buf.Len() > 0 {
+					lines = append(lines, buf.String())
+					buf.Reset()
+					w = 0
+					if seg.ansiState != "" {
+						buf.WriteString(seg.ansiState)
+					}
+				}
+				buf.WriteRune(r)
+				w += rw
 			}
 		}
-		buf.WriteRune(r)
-		w += rw
 	}
 	if buf.Len() > 0 {
 		lines = append(lines, buf.String())
 	}
 	return strings.Join(lines, "\n")
+}
+
+// --- Line segment tokenizer for smart wrapping ---
+
+type segKind int
+
+const (
+	segANSI  segKind = iota // ANSI escape sequence (0 display width)
+	segSpace                // whitespace (spaces, tabs)
+	segCJK                  // CJK ideograph/hangul/kana — can break anywhere
+	segOther                // Latin, digits, punctuation — keep together
+)
+
+type seg struct {
+	kind      segKind
+	s         string
+	w         int // display width
+	ansiState string
+}
+
+// isCJKRune returns true for runes that allow line breaks on either side.
+func isCJKRune(r rune) bool {
+	return (r >= 0x4E00 && r <= 0x9FFF) || // Han
+		(r >= 0x3400 && r <= 0x4DBF) || // Extension A
+		(r >= 0x20000 && r <= 0x2A6DF) || // Extension B
+		(r >= 0x3040 && r <= 0x309F) || // Hiragana
+		(r >= 0x30A0 && r <= 0x30FF) || // Katakana
+		(r >= 0xAC00 && r <= 0xD7AF) || // Hangul syllables
+		(r >= 0x1100 && r <= 0x11FF) || // Hangul Jamo
+		(r >= 0xF900 && r <= 0xFAFF) || // CJK compat ideographs
+		(r >= 0xFF01 && r <= 0xFF60) || // Fullwidth forms
+		(r >= 0x3000 && r <= 0x303F) // CJK punctuation
+}
+
+// tokenizeLine splits a line into typed segments for smart wrapping.
+func tokenizeLine(line string) []seg {
+	var segs []seg
+	var cur seg
+	var ansiState strings.Builder
+	haveAnsi := false
+	inEscape := false
+
+	flush := func() {
+		if len(cur.s) > 0 {
+			cur.w = ansi.StringWidth(cur.s)
+			if haveAnsi {
+				cur.ansiState = ansiState.String()
+			}
+			segs = append(segs, cur)
+			cur = seg{}
+		}
+	}
+
+	classify := func(r rune) segKind {
+		if r == ' ' || r == '\t' {
+			return segSpace
+		}
+		if isCJKRune(r) {
+			return segCJK
+		}
+		return segOther
+	}
+
+	for _, r := range line {
+		if r == '\x1b' {
+			if cur.kind != segANSI && cur.kind != 0 {
+				flush()
+			}
+			cur.kind = segANSI
+			cur.s += string(r)
+			ansiState.WriteRune(r)
+			inEscape = true
+			continue
+		}
+		if inEscape {
+			cur.s += string(r)
+			ansiState.WriteRune(r)
+			if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
+				inEscape = false
+				s := ansiState.String()
+				if strings.HasSuffix(s, "[0m") || strings.HasSuffix(s, "[m") {
+					ansiState.Reset()
+					haveAnsi = false
+				} else if strings.HasSuffix(s, "m") {
+					haveAnsi = true
+				}
+			}
+			continue
+		}
+		k := classify(r)
+		if k != cur.kind {
+			flush()
+		}
+		cur.kind = k
+		cur.s += string(r)
+	}
+	flush()
+	return segs
 }
 
 // Document.Margin=0 prevents misalignment inside lipgloss bubbles.

--- a/channel/math.go
+++ b/channel/math.go
@@ -1,0 +1,506 @@
+package channel
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// mathBlockRe matches $$...$$ display math blocks (dotall, non-greedy).
+var mathBlockRe = regexp.MustCompile(`(?s)\$\$\s*(.*?)\s*\$\$`)
+
+// mathInlineRe matches $...$ inline math.
+// Requirements for a valid match:
+//   - Content must contain at least one backslash command (\xx) or
+//     a superscript/subscript (^, _) or a Unicode math indicator.
+//   - This prevents matching currency like "$10 and $20".
+//   - Content must not span multiple lines.
+//
+// Since Go RE2 lacks lookbehind, we use a simple pattern and validate
+// content quality in the replacement function.
+var mathInlineRe = regexp.MustCompile(`\$([^\$\n]+?)\$`)
+
+// renderMathBlocks pre-processes markdown content containing LaTeX math
+// expressions, converting them to Unicode/plain-text representations that
+// the terminal can display. It follows the same pre-processing pattern as
+// renderMermaidBlocks.
+//
+// Block math ($$...$$) is rendered into a ``` code block so glamour
+// preserves whitespace alignment. Inline math ($...$) is rendered inline
+// with Unicode symbols.
+func renderMathBlocks(content string, maxW int) string {
+	// Phase 1: block math → code block
+	content = mathBlockRe.ReplaceAllStringFunc(content, func(match string) string {
+		sub := mathBlockRe.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		src := strings.TrimSpace(sub[1])
+		if src == "" {
+			return match
+		}
+		rendered := latexToUnicode(src)
+		if maxW > 0 {
+			rendered = truncateMathLines(rendered, maxW)
+		}
+		return "```\n" + rendered + "\n```"
+	})
+
+	// Phase 2: inline math → Unicode text
+	content = mathInlineRe.ReplaceAllStringFunc(content, func(match string) string {
+		sub := mathInlineRe.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		src := strings.TrimSpace(sub[1])
+		if src == "" || !looksLikeMath(src) {
+			return match
+		}
+		return latexToUnicode(src)
+	})
+
+	return content
+}
+
+// truncateMathLines truncates each line to maxW display columns.
+func truncateMathLines(s string, maxW int) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		line = strings.TrimRight(line, " \t")
+		if ansi.StringWidth(line) > maxW {
+			lines[i] = truncateStringWidth(line, maxW)
+		} else {
+			lines[i] = line
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// latexToUnicode converts a LaTeX math expression to a Unicode/plain-text
+// representation suitable for terminal display. It handles the most common
+// constructs: Greek letters, operators, sub/superscripts, fractions,
+// square roots, summations, integrals, and basic formatting.
+func latexToUnicode(src string) string {
+	// Apply transformations in order — order matters for nested constructs.
+	out := src
+
+	// 1. Named Greek letters: \alpha → α, \beta → β, etc.
+	out = replaceLongestFirst(out, greekLetters)
+
+	// 2. Named operators: \sum → ∑, \int → ∫, etc.
+	//    Must be longest-first to avoid \in matching before \int, \leq before \le, etc.
+	out = replaceLongestFirst(out, operators)
+
+	// 3. Named arrows: \rightarrow → →, etc.
+	out = replaceLongestFirst(out, arrows)
+
+	// 4. Bracket delimiters (multi-char sequences)
+	out = strings.ReplaceAll(out, `\left(`, "(")
+	out = strings.ReplaceAll(out, `\right)`, ")")
+	out = strings.ReplaceAll(out, `\left[`, "[")
+	out = strings.ReplaceAll(out, `\right]`, "]")
+	out = strings.ReplaceAll(out, `\left\{`, "{")
+	out = strings.ReplaceAll(out, `\right\}`, "}")
+	out = strings.ReplaceAll(out, `\left|`, "|")
+	out = strings.ReplaceAll(out, `\right|`, "|")
+	out = strings.ReplaceAll(out, `\bigl(`, "(")
+	out = strings.ReplaceAll(out, `\bigr)`, ")")
+	out = strings.ReplaceAll(out, `\Bigl(`, "(")
+	out = strings.ReplaceAll(out, `\Bigr)`, ")")
+	out = strings.ReplaceAll(out, `\left.`, "")
+	out = strings.ReplaceAll(out, `\right.`, "")
+
+	// 5. Whitespace commands
+	out = strings.ReplaceAll(out, `\,`, " ")
+	out = strings.ReplaceAll(out, `\;`, " ")
+	out = strings.ReplaceAll(out, `\quad`, "  ")
+	out = strings.ReplaceAll(out, `\qquad`, "    ")
+	out = strings.ReplaceAll(out, `\ `, " ")
+	out = strings.ReplaceAll(out, `~`, " ")
+
+	// 6. Structural constructs
+	out = renderFractions(out)
+	out = renderSquareRoots(out)
+
+	// 7. Superscripts: ^{...} and single-char ^x
+	out = renderSuperscripts(out)
+
+	// 8. Subscripts: _{...} and single-char _x
+	out = renderSubscripts(out)
+
+	// 9. Cleanup text commands
+	out = strings.ReplaceAll(out, `\text{`, "")
+	out = strings.ReplaceAll(out, `\mathrm{`, "")
+	out = strings.ReplaceAll(out, `\mathbf{`, "")
+	out = strings.ReplaceAll(out, `\mathit{`, "")
+	out = strings.ReplaceAll(out, `\mathcal{`, "")
+	out = strings.ReplaceAll(out, `\operatorname{`, "")
+	out = strings.ReplaceAll(out, `\text`, "")
+	out = strings.ReplaceAll(out, `\mathrm`, "")
+	out = strings.ReplaceAll(out, `\mathbf`, "")
+	out = strings.ReplaceAll(out, `\displaystyle`, "")
+	out = strings.ReplaceAll(out, `\limits`, "")
+
+	// 10. Remove leftover braces from processed constructs
+	out = removeBraces(out)
+
+	// 11. Remaining \cmd that we didn't handle → keep as-is (strip backslash)
+	out = unknownCmdRe.ReplaceAllString(out, "$1")
+
+	return strings.TrimSpace(out)
+}
+
+// replaceLongestFirst replaces all keys in the map with their values,
+// processing longest keys first to prevent partial matches (e.g. \int before \in).
+func replaceLongestFirst(s string, m map[string]string) string {
+	// Sort keys by length descending
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// Simple insertion sort by length descending
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && len(keys[j]) > len(keys[j-1]); j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	for _, k := range keys {
+		s = strings.ReplaceAll(s, k, m[k])
+	}
+	return s
+}
+
+// ---------- Greek Letters ----------
+
+var greekLetters = map[string]string{
+	`\alpha`:      "α",
+	`\beta`:       "β",
+	`\gamma`:      "γ",
+	`\delta`:      "δ",
+	`\epsilon`:    "ε",
+	`\varepsilon`: "ε",
+	`\zeta`:       "ζ",
+	`\eta`:        "η",
+	`\theta`:      "θ",
+	`\vartheta`:   "ϑ",
+	`\iota`:       "ι",
+	`\kappa`:      "κ",
+	`\lambda`:     "λ",
+	`\mu`:         "μ",
+	`\nu`:         "ν",
+	`\xi`:         "ξ",
+	`\pi`:         "π",
+	`\varpi`:      "ϖ",
+	`\rho`:        "ρ",
+	`\sigma`:      "σ",
+	`\tau`:        "τ",
+	`\upsilon`:    "υ",
+	`\phi`:        "φ",
+	`\varphi`:     "φ",
+	`\chi`:        "χ",
+	`\psi`:        "ψ",
+	`\omega`:      "ω",
+	// Uppercase
+	`\Gamma`:   "Γ",
+	`\Delta`:   "Δ",
+	`\Theta`:   "Θ",
+	`\Lambda`:  "Λ",
+	`\Xi`:      "Ξ",
+	`\Pi`:      "Π",
+	`\Sigma`:   "Σ",
+	`\Upsilon`: "Υ",
+	`\Phi`:     "Φ",
+	`\Psi`:     "Ψ",
+	`\Omega`:   "Ω",
+}
+
+// ---------- Operators ----------
+
+var operators = map[string]string{
+	`\sum`:        "∑",
+	`\prod`:       "∏",
+	`\coprod`:     "∐",
+	`\oint`:       "∮",
+	`\iiint`:      "∭",
+	`\iint`:       "∬",
+	`\int`:        "∫",
+	`\partial`:    "∂",
+	`\nabla`:      "∇",
+	`\infty`:      "∞",
+	`\pm`:         "±",
+	`\mp`:         "∓",
+	`\times`:      "×",
+	`\div`:        "÷",
+	`\cdot`:       "·",
+	`\circ`:       "∘",
+	`\bullet`:     "•",
+	`\star`:       "★",
+	`\approx`:     "≈",
+	`\neq`:        "≠",
+	`\leq`:        "≤",
+	`\geq`:        "≥",
+	`\le`:         "≤",
+	`\ge`:         "≥",
+	`\ll`:         "≪",
+	`\gg`:         "≫",
+	`\equiv`:      "≡",
+	`\sim`:        "∼",
+	`\simeq`:      "≃",
+	`\propto`:     "∝",
+	`\perp`:       "⊥",
+	`\parallel`:   "∥",
+	`\angle`:      "∠",
+	`\triangle`:   "△",
+	`\square`:     "□",
+	`\subseteq`:   "⊆",
+	`\supseteq`:   "⊇",
+	`\subset`:     "⊂",
+	`\supset`:     "⊃",
+	`\notin`:      "∉",
+	`\in`:         "∈",
+	`\cup`:        "∪",
+	`\cap`:        "∩",
+	`\emptyset`:   "∅",
+	`\varnothing`: "∅",
+	`\forall`:     "∀",
+	`\exists`:     "∃",
+	`\neg`:        "¬",
+	`\land`:       "∧",
+	`\lor`:        "∨",
+	`\oplus`:      "⊕",
+	`\otimes`:     "⊗",
+	`\odot`:       "⊙",
+	`\hbar`:       "ℏ",
+	`\ell`:        "ℓ",
+	`\Re`:         "ℜ",
+	`\Im`:         "ℑ",
+	`\aleph`:      "ℵ",
+	`\wp`:         "℘",
+	`\prime`:      "′",
+	`\dagger`:     "†",
+	`\ddagger`:    "‡",
+	`\cdots`:      "⋯",
+	`\ldots`:      "…",
+	`\vdots`:      "⋮",
+	`\ddots`:      "⋱",
+	`\%`:          "%",
+	`\&`:          "&",
+	`\#`:          "#",
+	`\_`:          "_",
+	`\{`:          "{",
+	`\}`:          "}",
+}
+
+// ---------- Arrows ----------
+
+var arrows = map[string]string{
+	`\rightarrow`:     "→",
+	`\to`:             "→",
+	`\leftarrow`:      "←",
+	`\gets`:           "←",
+	`\leftrightarrow`: "↔",
+	`\Rightarrow`:     "⇒",
+	`\Leftarrow`:      "⇐",
+	`\Leftrightarrow`: "⇔",
+	`\uparrow`:        "↑",
+	`\downarrow`:      "↓",
+	`\updownarrow`:    "↕",
+	`\Uparrow`:        "⇑",
+	`\Downarrow`:      "⇓",
+	`\Updownarrow`:    "⇕",
+	`\mapsto`:         "↦",
+	`\hookrightarrow`: "↪",
+	`\nearrow`:        "↗",
+	`\searrow`:        "↘",
+	`\swarrow`:        "↙",
+	`\nwarrow`:        "↖",
+	`\rightharpoonup`: "⇀",
+	`\leftharpoonup`:  "↼",
+}
+
+// ---------- Superscript / Subscript ----------
+
+var superscriptDigits = map[rune]rune{
+	'0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
+	'5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹',
+	'+': '⁺', '-': '⁻', '=': '⁼', '(': '⁽', ')': '⁾',
+	'n': 'ⁿ', 'i': 'ⁱ',
+}
+
+var subscriptDigits = map[rune]rune{
+	'0': '₀', '1': '₁', '2': '₂', '3': '₃', '4': '₄',
+	'5': '₅', '6': '₆', '7': '₇', '8': '₈', '9': '₉',
+	'+': '₊', '-': '₋', '=': '₌', '(': '₍', ')': '₎',
+	'a': 'ₐ', 'e': 'ₑ', 'o': 'ₒ', 'x': 'ₓ',
+	'h': 'ₕ', 'k': 'ₖ', 'l': 'ₗ', 'm': 'ₘ', 'n': 'ₙ',
+	'p': 'ₚ', 's': 'ₛ', 't': 'ₜ',
+	'i': 'ᵢ', 'j': 'ⱼ', 'r': 'ᵣ', 'u': 'ᵤ', 'v': 'ᵥ',
+}
+
+// fracRe matches \frac{num}{den} or \dfrac{num}{den}.
+var fracRe = regexp.MustCompile(`\\(?:d)?frac\{([^}]*)}\{([^}]*)}`)
+
+// sqrtRe matches \sqrt[n]{content} or \sqrt{content}.
+var sqrtRe = regexp.MustCompile(`\\sqrt(?:\[(\w+)\])?\{([^}]*)}`)
+
+// supRe matches ^{content} (braced multi-char superscript).
+var supBraceRe = regexp.MustCompile(`\^{([^}]+)}`)
+
+// supSingleRe matches ^x (single-char superscript, not a brace).
+var supSingleRe = regexp.MustCompile(`\^([^\\{_\s])`)
+
+// subBraceRe matches _{content} (braced multi-char subscript).
+var subBraceRe = regexp.MustCompile(`_{([^}]+)}`)
+
+// subSingleRe matches _x (single-char subscript, not a brace).
+var subSingleRe = regexp.MustCompile(`_([^\\{^\s])`)
+
+// unknownCmdRe matches remaining \word commands.
+var unknownCmdRe = regexp.MustCompile(`\\([a-zA-Z]+)`)
+
+// renderFractions converts \frac{a}{b} → a/b.
+func renderFractions(s string) string {
+	return fracRe.ReplaceAllStringFunc(s, func(match string) string {
+		sub := fracRe.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		num := strings.TrimSpace(sub[1])
+		den := strings.TrimSpace(sub[2])
+		if num == "" || den == "" {
+			return match
+		}
+		return num + "/" + den
+	})
+}
+
+// renderSquareRoots converts \sqrt{x} → √x and \sqrt[n]{x} → ⁿ√x.
+func renderSquareRoots(s string) string {
+	return sqrtRe.ReplaceAllStringFunc(s, func(match string) string {
+		sub := sqrtRe.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		index := strings.TrimSpace(sub[1])
+		content := strings.TrimSpace(sub[2])
+		if index != "" {
+			return index + "√" + content
+		}
+		return "√" + content
+	})
+}
+
+// renderSuperscripts converts ^{2} → ², ^n → ⁿ, etc.
+func renderSuperscripts(s string) string {
+	// First: braced multi-char ^{content}
+	s = supBraceRe.ReplaceAllStringFunc(s, func(match string) string {
+		sub := supBraceRe.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		return toSuperscript(sub[1])
+	})
+	// Then: single-char ^x
+	s = supSingleRe.ReplaceAllStringFunc(s, func(match string) string {
+		sub := supSingleRe.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		return toSuperscript(sub[1])
+	})
+	return s
+}
+
+// renderSubscripts converts _{2} → ₂, _i → ᵢ, etc.
+func renderSubscripts(s string) string {
+	// First: braced multi-char _{content}
+	s = subBraceRe.ReplaceAllStringFunc(s, func(match string) string {
+		sub := subBraceRe.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		return toSubscript(sub[1])
+	})
+	// Then: single-char _x
+	s = subSingleRe.ReplaceAllStringFunc(s, func(match string) string {
+		sub := subSingleRe.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		return toSubscript(sub[1])
+	})
+	return s
+}
+
+// toSuperscript converts a string to superscript Unicode where possible.
+// Characters without a superscript equivalent are kept as-is (no fallback prefix).
+func toSuperscript(s string) string {
+	var buf strings.Builder
+	allConverted := true
+	for _, r := range s {
+		if sr, ok := superscriptDigits[r]; ok {
+			buf.WriteRune(sr)
+		} else {
+			buf.WriteRune(r)
+			allConverted = false
+		}
+	}
+	_ = allConverted
+	return buf.String()
+}
+
+// toSubscript converts a string to subscript Unicode where possible.
+// Characters without a subscript equivalent are kept as-is (no fallback prefix).
+func toSubscript(s string) string {
+	var buf strings.Builder
+	for _, r := range s {
+		if sr, ok := subscriptDigits[r]; ok {
+			buf.WriteRune(sr)
+		} else {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
+}
+
+// removeBraces strips remaining { and } that are not needed for display.
+// It uses a simple heuristic: remove braces that wrap content without
+// any surrounding command context.
+func removeBraces(s string) string {
+	// Iteratively remove { } pairs. This is conservative — we only
+	// remove when the content inside is plain text without nested braces.
+	for strings.Contains(s, "{") {
+		next := bracePairRe.ReplaceAllStringFunc(s, func(match string) string {
+			// Strip the outer braces
+			inner := match[1 : len(match)-1]
+			if !strings.ContainsAny(inner, "{}") {
+				return inner
+			}
+			return match
+		})
+		if next == s {
+			break // no progress, stop
+		}
+		s = next
+	}
+	return s
+}
+
+// bracePairRe matches the innermost {content} pair (no nested braces inside).
+var bracePairRe = regexp.MustCompile(`\{([^{}]*)}`)
+
+// hasMath detects whether content contains LaTeX math expressions.
+func hasMath(content string) bool {
+	return mathBlockRe.MatchString(content) || mathInlineRe.MatchString(content)
+}
+
+// looksLikeMath returns true if the content between $ delimiters looks like
+// a LaTeX math expression rather than plain text with dollar signs (currency).
+// Heuristics: contains backslash commands, superscripts (^), subscripts (_),
+// or common math operators.
+var mathIndicatorRe = regexp.MustCompile(`\\[a-zA-Z]|\^|_|[{}]|\\[+\-=\{\}_#%&]`)
+
+func looksLikeMath(s string) bool {
+	return mathIndicatorRe.MatchString(s)
+}

--- a/channel/math.go
+++ b/channel/math.go
@@ -11,24 +11,13 @@ import (
 var mathBlockRe = regexp.MustCompile(`(?s)\$\$\s*(.*?)\s*\$\$`)
 
 // mathInlineRe matches $...$ inline math.
-// Requirements for a valid match:
-//   - Content must contain at least one backslash command (\xx) or
-//     a superscript/subscript (^, _) or a Unicode math indicator.
-//   - This prevents matching currency like "$10 and $20".
-//   - Content must not span multiple lines.
-//
-// Since Go RE2 lacks lookbehind, we use a simple pattern and validate
-// content quality in the replacement function.
+// Broad match; validated in replacement via looksLikeMath.
 var mathInlineRe = regexp.MustCompile(`\$([^\$\n]+?)\$`)
 
 // renderMathBlocks pre-processes markdown content containing LaTeX math
 // expressions, converting them to Unicode/plain-text representations that
-// the terminal can display. It follows the same pre-processing pattern as
+// the terminal can display. Follows the same pre-processing pattern as
 // renderMermaidBlocks.
-//
-// Block math ($$...$$) is rendered into a ``` code block so glamour
-// preserves whitespace alignment. Inline math ($...$) is rendered inline
-// with Unicode symbols.
 func renderMathBlocks(content string, maxW int) string {
 	// Phase 1: block math → code block
 	content = mathBlockRe.ReplaceAllStringFunc(content, func(match string) string {
@@ -77,39 +66,37 @@ func truncateMathLines(s string, maxW int) string {
 	return strings.Join(lines, "\n")
 }
 
-// latexToUnicode converts a LaTeX math expression to a Unicode/plain-text
-// representation suitable for terminal display. It handles the most common
-// constructs: Greek letters, operators, sub/superscripts, fractions,
-// square roots, summations, integrals, and basic formatting.
+// hasMath detects whether content contains LaTeX math expressions.
+func hasMath(content string) bool {
+	return mathBlockRe.MatchString(content) || mathInlineRe.MatchString(content)
+}
+
+// looksLikeMath returns true if the content between $ delimiters looks like
+// a LaTeX math expression rather than plain text with dollar signs (currency).
+var mathIndicatorRe = regexp.MustCompile(`\\[a-zA-Z]|\^|_|[{}]`)
+
+func looksLikeMath(s string) bool {
+	return mathIndicatorRe.MatchString(s)
+}
+
+// =====================================================================
+// latexToUnicode — core LaTeX → Unicode converter
+// =====================================================================
+
 func latexToUnicode(src string) string {
-	// Apply transformations in order — order matters for nested constructs.
 	out := src
 
-	// 1. Named Greek letters: \alpha → α, \beta → β, etc.
+	// 1. Named Greek letters (longest-first to avoid partial match)
 	out = replaceLongestFirst(out, greekLetters)
 
-	// 2. Named operators: \sum → ∑, \int → ∫, etc.
-	//    Must be longest-first to avoid \in matching before \int, \leq before \le, etc.
+	// 2. Named operators (longest-first: \int before \in, \leq before \le)
 	out = replaceLongestFirst(out, operators)
 
-	// 3. Named arrows: \rightarrow → →, etc.
+	// 3. Named arrows
 	out = replaceLongestFirst(out, arrows)
 
-	// 4. Bracket delimiters (multi-char sequences)
-	out = strings.ReplaceAll(out, `\left(`, "(")
-	out = strings.ReplaceAll(out, `\right)`, ")")
-	out = strings.ReplaceAll(out, `\left[`, "[")
-	out = strings.ReplaceAll(out, `\right]`, "]")
-	out = strings.ReplaceAll(out, `\left\{`, "{")
-	out = strings.ReplaceAll(out, `\right\}`, "}")
-	out = strings.ReplaceAll(out, `\left|`, "|")
-	out = strings.ReplaceAll(out, `\right|`, "|")
-	out = strings.ReplaceAll(out, `\bigl(`, "(")
-	out = strings.ReplaceAll(out, `\bigr)`, ")")
-	out = strings.ReplaceAll(out, `\Bigl(`, "(")
-	out = strings.ReplaceAll(out, `\Bigr)`, ")")
-	out = strings.ReplaceAll(out, `\left.`, "")
-	out = strings.ReplaceAll(out, `\right.`, "")
+	// 4. Bracket delimiters
+	out = replaceLongestFirst(out, delimiters)
 
 	// 5. Whitespace commands
 	out = strings.ReplaceAll(out, `\,`, " ")
@@ -119,207 +106,201 @@ func latexToUnicode(src string) string {
 	out = strings.ReplaceAll(out, `\ `, " ")
 	out = strings.ReplaceAll(out, `~`, " ")
 
-	// 6. Structural constructs
+	// 6. Structural constructs — use brace-aware parsing, NOT regex
 	out = renderFractions(out)
 	out = renderSquareRoots(out)
+	out = renderOver(out)
 
-	// 7. Superscripts: ^{...} and single-char ^x
+	// 7. Superscripts / subscripts — brace-aware
 	out = renderSuperscripts(out)
-
-	// 8. Subscripts: _{...} and single-char _x
 	out = renderSubscripts(out)
 
-	// 9. Cleanup text commands
-	out = strings.ReplaceAll(out, `\text{`, "")
-	out = strings.ReplaceAll(out, `\mathrm{`, "")
-	out = strings.ReplaceAll(out, `\mathbf{`, "")
-	out = strings.ReplaceAll(out, `\mathit{`, "")
-	out = strings.ReplaceAll(out, `\mathcal{`, "")
-	out = strings.ReplaceAll(out, `\operatorname{`, "")
-	out = strings.ReplaceAll(out, `\text`, "")
-	out = strings.ReplaceAll(out, `\mathrm`, "")
-	out = strings.ReplaceAll(out, `\mathbf`, "")
-	out = strings.ReplaceAll(out, `\displaystyle`, "")
-	out = strings.ReplaceAll(out, `\limits`, "")
+	// 8. Cleanup text-style commands
+	for _, cmd := range []string{
+		`\text`, `\mathrm`, `\mathbf`, `\mathit`, `\mathcal`,
+		`\mathbb`, `\mathfrak`, `\mathsf`, `\mathtt`,
+		`\operatorname`, `\mathrm`, `\textbf`, `\textit`,
+		`\displaystyle`, `\textstyle`, `\scriptstyle`,
+		`\limits`, `\nolimits`,
+	} {
+		out = strings.ReplaceAll(out, cmd, "")
+	}
 
-	// 10. Remove leftover braces from processed constructs
+	// 9. Remove leftover braces iteratively (innermost first)
 	out = removeBraces(out)
 
-	// 11. Remaining \cmd that we didn't handle → keep as-is (strip backslash)
+	// 10. Remaining \cmd → strip backslash
 	out = unknownCmdRe.ReplaceAllString(out, "$1")
 
 	return strings.TrimSpace(out)
 }
 
-// replaceLongestFirst replaces all keys in the map with their values,
-// processing longest keys first to prevent partial matches (e.g. \int before \in).
+// replaceLongestFirst replaces all keys in m with values,
+// processing longest keys first to prevent partial matches.
 func replaceLongestFirst(s string, m map[string]string) string {
-	// Sort keys by length descending
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	// Simple insertion sort by length descending
-	for i := 1; i < len(keys); i++ {
-		for j := i; j > 0 && len(keys[j]) > len(keys[j-1]); j-- {
-			keys[j], keys[j-1] = keys[j-1], keys[j]
-		}
-	}
+	keys := sortedKeysByLenDesc(m)
 	for _, k := range keys {
 		s = strings.ReplaceAll(s, k, m[k])
 	}
 	return s
 }
 
-// ---------- Greek Letters ----------
-
-var greekLetters = map[string]string{
-	`\alpha`:      "α",
-	`\beta`:       "β",
-	`\gamma`:      "γ",
-	`\delta`:      "δ",
-	`\epsilon`:    "ε",
-	`\varepsilon`: "ε",
-	`\zeta`:       "ζ",
-	`\eta`:        "η",
-	`\theta`:      "θ",
-	`\vartheta`:   "ϑ",
-	`\iota`:       "ι",
-	`\kappa`:      "κ",
-	`\lambda`:     "λ",
-	`\mu`:         "μ",
-	`\nu`:         "ν",
-	`\xi`:         "ξ",
-	`\pi`:         "π",
-	`\varpi`:      "ϖ",
-	`\rho`:        "ρ",
-	`\sigma`:      "σ",
-	`\tau`:        "τ",
-	`\upsilon`:    "υ",
-	`\phi`:        "φ",
-	`\varphi`:     "φ",
-	`\chi`:        "χ",
-	`\psi`:        "ψ",
-	`\omega`:      "ω",
-	// Uppercase
-	`\Gamma`:   "Γ",
-	`\Delta`:   "Δ",
-	`\Theta`:   "Θ",
-	`\Lambda`:  "Λ",
-	`\Xi`:      "Ξ",
-	`\Pi`:      "Π",
-	`\Sigma`:   "Σ",
-	`\Upsilon`: "Υ",
-	`\Phi`:     "Φ",
-	`\Psi`:     "Ψ",
-	`\Omega`:   "Ω",
+func sortedKeysByLenDesc(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// insertion sort by length descending
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && len(keys[j]) > len(keys[j-1]); j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	return keys
 }
 
-// ---------- Operators ----------
+// =====================================================================
+// Brace-aware structural parsers
+// =====================================================================
 
-var operators = map[string]string{
-	`\sum`:        "∑",
-	`\prod`:       "∏",
-	`\coprod`:     "∐",
-	`\oint`:       "∮",
-	`\iiint`:      "∭",
-	`\iint`:       "∬",
-	`\int`:        "∫",
-	`\partial`:    "∂",
-	`\nabla`:      "∇",
-	`\infty`:      "∞",
-	`\pm`:         "±",
-	`\mp`:         "∓",
-	`\times`:      "×",
-	`\div`:        "÷",
-	`\cdot`:       "·",
-	`\circ`:       "∘",
-	`\bullet`:     "•",
-	`\star`:       "★",
-	`\approx`:     "≈",
-	`\neq`:        "≠",
-	`\leq`:        "≤",
-	`\geq`:        "≥",
-	`\le`:         "≤",
-	`\ge`:         "≥",
-	`\ll`:         "≪",
-	`\gg`:         "≫",
-	`\equiv`:      "≡",
-	`\sim`:        "∼",
-	`\simeq`:      "≃",
-	`\propto`:     "∝",
-	`\perp`:       "⊥",
-	`\parallel`:   "∥",
-	`\angle`:      "∠",
-	`\triangle`:   "△",
-	`\square`:     "□",
-	`\subseteq`:   "⊆",
-	`\supseteq`:   "⊇",
-	`\subset`:     "⊂",
-	`\supset`:     "⊃",
-	`\notin`:      "∉",
-	`\in`:         "∈",
-	`\cup`:        "∪",
-	`\cap`:        "∩",
-	`\emptyset`:   "∅",
-	`\varnothing`: "∅",
-	`\forall`:     "∀",
-	`\exists`:     "∃",
-	`\neg`:        "¬",
-	`\land`:       "∧",
-	`\lor`:        "∨",
-	`\oplus`:      "⊕",
-	`\otimes`:     "⊗",
-	`\odot`:       "⊙",
-	`\hbar`:       "ℏ",
-	`\ell`:        "ℓ",
-	`\Re`:         "ℜ",
-	`\Im`:         "ℑ",
-	`\aleph`:      "ℵ",
-	`\wp`:         "℘",
-	`\prime`:      "′",
-	`\dagger`:     "†",
-	`\ddagger`:    "‡",
-	`\cdots`:      "⋯",
-	`\ldots`:      "…",
-	`\vdots`:      "⋮",
-	`\ddots`:      "⋱",
-	`\%`:          "%",
-	`\&`:          "&",
-	`\#`:          "#",
-	`\_`:          "_",
-	`\{`:          "{",
-	`\}`:          "}",
+// extractBraced finds the content inside {…} starting at position pos.
+// Handles nested braces correctly. Returns the inner content and the
+// end position (index after closing }). Returns ("", pos) if no match.
+func extractBraced(s string, pos int) (content string, end int) {
+	if pos >= len(s) || s[pos] != '{' {
+		return "", pos
+	}
+	depth := 1
+	i := pos + 1
+	for i < len(s) && depth > 0 {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+		}
+		i++
+	}
+	if depth != 0 {
+		return "", pos // unmatched brace
+	}
+	return s[pos+1 : i-1], i
 }
 
-// ---------- Arrows ----------
+// renderFractions converts \frac{num}{den} and \dfrac{num}{den} to num/den.
+// Uses brace-aware parsing to handle nested braces correctly.
+func renderFractions(s string) string {
+	for {
+		idx := fracCmdIndex(s)
+		if idx < 0 {
+			break
+		}
+		// Find the opening brace of numerator
+		numStart := skipSpaces(s, idx)
+		if numStart >= len(s) || s[numStart] != '{' {
+			break
+		}
+		num, afterNum := extractBraced(s, numStart)
+		if afterNum == numStart {
+			break
+		}
+		denStart := skipSpaces(s, afterNum)
+		if denStart >= len(s) || s[denStart] != '{' {
+			break
+		}
+		den, afterDen := extractBraced(s, denStart)
+		if afterDen == denStart {
+			break
+		}
 
-var arrows = map[string]string{
-	`\rightarrow`:     "→",
-	`\to`:             "→",
-	`\leftarrow`:      "←",
-	`\gets`:           "←",
-	`\leftrightarrow`: "↔",
-	`\Rightarrow`:     "⇒",
-	`\Leftarrow`:      "⇐",
-	`\Leftrightarrow`: "⇔",
-	`\uparrow`:        "↑",
-	`\downarrow`:      "↓",
-	`\updownarrow`:    "↕",
-	`\Uparrow`:        "⇑",
-	`\Downarrow`:      "⇓",
-	`\Updownarrow`:    "⇕",
-	`\mapsto`:         "↦",
-	`\hookrightarrow`: "↪",
-	`\nearrow`:        "↗",
-	`\searrow`:        "↘",
-	`\swarrow`:        "↙",
-	`\nwarrow`:        "↖",
-	`\rightharpoonup`: "⇀",
-	`\leftharpoonup`:  "↼",
+		cmdStart := fracCmdStart(s, idx)
+		replacement := num + "/" + den
+		s = s[:cmdStart] + replacement + s[afterDen:]
+	}
+	return s
 }
 
-// ---------- Superscript / Subscript ----------
+// fracCmdIndex finds the index of '{' right after \frac or \dfrac.
+func fracCmdIndex(s string) int {
+	for _, prefix := range []string{`\dfrac{`, `\frac{`} {
+		if i := strings.Index(s, prefix); i >= 0 {
+			return i + len(prefix) - 1 // index of '{'
+		}
+	}
+	return -1
+}
+
+func fracCmdStart(s string, braceIdx int) int {
+	// Walk back from braceIdx to find the \ that starts \frac or \dfrac
+	sub := s[:braceIdx+1]
+	for _, prefix := range []string{`\dfrac{`, `\frac{`} {
+		if strings.HasSuffix(sub, prefix) {
+			return len(sub) - len(prefix)
+		}
+	}
+	return 0
+}
+
+func skipSpaces(s string, i int) int {
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	return i
+}
+
+// renderSquareRoots converts \sqrt{x} → √x and \sqrt[n]{x} → ⁿ√x.
+// Brace-aware for nested content.
+func renderSquareRoots(s string) string {
+	for {
+		idx := strings.Index(s, `\sqrt`)
+		if idx < 0 {
+			break
+		}
+		pos := idx + len(`\sqrt`)
+		var indexStr string
+
+		// Optional [n] index
+		if pos < len(s) && s[pos] == '[' {
+			endBracket := strings.IndexByte(s[pos:], ']')
+			if endBracket > 0 {
+				indexStr = s[pos+1 : pos+endBracket]
+				// Convert index to superscript
+				indexStr = toSuperscript(indexStr)
+				pos = pos + endBracket + 1
+			}
+		}
+
+		pos = skipSpaces(s, pos)
+		if pos >= len(s) || s[pos] != '{' {
+			break
+		}
+		content, afterContent := extractBraced(s, pos)
+		if afterContent == pos {
+			break
+		}
+
+		replacement := indexStr + "√" + content
+		s = s[:idx] + replacement + s[afterContent:]
+	}
+	return s
+}
+
+// renderOver converts \over (LaTeX infix fraction: {a \over b} → a/b).
+func renderOver(s string) string {
+	return overRe.ReplaceAllStringFunc(s, func(match string) string {
+		sub := overRe.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		return strings.TrimSpace(sub[1]) + "/" + strings.TrimSpace(sub[2])
+	})
+}
+
+var overRe = regexp.MustCompile(`\{([^{}]*)\s*\\over\s*([^{}]*)}`)
+
+// =====================================================================
+// Superscript / Subscript
+// =====================================================================
 
 var superscriptDigits = map[rune]rune{
 	'0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
@@ -338,120 +319,87 @@ var subscriptDigits = map[rune]rune{
 	'i': 'ᵢ', 'j': 'ⱼ', 'r': 'ᵣ', 'u': 'ᵤ', 'v': 'ᵥ',
 }
 
-// fracRe matches \frac{num}{den} or \dfrac{num}{den}.
-var fracRe = regexp.MustCompile(`\\(?:d)?frac\{([^}]*)}\{([^}]*)}`)
-
-// sqrtRe matches \sqrt[n]{content} or \sqrt{content}.
-var sqrtRe = regexp.MustCompile(`\\sqrt(?:\[(\w+)\])?\{([^}]*)}`)
-
-// supRe matches ^{content} (braced multi-char superscript).
-var supBraceRe = regexp.MustCompile(`\^{([^}]+)}`)
-
-// supSingleRe matches ^x (single-char superscript, not a brace).
-var supSingleRe = regexp.MustCompile(`\^([^\\{_\s])`)
-
-// subBraceRe matches _{content} (braced multi-char subscript).
-var subBraceRe = regexp.MustCompile(`_{([^}]+)}`)
-
-// subSingleRe matches _x (single-char subscript, not a brace).
-var subSingleRe = regexp.MustCompile(`_([^\\{^\s])`)
-
-// unknownCmdRe matches remaining \word commands.
-var unknownCmdRe = regexp.MustCompile(`\\([a-zA-Z]+)`)
-
-// renderFractions converts \frac{a}{b} → a/b.
-func renderFractions(s string) string {
-	return fracRe.ReplaceAllStringFunc(s, func(match string) string {
-		sub := fracRe.FindStringSubmatch(match)
-		if len(sub) < 3 {
-			return match
-		}
-		num := strings.TrimSpace(sub[1])
-		den := strings.TrimSpace(sub[2])
-		if num == "" || den == "" {
-			return match
-		}
-		return num + "/" + den
-	})
-}
-
-// renderSquareRoots converts \sqrt{x} → √x and \sqrt[n]{x} → ⁿ√x.
-func renderSquareRoots(s string) string {
-	return sqrtRe.ReplaceAllStringFunc(s, func(match string) string {
-		sub := sqrtRe.FindStringSubmatch(match)
-		if len(sub) < 3 {
-			return match
-		}
-		index := strings.TrimSpace(sub[1])
-		content := strings.TrimSpace(sub[2])
-		if index != "" {
-			return index + "√" + content
-		}
-		return "√" + content
-	})
-}
-
-// renderSuperscripts converts ^{2} → ², ^n → ⁿ, etc.
+// renderSuperscripts converts ^{...} and ^x to superscript Unicode.
+// Brace-aware for nested content like ^{i\pi}.
 func renderSuperscripts(s string) string {
-	// First: braced multi-char ^{content}
-	s = supBraceRe.ReplaceAllStringFunc(s, func(match string) string {
-		sub := supBraceRe.FindStringSubmatch(match)
-		if len(sub) < 2 {
-			return match
-		}
-		return toSuperscript(sub[1])
-	})
-	// Then: single-char ^x
-	s = supSingleRe.ReplaceAllStringFunc(s, func(match string) string {
-		sub := supSingleRe.FindStringSubmatch(match)
-		if len(sub) < 2 {
-			return match
-		}
-		return toSuperscript(sub[1])
-	})
+	// Braced: ^{...}
+	s = renderPowOrSub(s, '^', toSuperscript)
+	// Single-char: ^x (not followed by { or \)
+	s = renderPowOrSubSingle(s, '^', toSuperscript)
 	return s
 }
 
-// renderSubscripts converts _{2} → ₂, _i → ᵢ, etc.
+// renderSubscripts converts _{...} and _x to subscript Unicode.
 func renderSubscripts(s string) string {
-	// First: braced multi-char _{content}
-	s = subBraceRe.ReplaceAllStringFunc(s, func(match string) string {
-		sub := subBraceRe.FindStringSubmatch(match)
-		if len(sub) < 2 {
-			return match
-		}
-		return toSubscript(sub[1])
-	})
-	// Then: single-char _x
-	s = subSingleRe.ReplaceAllStringFunc(s, func(match string) string {
-		sub := subSingleRe.FindStringSubmatch(match)
-		if len(sub) < 2 {
-			return match
-		}
-		return toSubscript(sub[1])
-	})
+	// Braced: _{...}
+	s = renderPowOrSub(s, '_', toSubscript)
+	// Single-char: _x
+	s = renderPowOrSubSingle(s, '_', toSubscript)
 	return s
 }
 
-// toSuperscript converts a string to superscript Unicode where possible.
-// Characters without a superscript equivalent are kept as-is (no fallback prefix).
+// renderPowOrSub handles ^{...} or _{...} with brace-aware parsing.
+func renderPowOrSub(s string, marker byte, convert func(string) string) string {
+	for {
+		idx := indexOfMarkerBrace(s, marker)
+		if idx < 0 {
+			break
+		}
+		braceStart := idx + 1
+		if braceStart >= len(s) || s[braceStart] != '{' {
+			break
+		}
+		content, afterContent := extractBraced(s, braceStart)
+		if afterContent == braceStart {
+			break
+		}
+		replacement := convert(content)
+		s = s[:idx] + replacement + s[afterContent:]
+	}
+	return s
+}
+
+// renderPowOrSubSingle handles ^x or _x (single char, no braces).
+var singlePowRe = regexp.MustCompile(`\^([^\\{_\s])`)
+var singleSubRe = regexp.MustCompile(`_([^\\{^\s])`)
+
+func renderPowOrSubSingle(s string, marker byte, convert func(string) string) string {
+	var re *regexp.Regexp
+	if marker == '^' {
+		re = singlePowRe
+	} else {
+		re = singleSubRe
+	}
+	return re.ReplaceAllStringFunc(s, func(match string) string {
+		sub := re.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		return convert(sub[1])
+	})
+}
+
+func indexOfMarkerBrace(s string, marker byte) int {
+	for i := 0; i < len(s)-1; i++ {
+		if s[i] == marker && i+1 < len(s) && s[i+1] == '{' {
+			return i
+		}
+	}
+	return -1
+}
+
 func toSuperscript(s string) string {
 	var buf strings.Builder
-	allConverted := true
 	for _, r := range s {
 		if sr, ok := superscriptDigits[r]; ok {
 			buf.WriteRune(sr)
 		} else {
 			buf.WriteRune(r)
-			allConverted = false
 		}
 	}
-	_ = allConverted
 	return buf.String()
 }
 
-// toSubscript converts a string to subscript Unicode where possible.
-// Characters without a subscript equivalent are kept as-is (no fallback prefix).
 func toSubscript(s string) string {
 	var buf strings.Builder
 	for _, r := range s {
@@ -464,43 +412,84 @@ func toSubscript(s string) string {
 	return buf.String()
 }
 
-// removeBraces strips remaining { and } that are not needed for display.
-// It uses a simple heuristic: remove braces that wrap content without
-// any surrounding command context.
+// =====================================================================
+// Brace cleanup
+// =====================================================================
+
+// removeBraces iteratively strips the innermost {content} pairs.
+var innerBraceRe = regexp.MustCompile(`\{([^{}]*)}`)
+
 func removeBraces(s string) string {
-	// Iteratively remove { } pairs. This is conservative — we only
-	// remove when the content inside is plain text without nested braces.
-	for strings.Contains(s, "{") {
-		next := bracePairRe.ReplaceAllStringFunc(s, func(match string) string {
-			// Strip the outer braces
-			inner := match[1 : len(match)-1]
-			if !strings.ContainsAny(inner, "{}") {
-				return inner
-			}
-			return match
-		})
+	for i := 0; i < 10; i++ {
+		next := innerBraceRe.ReplaceAllString(s, "$1")
 		if next == s {
-			break // no progress, stop
+			break
 		}
 		s = next
 	}
 	return s
 }
 
-// bracePairRe matches the innermost {content} pair (no nested braces inside).
-var bracePairRe = regexp.MustCompile(`\{([^{}]*)}`)
+// =====================================================================
+// Symbol tables
+// =====================================================================
 
-// hasMath detects whether content contains LaTeX math expressions.
-func hasMath(content string) bool {
-	return mathBlockRe.MatchString(content) || mathInlineRe.MatchString(content)
+var unknownCmdRe = regexp.MustCompile(`\\([a-zA-Z]+)`)
+
+var greekLetters = map[string]string{
+	`\alpha`: "α", `\beta`: "β", `\gamma`: "γ", `\delta`: "δ",
+	`\epsilon`: "ε", `\varepsilon`: "ε", `\zeta`: "ζ", `\eta`: "η",
+	`\theta`: "θ", `\vartheta`: "ϑ", `\iota`: "ι", `\kappa`: "κ",
+	`\lambda`: "λ", `\mu`: "μ", `\nu`: "ν", `\xi`: "ξ",
+	`\pi`: "π", `\varpi`: "ϖ", `\rho`: "ρ", `\sigma`: "σ",
+	`\tau`: "τ", `\upsilon`: "υ", `\phi`: "φ", `\varphi`: "φ",
+	`\chi`: "χ", `\psi`: "ψ", `\omega`: "ω",
+	`\Gamma`: "Γ", `\Delta`: "Δ", `\Theta`: "Θ", `\Lambda`: "Λ",
+	`\Xi`: "Ξ", `\Pi`: "Π", `\Sigma`: "Σ", `\Upsilon`: "Υ",
+	`\Phi`: "Φ", `\Psi`: "Ψ", `\Omega`: "Ω",
 }
 
-// looksLikeMath returns true if the content between $ delimiters looks like
-// a LaTeX math expression rather than plain text with dollar signs (currency).
-// Heuristics: contains backslash commands, superscripts (^), subscripts (_),
-// or common math operators.
-var mathIndicatorRe = regexp.MustCompile(`\\[a-zA-Z]|\^|_|[{}]|\\[+\-=\{\}_#%&]`)
+var operators = map[string]string{
+	`\sum`: "∑", `\prod`: "∏", `\coprod`: "∐",
+	`\oint`: "∮", `\iiint`: "∭", `\iint`: "∬", `\int`: "∫",
+	`\partial`: "∂", `\nabla`: "∇", `\infty`: "∞",
+	`\pm`: "±", `\mp`: "∓", `\times`: "×", `\div`: "÷",
+	`\cdot`: "·", `\circ`: "∘", `\bullet`: "•", `\star`: "★",
+	`\approx`: "≈", `\neq`: "≠", `\leq`: "≤", `\geq`: "≥",
+	`\le`: "≤", `\ge`: "≥", `\ll`: "≪", `\gg`: "≫",
+	`\equiv`: "≡", `\sim`: "∼", `\simeq`: "≃", `\propto`: "∝",
+	`\perp`: "⊥", `\parallel`: "∥", `\angle`: "∠",
+	`\triangle`: "△", `\square`: "□",
+	`\subseteq`: "⊆", `\supseteq`: "⊇", `\subset`: "⊂", `\supset`: "⊃",
+	`\notin`: "∉", `\in`: "∈",
+	`\cup`: "∪", `\cap`: "∩", `\emptyset`: "∅", `\varnothing`: "∅",
+	`\forall`: "∀", `\exists`: "∃", `\neg`: "¬", `\land`: "∧", `\lor`: "∨",
+	`\oplus`: "⊕", `\otimes`: "⊗", `\odot`: "⊙",
+	`\hbar`: "ℏ", `\ell`: "ℓ", `\Re`: "ℜ", `\Im`: "ℑ",
+	`\aleph`: "ℵ", `\wp`: "℘", `\prime`: "′",
+	`\dagger`: "†", `\ddagger`: "‡",
+	`\cdots`: "⋯", `\ldots`: "…", `\vdots`: "⋮", `\ddots`: "⋱",
+	`\%`: "%", `\&`: "&", `\#`: "#", `\_`: "_",
+	`\{`: "{", `\}`: "}",
+}
 
-func looksLikeMath(s string) bool {
-	return mathIndicatorRe.MatchString(s)
+var arrows = map[string]string{
+	`\rightarrow`: "→", `\to`: "→", `\leftarrow`: "←", `\gets`: "←",
+	`\leftrightarrow`: "↔",
+	`\Rightarrow`:     "⇒", `\Leftarrow`: "⇐", `\Leftrightarrow`: "⇔",
+	`\uparrow`: "↑", `\downarrow`: "↓", `\updownarrow`: "↕",
+	`\Uparrow`: "⇑", `\Downarrow`: "⇓", `\Updownarrow`: "⇕",
+	`\mapsto`: "↦", `\hookrightarrow`: "↪",
+	`\nearrow`: "↗", `\searrow`: "↘", `\swarrow`: "↙", `\nwarrow`: "↖",
+	`\rightharpoonup`: "⇀", `\leftharpoonup`: "↼",
+}
+
+var delimiters = map[string]string{
+	`\left(`: "(", `\right)`: ")",
+	`\left[`: "[", `\right]`: "]",
+	`\left\{`: "{", `\right\}`: "}",
+	`\left|`: "|", `\right|`: "|",
+	`\bigl(`: "(", `\bigr)`: ")",
+	`\Bigl(`: "(", `\Bigr)`: ")",
+	`\left.`: "", `\right.`: "",
 }

--- a/channel/math.go
+++ b/channel/math.go
@@ -86,8 +86,10 @@ func cleanSpaces(s string) string {
 	return strings.Join(lines, "\n")
 }
 
-// alignLines pads lines so content after \x00 markers aligns.
-// The parser emits \x00 for each & alignment marker.
+// alignLines pads columns so that &-separated cells align in each group.
+// The parser emits \x00 for each & alignment marker. Lines may have
+// multiple \x00 markers (matrix columns). Each column is padded to
+// the max display-width of that column across the group.
 func alignLines(s string) string {
 	if !strings.ContainsRune(s, '\x00') {
 		return s
@@ -102,28 +104,55 @@ func alignLines(s string) string {
 		for i < len(lines) && strings.ContainsRune(lines[i], '\x00') {
 			i++
 		}
-		// Find max display-width before marker in group
-		maxW := 0
-		for j := start; j < i; j++ {
-			idx := strings.IndexRune(lines[j], '\x00')
-			if idx >= 0 {
-				w := ansi.StringWidth(lines[j][:idx])
-				if w > maxW {
-					maxW = w
+		alignGroup(lines, start, i)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// alignGroup pads a contiguous group of lines [start, end) so that
+// each \x00-delimited column is aligned by display width.
+func alignGroup(lines []string, start, end int) {
+	// Split each line into columns by \x00
+	cols := make([][]string, end-start)
+	maxCols := 0
+	for j := start; j < end; j++ {
+		parts := strings.Split(lines[j], "\x00")
+		cols[j-start] = parts
+		if len(parts) > maxCols {
+			maxCols = len(parts)
+		}
+	}
+	// For each column index, find max display width
+	colWidths := make([]int, maxCols)
+	for c := 0; c < maxCols; c++ {
+		for j := range cols {
+			if c < len(cols[j]) {
+				w := ansi.StringWidth(cols[j][c])
+				if w > colWidths[c] {
+					colWidths[c] = w
 				}
 			}
 		}
-		// Pad each line to maxW
-		for j := start; j < i; j++ {
-			idx := strings.IndexRune(lines[j], '\x00')
-			if idx >= 0 {
-				w := ansi.StringWidth(lines[j][:idx])
-				pad := maxW - w
-				lines[j] = lines[j][:idx] + strings.Repeat(" ", pad) + lines[j][idx+1:]
+	}
+	// Rebuild each line with padding
+	for j := start; j < end; j++ {
+		var buf strings.Builder
+		parts := cols[j-start]
+		for c, part := range parts {
+			if c > 0 {
+				buf.WriteString(" ") // column separator space
+			}
+			buf.WriteString(part)
+			if c < len(parts)-1 {
+				// Pad to column width
+				w := ansi.StringWidth(part)
+				if w < colWidths[c] {
+					buf.WriteString(strings.Repeat(" ", colWidths[c]-w))
+				}
 			}
 		}
+		lines[j] = buf.String()
 	}
-	return strings.Join(lines, "\n")
 }
 
 // ─── Recursive-descent parser ───
@@ -323,6 +352,10 @@ func (p *parser) parseEscape() string {
 		if p.pos < len(p.input) && p.peek() == '{' {
 			p.pos++
 			p.readUntilRune('}')
+		}
+		// Consume trailing newline to avoid blank lines
+		if p.pos < len(p.input) && p.input[p.pos] == '\n' {
+			p.pos++
 		}
 		return ""
 	}

--- a/channel/math.go
+++ b/channel/math.go
@@ -92,23 +92,37 @@ func latexToUnicode(src string) string {
 	// 1. Line breaks: \\ → newline (before symbol replacement eats them)
 	out = lineBreakRe.ReplaceAllString(out, "\n")
 
-	// 2. Unwrap text-style commands that take a braced argument:
+	// 2. Alignment markers: &= → =, & → space (LaTeX align env)
+	//    Must happen before symbol replacement.
+	out = strings.ReplaceAll(out, "&=", "=")
+	out = strings.ReplaceAll(out, "&", " ")
+
+	// 3. Unwrap text-style commands that take a braced argument:
 	//    \text{prime} → prime,  \mathrm{x} → x
 	//    Must happen BEFORE subscript/superscript so the content is plain text.
 	out = unwrapTextCommands(out)
 
-	// 3. Named Greek letters (longest-first)
+	// 4. Named Greek letters (longest-first)
 	out = replaceLongestFirst(out, greekLetters)
 
-	// 4. Named operators + delimiters merged into one longest-first pass.
+	// 5. Named operators + delimiters merged into one longest-first pass.
 	//    CRITICAL: \left[ (7 chars) must beat \le (3 chars).
-	//    When separate, operators ran first and \le ate the start of \left.
 	out = replaceLongestFirst(out, mergedOperators)
 
-	// 5. Named arrows
+	// 6. Named arrows
 	out = replaceLongestFirst(out, arrows)
 
-	// 6. Whitespace commands
+	// 7. Math functions: \sin, \cos, \log, \det, etc.
+	//    These are just words — strip the backslash.
+	out = mathFuncRe.ReplaceAllString(out, "$1")
+
+	// 8. Accents: \hat{x} → x̂, \vec{x} → x⃗, etc.
+	out = renderAccents(out)
+
+	// 9. Binomial: \binom{n}{k} → (n k)
+	out = renderBinomials(out)
+
+	// 10. Whitespace commands
 	out = strings.ReplaceAll(out, `\,`, " ")
 	out = strings.ReplaceAll(out, `\;`, " ")
 	out = strings.ReplaceAll(out, `\quad`, "  ")
@@ -116,16 +130,16 @@ func latexToUnicode(src string) string {
 	out = strings.ReplaceAll(out, `\ `, " ")
 	out = strings.ReplaceAll(out, `~`, " ")
 
-	// 7. Structural constructs — brace-aware parsing
+	// 11. Structural constructs — brace-aware parsing
 	out = renderFractions(out)
 	out = renderSquareRoots(out)
 	out = renderOver(out)
 
-	// 8. Superscripts / subscripts — brace-aware
+	// 12. Superscripts / subscripts — brace-aware
 	out = renderSuperscripts(out)
 	out = renderSubscripts(out)
 
-	// 9. Strip remaining bare text-style commands (no braces left)
+	// 13. Strip remaining bare text-style commands (no braces left)
 	for _, cmd := range []string{
 		`\text`, `\mathrm`, `\mathbf`, `\mathit`, `\mathcal`,
 		`\mathbb`, `\mathfrak`, `\mathsf`, `\mathtt`,
@@ -136,13 +150,16 @@ func latexToUnicode(src string) string {
 		out = strings.ReplaceAll(out, cmd, "")
 	}
 
-	// 10. Remove leftover braces iteratively (innermost first)
+	// 14. Remove leftover braces iteratively (innermost first)
 	out = removeBraces(out)
 
-	// 11. Remaining \cmd → strip backslash
+	// 15. Remaining \cmd → strip backslash
 	out = unknownCmdRe.ReplaceAllString(out, "$1")
 
-	return strings.TrimSpace(out)
+	// 16. Clean up multiple spaces and leading/trailing whitespace per line
+	out = cleanSpaces(out)
+
+	return out
 }
 
 // replaceLongestFirst replaces all keys in m with values,
@@ -177,8 +194,95 @@ func sortedKeysByLenDesc(m map[string]string) []string {
 var envRe = regexp.MustCompile(`\\(?:begin|end)\{[^}]*}`)
 
 // lineBreakRe matches LaTeX line breaks \\ (but not \{ or other escapes).
-// Must handle \\ at end of line and mid-expression.
 var lineBreakRe = regexp.MustCompile(`\\\\\s*`)
+
+// mathFuncRe matches standard math function names: \sin, \cos, \log, etc.
+var mathFuncRe = regexp.MustCompile(`\\(sin|cos|tan|cot|sec|csc|arcsin|arccos|arctan|sinh|cosh|tanh|coth|ln|log|exp|lim|sup|inf|det|dim|ker|deg|gcd|min|max|arg|hom|Pr|sgn|mod|bmod|pmod)\b`)
+
+// accentCmdRe matches \hat{x}, \vec{x}, etc. — applies combining Unicode.
+var accentCmdRe = regexp.MustCompile(`\\(hat|check|breve|acute|grave|tilde|bar|vec|dot|ddot|ring|widehat|widetilde|overline|underline|overrightarrow|overleftarrow)\{([^{}]*)}`)
+
+var accentMap = map[string]string{
+	"hat":            "\u0302", // ̂
+	"check":          "\u030C", // ̌
+	"breve":          "\u0306", // ̆
+	"acute":          "\u0301", // ́
+	"grave":          "\u0300", // ̀
+	"tilde":          "\u0303", // ̃
+	"widehat":        "\u0302",
+	"widetilde":      "\u0303",
+	"bar":            "\u0304", // ̄
+	"overline":       "\u0304",
+	"underline":      "\u0332", // ̲
+	"vec":            "\u20D7", // ⃗
+	"overrightarrow": "\u20D7",
+	"overleftarrow":  "\u20D6", // ⃖
+	"dot":            "\u0307", // ̇
+	"ddot":           "\u0308", // ̈
+	"ring":           "\u030A", // ̊
+}
+
+func renderAccents(s string) string {
+	return accentCmdRe.ReplaceAllStringFunc(s, func(match string) string {
+		sub := accentCmdRe.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		cmd, content := sub[1], sub[2]
+		if combining, ok := accentMap[cmd]; ok {
+			// Apply combining char to first rune of content
+			runes := []rune(content)
+			if len(runes) == 0 {
+				return content
+			}
+			var buf strings.Builder
+			buf.WriteRune(runes[0])
+			buf.WriteString(combining)
+			for _, r := range runes[1:] {
+				buf.WriteRune(r)
+			}
+			return buf.String()
+		}
+		return content
+	})
+}
+
+// binomRe matches \binom{n}{k} and \tbinom{n}{k}.
+func renderBinomials(s string) string {
+	for {
+		idx := strings.Index(s, `\binom{`)
+		if idx < 0 {
+			if idx = strings.Index(s, `\tbinom{`); idx < 0 {
+				break
+			}
+		}
+		// Find cmd start
+		cmdStart := idx
+		pos := idx
+		// Skip \binom or \tbinom
+		for pos < len(s) && s[pos] != '{' {
+			pos++
+		}
+		if pos >= len(s) {
+			break
+		}
+		n, afterN := extractBraced(s, pos)
+		if afterN == pos {
+			break
+		}
+		kPos := skipSpaces(s, afterN)
+		if kPos >= len(s) || s[kPos] != '{' {
+			break
+		}
+		k, afterK := extractBraced(s, kPos)
+		if afterK == kPos {
+			break
+		}
+		replacement := "(" + n + " " + k + ")"
+		s = s[:cmdStart] + replacement + s[afterK:]
+	}
+	return s
+}
 
 // textCmdRe matches \text{content}, \mathrm{content}, etc. — unwraps the
 // braced argument, keeping only the inner text. This prevents subscript
@@ -456,6 +560,20 @@ func removeBraces(s string) string {
 	return s
 }
 
+// multiSpaceRe collapses 3+ consecutive spaces to 2.
+var multiSpaceRe = regexp.MustCompile(` {3,}`)
+
+// cleanSpaces collapses multiple spaces and trims each line.
+func cleanSpaces(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		line = multiSpaceRe.ReplaceAllString(line, "  ")
+		line = strings.TrimSpace(line)
+		lines[i] = line
+	}
+	return strings.Join(lines, "\n")
+}
+
 // =====================================================================
 // Symbol tables
 // =====================================================================
@@ -486,6 +604,15 @@ var mergedOperators = map[string]string{
 	`\left.`: "", `\right.`: "",
 	`\bigl(`: "(", `\bigr)`: ")",
 	`\Bigl(`: "(", `\Bigr)`: ")",
+	`\left\lvert`: "|", `\right\rvert`: "|",
+	`\left\langle`: "⟨", `\right\rangle`: "⟩",
+	// Bracket symbols
+	`\langle`: "⟨", `\rangle`: "⟩",
+	`\lfloor`: "⌊", `\rfloor`: "⌋",
+	`\lceil`: "⌈", `\rceil`: "⌉",
+	`\lbrace`: "{", `\rbrace`: "}",
+	`\lvert`: "|", `\rvert`: "|",
+	`\Vert`: "‖", `\vert`: "|",
 	// Core operators
 	`\sum`: "∑", `\prod`: "∏", `\coprod`: "∐",
 	`\oint`: "∮", `\iiint`: "∭", `\iint`: "∬", `\int`: "∫",
@@ -506,8 +633,25 @@ var mergedOperators = map[string]string{
 	`\aleph`: "ℵ", `\wp`: "℘", `\prime`: "′",
 	`\dagger`: "†", `\ddagger`: "‡",
 	`\cdots`: "⋯", `\ldots`: "…", `\vdots`: "⋮", `\ddots`: "⋱",
-	// Symbols previously missing
-	`\mid`: "∣", `\vert`: "|", `\Vert`: "‖",
+	// Additional operators
+	`\mid`:     "∣",
+	`\implies`: "⟹", `\iff`: "⟺", `\impliedby`: "⟸",
+	`\therefore`: "∴", `\because`: "∵",
+	`\surd`: "√",
+	`\cong`: "≅", `\doteq`: "≐",
+	`\lesssim`: "≲", `\gtrsim`: "≳",
+	`\prec`: "≺", `\succ`: "≻",
+	`\bowtie`: "⋈",
+	`\uplus`:  "⊎", `\setminus`: "∖",
+	`\wr`:      "≀",
+	`\diamond`: "◇",
+	`\Join`:    "⋈",
+	`\bigcirc`: "◯",
+	`\amalg`:   "∐",
+	`\sharp`:   "♯", `\flat`: "♭", `\natural`: "♮",
+	`\Box`: "□", `\Diamond`: "◇",
+	`\clubsuit`: "♣", `\diamondsuit`: "♦", `\heartsuit`: "♥", `\spadesuit`: "♠",
+	// Sizing — just strip these
 	`\big`: "", `\Big`: "", `\bigg`: "", `\Bigg`: "",
 	// Escaped special chars
 	`\%`: "%", `\&`: "&", `\#`: "#", `\_`: "_",

--- a/channel/math.go
+++ b/channel/math.go
@@ -86,19 +86,29 @@ func looksLikeMath(s string) bool {
 func latexToUnicode(src string) string {
 	out := src
 
-	// 1. Named Greek letters (longest-first to avoid partial match)
+	// 0. Strip LaTeX environments early: \begin{cases}, \end{aligned}, etc.
+	out = envRe.ReplaceAllString(out, "")
+
+	// 1. Line breaks: \\ → newline (before symbol replacement eats them)
+	out = lineBreakRe.ReplaceAllString(out, "\n")
+
+	// 2. Unwrap text-style commands that take a braced argument:
+	//    \text{prime} → prime,  \mathrm{x} → x
+	//    Must happen BEFORE subscript/superscript so the content is plain text.
+	out = unwrapTextCommands(out)
+
+	// 3. Named Greek letters (longest-first)
 	out = replaceLongestFirst(out, greekLetters)
 
-	// 2. Named operators (longest-first: \int before \in, \leq before \le)
-	out = replaceLongestFirst(out, operators)
+	// 4. Named operators + delimiters merged into one longest-first pass.
+	//    CRITICAL: \left[ (7 chars) must beat \le (3 chars).
+	//    When separate, operators ran first and \le ate the start of \left.
+	out = replaceLongestFirst(out, mergedOperators)
 
-	// 3. Named arrows
+	// 5. Named arrows
 	out = replaceLongestFirst(out, arrows)
 
-	// 4. Bracket delimiters
-	out = replaceLongestFirst(out, delimiters)
-
-	// 5. Whitespace commands
+	// 6. Whitespace commands
 	out = strings.ReplaceAll(out, `\,`, " ")
 	out = strings.ReplaceAll(out, `\;`, " ")
 	out = strings.ReplaceAll(out, `\quad`, "  ")
@@ -106,30 +116,30 @@ func latexToUnicode(src string) string {
 	out = strings.ReplaceAll(out, `\ `, " ")
 	out = strings.ReplaceAll(out, `~`, " ")
 
-	// 6. Structural constructs — use brace-aware parsing, NOT regex
+	// 7. Structural constructs — brace-aware parsing
 	out = renderFractions(out)
 	out = renderSquareRoots(out)
 	out = renderOver(out)
 
-	// 7. Superscripts / subscripts — brace-aware
+	// 8. Superscripts / subscripts — brace-aware
 	out = renderSuperscripts(out)
 	out = renderSubscripts(out)
 
-	// 8. Cleanup text-style commands
+	// 9. Strip remaining bare text-style commands (no braces left)
 	for _, cmd := range []string{
 		`\text`, `\mathrm`, `\mathbf`, `\mathit`, `\mathcal`,
 		`\mathbb`, `\mathfrak`, `\mathsf`, `\mathtt`,
-		`\operatorname`, `\mathrm`, `\textbf`, `\textit`,
+		`\operatorname`, `\textbf`, `\textit`,
 		`\displaystyle`, `\textstyle`, `\scriptstyle`,
 		`\limits`, `\nolimits`,
 	} {
 		out = strings.ReplaceAll(out, cmd, "")
 	}
 
-	// 9. Remove leftover braces iteratively (innermost first)
+	// 10. Remove leftover braces iteratively (innermost first)
 	out = removeBraces(out)
 
-	// 10. Remaining \cmd → strip backslash
+	// 11. Remaining \cmd → strip backslash
 	out = unknownCmdRe.ReplaceAllString(out, "$1")
 
 	return strings.TrimSpace(out)
@@ -162,6 +172,22 @@ func sortedKeysByLenDesc(m map[string]string) []string {
 // =====================================================================
 // Brace-aware structural parsers
 // =====================================================================
+
+// envRe strips \begin{xxx} and \end{xxx} environment markers.
+var envRe = regexp.MustCompile(`\\(?:begin|end)\{[^}]*}`)
+
+// lineBreakRe matches LaTeX line breaks \\ (but not \{ or other escapes).
+// Must handle \\ at end of line and mid-expression.
+var lineBreakRe = regexp.MustCompile(`\\\\\s*`)
+
+// textCmdRe matches \text{content}, \mathrm{content}, etc. — unwraps the
+// braced argument, keeping only the inner text. This prevents subscript
+// conversion from mangling words like "prime" into ₚᵣᵢₘₑ.
+var textCmdRe = regexp.MustCompile(`\\(?:text|mathrm|mathbf|mathit|mathcal|mathbb|mathfrak|mathsf|mathtt|operatorname|textbf|textit)\{([^{}]*)}`)
+
+func unwrapTextCommands(s string) string {
+	return textCmdRe.ReplaceAllString(s, "$1")
+}
 
 // extractBraced finds the content inside {…} starting at position pos.
 // Handles nested braces correctly. Returns the inner content and the
@@ -449,7 +475,18 @@ var greekLetters = map[string]string{
 	`\Phi`: "Φ", `\Psi`: "Ψ", `\Omega`: "Ω",
 }
 
-var operators = map[string]string{
+// mergedOperators = operators + delimiters merged into a single map
+// so that longest-first replacement handles \left[ (7ch) > \le (3ch).
+var mergedOperators = map[string]string{
+	// Delimiters (longer keys first implicitly via longest-first sort)
+	`\left\{`: "{", `\right\}`: "}",
+	`\left(`: "(", `\right)`: ")",
+	`\left[`: "[", `\right]`: "]",
+	`\left|`: "|", `\right|`: "|",
+	`\left.`: "", `\right.`: "",
+	`\bigl(`: "(", `\bigr)`: ")",
+	`\Bigl(`: "(", `\Bigr)`: ")",
+	// Core operators
 	`\sum`: "∑", `\prod`: "∏", `\coprod`: "∐",
 	`\oint`: "∮", `\iiint`: "∭", `\iint`: "∬", `\int`: "∫",
 	`\partial`: "∂", `\nabla`: "∇", `\infty`: "∞",
@@ -469,6 +506,10 @@ var operators = map[string]string{
 	`\aleph`: "ℵ", `\wp`: "℘", `\prime`: "′",
 	`\dagger`: "†", `\ddagger`: "‡",
 	`\cdots`: "⋯", `\ldots`: "…", `\vdots`: "⋮", `\ddots`: "⋱",
+	// Symbols previously missing
+	`\mid`: "∣", `\vert`: "|", `\Vert`: "‖",
+	`\big`: "", `\Big`: "", `\bigg`: "", `\Bigg`: "",
+	// Escaped special chars
 	`\%`: "%", `\&`: "&", `\#`: "#", `\_`: "_",
 	`\{`: "{", `\}`: "}",
 }
@@ -482,14 +523,4 @@ var arrows = map[string]string{
 	`\mapsto`: "↦", `\hookrightarrow`: "↪",
 	`\nearrow`: "↗", `\searrow`: "↘", `\swarrow`: "↙", `\nwarrow`: "↖",
 	`\rightharpoonup`: "⇀", `\leftharpoonup`: "↼",
-}
-
-var delimiters = map[string]string{
-	`\left(`: "(", `\right)`: ")",
-	`\left[`: "[", `\right]`: "]",
-	`\left\{`: "{", `\right\}`: "}",
-	`\left|`: "|", `\right|`: "|",
-	`\bigl(`: "(", `\bigr)`: ")",
-	`\Bigl(`: "(", `\Bigr)`: ")",
-	`\left.`: "", `\right.`: "",
 }

--- a/channel/math.go
+++ b/channel/math.go
@@ -73,12 +73,17 @@ func renderLaTeX(src string) string {
 	raw := p.parseTop()
 	raw = cleanSpaces(raw)
 	raw = alignLines(raw)
+	raw = renderEnvironments(raw)
 	return strings.TrimRight(raw, "\n")
 }
 
 func cleanSpaces(s string) string {
 	lines := strings.Split(s, "\n")
 	for i, line := range lines {
+		// Skip ENV marker lines
+		if strings.ContainsRune(line, '\x01') {
+			continue
+		}
 		line = multiSpaceRe.ReplaceAllString(line, "  ")
 		line = strings.TrimRight(line, " \t")
 		lines[i] = line
@@ -86,22 +91,169 @@ func cleanSpaces(s string) string {
 	return strings.Join(lines, "\n")
 }
 
+// ─── Environment rendering (brackets + side-by-side) ───
+
+// envBlock represents a parsed block between ENV markers or plain text.
+type envBlock struct {
+	lines []string
+	env   string // "bmatrix", "pmatrix", "" for plain text
+}
+
+// envBrackets maps environment names to bracket pairs.
+var envBrackets = map[string][2]string{
+	"bmatrix": {"[", "]"},
+	"pmatrix": {"(", ")"},
+	"vmatrix": {"|", "|"},
+	"Vmatrix": {"‖", "‖"},
+	"Bmatrix": {"{", "}"},
+}
+
+// renderEnvironments processes ENV markers: adds brackets to matrix blocks
+// and renders adjacent blocks side-by-side.
+func renderEnvironments(s string) string {
+	if !strings.ContainsRune(s, '\x01') {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	blocks := parseBlocks(lines)
+	if len(blocks) == 0 {
+		return s
+	}
+
+	// Add brackets to env blocks
+	for i := range blocks {
+		if bk, ok := envBrackets[blocks[i].env]; ok {
+			left, right := bk[0], bk[1]
+			for j := range blocks[i].lines {
+				blocks[i].lines[j] = left + " " + blocks[i].lines[j] + " " + right
+			}
+		}
+	}
+
+	// Render all adjacent blocks side-by-side
+	return renderRow(blocks)
+}
+
+// parseBlocks splits lines into blocks using ENV markers.
+func parseBlocks(lines []string) []envBlock {
+	var blocks []envBlock
+	var current *envBlock
+
+	for _, line := range lines {
+		if strings.ContainsRune(line, '\x01') {
+			if strings.HasPrefix(line, "\x01ENV:") {
+				envName := line[strings.IndexByte(line, ':')+1:]
+				if idx := strings.IndexByte(envName, '\x02'); idx >= 0 {
+					envName = envName[:idx]
+				}
+				current = &envBlock{env: envName}
+			} else if strings.HasPrefix(line, "\x01/ENV:") {
+				if current != nil && len(current.lines) > 0 {
+					blocks = append(blocks, *current)
+				}
+				current = nil
+			}
+			continue
+		}
+		if current != nil {
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" {
+				current.lines = append(current.lines, line)
+			}
+		} else if strings.TrimSpace(line) != "" {
+			blocks = append(blocks, envBlock{lines: []string{line}})
+		}
+	}
+	if current != nil && len(current.lines) > 0 {
+		blocks = append(blocks, *current)
+	}
+	return blocks
+}
+
+// renderRow renders blocks side-by-side, centering shorter blocks vertically.
+func renderRow(blocks []envBlock) string {
+	if len(blocks) == 0 {
+		return ""
+	}
+	if len(blocks) == 1 {
+		return strings.Join(blocks[0].lines, "\n")
+	}
+
+	// Find max height
+	maxH := 0
+	for _, b := range blocks {
+		if len(b.lines) > maxH {
+			maxH = len(b.lines)
+		}
+	}
+
+	// Compute display width of each block (max line width)
+	widths := make([]int, len(blocks))
+	for i, b := range blocks {
+		for _, line := range b.lines {
+			w := ansi.StringWidth(line)
+			if w > widths[i] {
+				widths[i] = w
+			}
+		}
+	}
+
+	// Pad each block vertically (center) and horizontally (to block width)
+	padded := make([][]string, len(blocks))
+	for i, b := range blocks {
+		topPad := (maxH - len(b.lines)) / 2
+		var paddedLines []string
+		blank := strings.Repeat(" ", widths[i])
+		for j := 0; j < topPad; j++ {
+			paddedLines = append(paddedLines, blank)
+		}
+		for _, line := range b.lines {
+			w := ansi.StringWidth(line)
+			if w < widths[i] {
+				line += strings.Repeat(" ", widths[i]-w)
+			}
+			paddedLines = append(paddedLines, line)
+		}
+		for j := topPad + len(b.lines); j < maxH; j++ {
+			paddedLines = append(paddedLines, blank)
+		}
+		padded[i] = paddedLines
+	}
+
+	// Interleave lines from all blocks
+	var out strings.Builder
+	for row := 0; row < maxH; row++ {
+		if row > 0 {
+			out.WriteRune('\n')
+		}
+		for col := 0; col < len(blocks); col++ {
+			out.WriteString(padded[col][row])
+			if col < len(blocks)-1 {
+				out.WriteString(" ")
+			}
+		}
+	}
+	return out.String()
+}
+
 // alignLines pads columns so that &-separated cells align in each group.
 // The parser emits \x00 for each & alignment marker. Lines may have
 // multiple \x00 markers (matrix columns). Each column is padded to
 // the max display-width of that column across the group.
+// Lines containing \x01 (ENV markers) are skipped.
 func alignLines(s string) string {
 	if !strings.ContainsRune(s, '\x00') {
 		return s
 	}
 	lines := strings.Split(s, "\n")
 	for i := 0; i < len(lines); {
-		if !strings.ContainsRune(lines[i], '\x00') {
+		// Skip lines without \x00 or with ENV markers
+		if !strings.ContainsRune(lines[i], '\x00') || strings.ContainsRune(lines[i], '\x01') {
 			i++
 			continue
 		}
 		start := i
-		for i < len(lines) && strings.ContainsRune(lines[i], '\x00') {
+		for i < len(lines) && strings.ContainsRune(lines[i], '\x00') && !strings.ContainsRune(lines[i], '\x01') {
 			i++
 		}
 		alignGroup(lines, start, i)
@@ -348,16 +500,22 @@ func (p *parser) parseEscape() string {
 		}
 		return ""
 	case "begin", "end":
+		isEnd := name == "end"
 		p.skipSpaces()
+		envName := ""
 		if p.pos < len(p.input) && p.peek() == '{' {
 			p.pos++
-			p.readUntilRune('}')
+			envName = p.readUntilRune('}')
 		}
 		// Consume trailing newline to avoid blank lines
 		if p.pos < len(p.input) && p.input[p.pos] == '\n' {
 			p.pos++
 		}
-		return ""
+		prefix := "\n\x01ENV:"
+		if isEnd {
+			prefix = "\n\x01/ENV:"
+		}
+		return prefix + envName + "\x02\n"
 	}
 
 	// --- Symbol lookup ---

--- a/channel/math.go
+++ b/channel/math.go
@@ -224,10 +224,13 @@ func (p *parser) parseArg() string {
 func (p *parser) parseEscape() string {
 	p.pos++ // skip \
 
-	// \\ → newline
+	// \\ → newline, also consume trailing source newline
 	if p.pos < len(p.input) && p.input[p.pos] == '\\' {
 		p.pos++
 		p.skipSpaces()
+		if p.pos < len(p.input) && p.input[p.pos] == '\n' {
+			p.pos++
+		}
 		return "\n"
 	}
 

--- a/channel/math.go
+++ b/channel/math.go
@@ -7,19 +7,18 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// mathBlockRe matches $$...$$ display math blocks (dotall, non-greedy).
-var mathBlockRe = regexp.MustCompile(`(?s)\$\$\s*(.*?)\s*\$\$`)
+// ─── Markdown-level extraction (regex, unavoidable) ───
 
-// mathInlineRe matches $...$ inline math.
-// Broad match; validated in replacement via looksLikeMath.
-var mathInlineRe = regexp.MustCompile(`\$([^\$\n]+?)\$`)
+var (
+	mathBlockRe     = regexp.MustCompile(`(?s)\$\$\s*(.*?)\s*\$\$`)
+	mathInlineRe    = regexp.MustCompile(`\$([^\$\n]+?)\$`)
+	mathIndicatorRe = regexp.MustCompile(`\\[a-zA-Z]|\^|_|[{}]`)
+	multiSpaceRe    = regexp.MustCompile(` {3,}`)
+)
 
-// renderMathBlocks pre-processes markdown content containing LaTeX math
-// expressions, converting them to Unicode/plain-text representations that
-// the terminal can display. Follows the same pre-processing pattern as
-// renderMermaidBlocks.
+// renderMathBlocks pre-processes markdown, converting LaTeX math blocks/inline
+// to Unicode via renderLaTeX. Block math wraps in code fences for glamour.
 func renderMathBlocks(content string, maxW int) string {
-	// Phase 1: block math → code block
 	content = mathBlockRe.ReplaceAllStringFunc(content, func(match string) string {
 		sub := mathBlockRe.FindStringSubmatch(match)
 		if len(sub) < 2 {
@@ -29,14 +28,13 @@ func renderMathBlocks(content string, maxW int) string {
 		if src == "" {
 			return match
 		}
-		rendered := latexToUnicode(src)
+		rendered := renderLaTeX(src)
 		if maxW > 0 {
 			rendered = truncateMathLines(rendered, maxW)
 		}
 		return "```\n" + rendered + "\n```"
 	})
 
-	// Phase 2: inline math → Unicode text
 	content = mathInlineRe.ReplaceAllStringFunc(content, func(match string) string {
 		sub := mathInlineRe.FindStringSubmatch(match)
 		if len(sub) < 2 {
@@ -46,13 +44,15 @@ func renderMathBlocks(content string, maxW int) string {
 		if src == "" || !looksLikeMath(src) {
 			return match
 		}
-		return latexToUnicode(src)
+		return renderLaTeX(src)
 	})
-
 	return content
 }
 
-// truncateMathLines truncates each line to maxW display columns.
+func hasMath(content string) bool {
+	return mathBlockRe.MatchString(content) || mathInlineRe.MatchString(content)
+}
+func looksLikeMath(s string) bool { return mathIndicatorRe.MatchString(s) }
 func truncateMathLines(s string, maxW int) string {
 	lines := strings.Split(s, "\n")
 	for i, line := range lines {
@@ -66,141 +66,335 @@ func truncateMathLines(s string, maxW int) string {
 	return strings.Join(lines, "\n")
 }
 
-// hasMath detects whether content contains LaTeX math expressions.
-func hasMath(content string) bool {
-	return mathBlockRe.MatchString(content) || mathInlineRe.MatchString(content)
+// ─── Public entry ───
+
+func renderLaTeX(src string) string {
+	p := &parser{input: []rune(src)}
+	raw := p.parseTop()
+	raw = cleanSpaces(raw)
+	raw = alignLines(raw)
+	return strings.TrimRight(raw, "\n")
 }
 
-// looksLikeMath returns true if the content between $ delimiters looks like
-// a LaTeX math expression rather than plain text with dollar signs (currency).
-var mathIndicatorRe = regexp.MustCompile(`\\[a-zA-Z]|\^|_|[{}]`)
-
-func looksLikeMath(s string) bool {
-	return mathIndicatorRe.MatchString(s)
-}
-
-// =====================================================================
-// latexToUnicode — core LaTeX → Unicode converter
-// =====================================================================
-
-func latexToUnicode(src string) string {
-	out := src
-
-	// 0. Strip LaTeX environments early: \begin{cases}, \end{aligned}, etc.
-	out = envRe.ReplaceAllString(out, "")
-
-	// 1. Line breaks: \\ → newline (before symbol replacement eats them)
-	out = lineBreakRe.ReplaceAllString(out, "\n")
-
-	// 2. Alignment markers: &= → =, & → space (LaTeX align env)
-	//    Must happen before symbol replacement.
-	out = strings.ReplaceAll(out, "&=", "=")
-	out = strings.ReplaceAll(out, "&", " ")
-
-	// 3. Unwrap text-style commands that take a braced argument:
-	//    \text{prime} → prime,  \mathrm{x} → x
-	//    Must happen BEFORE subscript/superscript so the content is plain text.
-	out = unwrapTextCommands(out)
-
-	// 4. Named Greek letters (longest-first)
-	out = replaceLongestFirst(out, greekLetters)
-
-	// 5. Named operators + delimiters merged into one longest-first pass.
-	//    CRITICAL: \left[ (7 chars) must beat \le (3 chars).
-	out = replaceLongestFirst(out, mergedOperators)
-
-	// 6. Named arrows
-	out = replaceLongestFirst(out, arrows)
-
-	// 7. Math functions: \sin, \cos, \log, \det, etc.
-	//    These are just words — strip the backslash.
-	out = mathFuncRe.ReplaceAllString(out, "$1")
-
-	// 8. Accents: \hat{x} → x̂, \vec{x} → x⃗, etc.
-	out = renderAccents(out)
-
-	// 9. Binomial: \binom{n}{k} → (n k)
-	out = renderBinomials(out)
-
-	// 10. Whitespace commands
-	out = strings.ReplaceAll(out, `\,`, " ")
-	out = strings.ReplaceAll(out, `\;`, " ")
-	out = strings.ReplaceAll(out, `\quad`, "  ")
-	out = strings.ReplaceAll(out, `\qquad`, "    ")
-	out = strings.ReplaceAll(out, `\ `, " ")
-	out = strings.ReplaceAll(out, `~`, " ")
-
-	// 11. Structural constructs — brace-aware parsing
-	out = renderFractions(out)
-	out = renderSquareRoots(out)
-	out = renderOver(out)
-
-	// 12. Superscripts / subscripts — brace-aware
-	out = renderSuperscripts(out)
-	out = renderSubscripts(out)
-
-	// 13. Strip remaining bare text-style commands (no braces left)
-	for _, cmd := range []string{
-		`\text`, `\mathrm`, `\mathbf`, `\mathit`, `\mathcal`,
-		`\mathbb`, `\mathfrak`, `\mathsf`, `\mathtt`,
-		`\operatorname`, `\textbf`, `\textit`,
-		`\displaystyle`, `\textstyle`, `\scriptstyle`,
-		`\limits`, `\nolimits`,
-	} {
-		out = strings.ReplaceAll(out, cmd, "")
+func cleanSpaces(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		line = multiSpaceRe.ReplaceAllString(line, "  ")
+		line = strings.TrimRight(line, " \t")
+		lines[i] = line
 	}
-
-	// 14. Remove leftover braces iteratively (innermost first)
-	out = removeBraces(out)
-
-	// 15. Remaining \cmd → strip backslash
-	out = unknownCmdRe.ReplaceAllString(out, "$1")
-
-	// 16. Clean up multiple spaces and leading/trailing whitespace per line
-	out = cleanSpaces(out)
-
-	return out
+	return strings.Join(lines, "\n")
 }
 
-// replaceLongestFirst replaces all keys in m with values,
-// processing longest keys first to prevent partial matches.
-func replaceLongestFirst(s string, m map[string]string) string {
-	keys := sortedKeysByLenDesc(m)
-	for _, k := range keys {
-		s = strings.ReplaceAll(s, k, m[k])
+// alignLines pads lines so content after \x00 markers aligns.
+// The parser emits \x00 for each & alignment marker.
+func alignLines(s string) string {
+	if !strings.ContainsRune(s, '\x00') {
+		return s
 	}
-	return s
-}
-
-func sortedKeysByLenDesc(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	// insertion sort by length descending
-	for i := 1; i < len(keys); i++ {
-		for j := i; j > 0 && len(keys[j]) > len(keys[j-1]); j-- {
-			keys[j], keys[j-1] = keys[j-1], keys[j]
+	lines := strings.Split(s, "\n")
+	for i := 0; i < len(lines); {
+		if !strings.ContainsRune(lines[i], '\x00') {
+			i++
+			continue
+		}
+		start := i
+		for i < len(lines) && strings.ContainsRune(lines[i], '\x00') {
+			i++
+		}
+		// Find max display-width before marker in group
+		maxW := 0
+		for j := start; j < i; j++ {
+			idx := strings.IndexRune(lines[j], '\x00')
+			if idx >= 0 {
+				w := ansi.StringWidth(lines[j][:idx])
+				if w > maxW {
+					maxW = w
+				}
+			}
+		}
+		// Pad each line to maxW
+		for j := start; j < i; j++ {
+			idx := strings.IndexRune(lines[j], '\x00')
+			if idx >= 0 {
+				w := ansi.StringWidth(lines[j][:idx])
+				pad := maxW - w
+				lines[j] = lines[j][:idx] + strings.Repeat(" ", pad) + lines[j][idx+1:]
+			}
 		}
 	}
-	return keys
+	return strings.Join(lines, "\n")
 }
 
-// =====================================================================
-// Brace-aware structural parsers
-// =====================================================================
+// ─── Recursive-descent parser ───
 
-// envRe strips \begin{xxx} and \end{xxx} environment markers.
-var envRe = regexp.MustCompile(`\\(?:begin|end)\{[^}]*}`)
+type parser struct {
+	input []rune
+	pos   int
+}
 
-// lineBreakRe matches LaTeX line breaks \\ (but not \{ or other escapes).
-var lineBreakRe = regexp.MustCompile(`\\\\\s*`)
+func (p *parser) peek() rune {
+	if p.pos >= len(p.input) {
+		return -1
+	}
+	return p.input[p.pos]
+}
 
-// mathFuncRe matches standard math function names: \sin, \cos, \log, etc.
-var mathFuncRe = regexp.MustCompile(`\\(sin|cos|tan|cot|sec|csc|arcsin|arccos|arctan|sinh|cosh|tanh|coth|ln|log|exp|lim|sup|inf|det|dim|ker|deg|gcd|min|max|arg|hom|Pr|sgn|mod|bmod|pmod)\b`)
+func (p *parser) next() rune {
+	if p.pos >= len(p.input) {
+		return -1
+	}
+	ch := p.input[p.pos]
+	p.pos++
+	return ch
+}
 
-// accentCmdRe matches \hat{x}, \vec{x}, etc. — applies combining Unicode.
-var accentCmdRe = regexp.MustCompile(`\\(hat|check|breve|acute|grave|tilde|bar|vec|dot|ddot|ring|widehat|widetilde|overline|underline|overrightarrow|overleftarrow)\{([^{}]*)}`)
+func (p *parser) skipSpaces() {
+	for p.pos < len(p.input) && (p.input[p.pos] == ' ' || p.input[p.pos] == '\t') {
+		p.pos++
+	}
+}
+
+func (p *parser) readAlpha() string {
+	start := p.pos
+	for p.pos < len(p.input) && isAlpha(p.input[p.pos]) {
+		p.pos++
+	}
+	return string(p.input[start:p.pos])
+}
+
+func isAlpha(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}
+
+// parseTop is the entry: parse until EOF.
+func (p *parser) parseTop() string { return p.parse(-1) }
+
+// parse reads input until stop rune is found (consumed) or EOF.
+// stop < 0 means no stop (parse to EOF).
+func (p *parser) parse(stop rune) string {
+	var buf strings.Builder
+	for p.pos < len(p.input) {
+		ch := p.peek()
+		if stop >= 0 && ch == stop {
+			p.pos++ // consume stop
+			return buf.String()
+		}
+		switch ch {
+		case '\\':
+			buf.WriteString(p.parseEscape())
+		case '^':
+			p.pos++
+			buf.WriteString(toSuperscript(p.parseArg()))
+		case '_':
+			p.pos++
+			buf.WriteString(toSubscript(p.parseArg()))
+		case '{':
+			p.pos++ // skip {
+			buf.WriteString(p.parse('}'))
+		case '}':
+			return buf.String() // don't consume; caller handles
+		case '&':
+			p.pos++
+			buf.WriteRune('\x00') // alignment marker
+		default:
+			buf.WriteRune(p.next())
+		}
+	}
+	return buf.String()
+}
+
+// parseArg reads a single argument: {content} or a single char/command.
+func (p *parser) parseArg() string {
+	p.skipSpaces()
+	if p.pos >= len(p.input) {
+		return ""
+	}
+	if p.peek() == '{' {
+		p.pos++ // skip {
+		return p.parse('}')
+	}
+	if p.peek() == '\\' {
+		return p.parseEscape()
+	}
+	return string(p.next())
+}
+
+// parseEscape handles a \command or escaped character.
+func (p *parser) parseEscape() string {
+	p.pos++ // skip \
+
+	// \\ → newline
+	if p.pos < len(p.input) && p.input[p.pos] == '\\' {
+		p.pos++
+		p.skipSpaces()
+		return "\n"
+	}
+
+	// Non-alpha escape: \{ \} \% \_ etc
+	if p.pos >= len(p.input) || !isAlpha(p.peek()) {
+		ch := p.next()
+		switch ch {
+		case ' ', ',', ';', '!':
+			return " "
+		}
+		return string(ch)
+	}
+
+	name := p.readAlpha()
+
+	// --- Structural commands ---
+	switch name {
+	case "frac", "dfrac":
+		num := p.parseArg()
+		den := p.parseArg()
+		return num + "/" + den
+	case "sqrt":
+		idx := ""
+		if p.pos < len(p.input) && p.peek() == '[' {
+			p.pos++ // skip [
+			idx = p.readUntilRune(']')
+		}
+		content := p.parseArg()
+		if idx != "" {
+			return toSuperscript(idx) + "√" + content
+		}
+		return "√" + content
+	case "binom", "tbinom":
+		n := p.parseArg()
+		k := p.parseArg()
+		return "(" + n + " " + k + ")"
+	case "over":
+		return "/" // best-effort for {a \over b}
+	}
+
+	// --- Accents ---
+	if combining, ok := accentMap[name]; ok {
+		content := p.parseArg()
+		runes := []rune(content)
+		if len(runes) == 0 {
+			return ""
+		}
+		var buf strings.Builder
+		buf.WriteRune(runes[0])
+		buf.WriteString(combining)
+		for _, r := range runes[1:] {
+			buf.WriteRune(r)
+		}
+		return buf.String()
+	}
+
+	// --- Text-unwrap commands ---
+	if textCmds[name] {
+		return p.parseArg()
+	}
+
+	// --- Delimiter commands ---
+	switch name {
+	case "left", "right":
+		p.skipSpaces()
+		if p.pos < len(p.input) {
+			if p.peek() == '\\' {
+				p.pos++ // skip \
+				if p.pos < len(p.input) {
+					ch := p.next()
+					return string(ch) // \left\{ → {
+				}
+				return ""
+			}
+			ch := p.next()
+			if ch == '.' {
+				return ""
+			}
+			return string(ch)
+		}
+		return ""
+	case "bigl", "bigr", "Bigl", "Bigr", "big", "Big", "bigg", "Bigg":
+		p.skipSpaces()
+		if p.pos < len(p.input) {
+			return string(p.next())
+		}
+		return ""
+	case "begin", "end":
+		p.skipSpaces()
+		if p.pos < len(p.input) && p.peek() == '{' {
+			p.pos++
+			p.readUntilRune('}')
+		}
+		return ""
+	}
+
+	// --- Symbol lookup ---
+	key := name // lookup without backslash prefix; table keys have no \
+	if sym, ok := symbols[key]; ok {
+		return sym
+	}
+
+	// --- Math functions ---
+	if mathFuncs[name] {
+		return name
+	}
+
+	// Unknown: strip backslash, keep name
+	return name
+}
+
+func (p *parser) readUntilRune(stop rune) string {
+	start := p.pos
+	for p.pos < len(p.input) && p.input[p.pos] != stop {
+		p.pos++
+	}
+	result := string(p.input[start:p.pos])
+	if p.pos < len(p.input) {
+		p.pos++ // consume stop
+	}
+	return result
+}
+
+// ─── Superscript / Subscript ───
+
+var supMap = map[rune]rune{
+	'0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
+	'5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹',
+	'+': '⁺', '-': '⁻', '=': '⁼', '(': '⁽', ')': '⁾',
+	'n': 'ⁿ', 'i': 'ⁱ',
+}
+
+var subMap = map[rune]rune{
+	'0': '₀', '1': '₁', '2': '₂', '3': '₃', '4': '₄',
+	'5': '₅', '6': '₆', '7': '₇', '8': '₈', '9': '₉',
+	'+': '₊', '-': '₋', '=': '₌', '(': '₍', ')': '₎',
+	'a': 'ₐ', 'e': 'ₑ', 'o': 'ₒ', 'x': 'ₓ',
+	'h': 'ₕ', 'k': 'ₖ', 'l': 'ₗ', 'm': 'ₘ', 'n': 'ₙ',
+	'p': 'ₚ', 's': 'ₛ', 't': 'ₜ',
+	'i': 'ᵢ', 'j': 'ⱼ', 'r': 'ᵣ', 'u': 'ᵤ', 'v': 'ᵥ',
+}
+
+func toSuperscript(s string) string {
+	var buf strings.Builder
+	for _, r := range s {
+		if sr, ok := supMap[r]; ok {
+			buf.WriteRune(sr)
+		} else {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
+}
+
+func toSubscript(s string) string {
+	var buf strings.Builder
+	for _, r := range s {
+		if sr, ok := subMap[r]; ok {
+			buf.WriteRune(sr)
+		} else {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
+}
+
+// ─── Accent combining characters ───
 
 var accentMap = map[string]string{
 	"hat":            "\u0302", // ̂
@@ -222,449 +416,87 @@ var accentMap = map[string]string{
 	"ring":           "\u030A", // ̊
 }
 
-func renderAccents(s string) string {
-	return accentCmdRe.ReplaceAllStringFunc(s, func(match string) string {
-		sub := accentCmdRe.FindStringSubmatch(match)
-		if len(sub) < 3 {
-			return match
-		}
-		cmd, content := sub[1], sub[2]
-		if combining, ok := accentMap[cmd]; ok {
-			// Apply combining char to first rune of content
-			runes := []rune(content)
-			if len(runes) == 0 {
-				return content
-			}
-			var buf strings.Builder
-			buf.WriteRune(runes[0])
-			buf.WriteString(combining)
-			for _, r := range runes[1:] {
-				buf.WriteRune(r)
-			}
-			return buf.String()
-		}
-		return content
-	})
+// textCmds lists commands that take a braced arg and just unwrap it.
+var textCmds = map[string]bool{
+	"text": true, "mathrm": true, "mathbf": true, "mathit": true,
+	"mathcal": true, "mathbb": true, "mathfrak": true, "mathsf": true,
+	"mathtt": true, "operatorname": true, "textbf": true, "textit": true,
 }
 
-// binomRe matches \binom{n}{k} and \tbinom{n}{k}.
-func renderBinomials(s string) string {
-	for {
-		idx := strings.Index(s, `\binom{`)
-		if idx < 0 {
-			if idx = strings.Index(s, `\tbinom{`); idx < 0 {
-				break
-			}
-		}
-		// Find cmd start
-		cmdStart := idx
-		pos := idx
-		// Skip \binom or \tbinom
-		for pos < len(s) && s[pos] != '{' {
-			pos++
-		}
-		if pos >= len(s) {
-			break
-		}
-		n, afterN := extractBraced(s, pos)
-		if afterN == pos {
-			break
-		}
-		kPos := skipSpaces(s, afterN)
-		if kPos >= len(s) || s[kPos] != '{' {
-			break
-		}
-		k, afterK := extractBraced(s, kPos)
-		if afterK == kPos {
-			break
-		}
-		replacement := "(" + n + " " + k + ")"
-		s = s[:cmdStart] + replacement + s[afterK:]
-	}
-	return s
+// mathFuncs lists function names whose backslash is stripped.
+var mathFuncs = map[string]bool{
+	"sin": true, "cos": true, "tan": true, "cot": true, "sec": true, "csc": true,
+	"arcsin": true, "arccos": true, "arctan": true,
+	"sinh": true, "cosh": true, "tanh": true, "coth": true,
+	"ln": true, "log": true, "exp": true, "lim": true,
+	"sup": true, "inf": true, "det": true, "dim": true,
+	"ker": true, "deg": true, "gcd": true, "min": true, "max": true,
+	"arg": true, "hom": true, "Pr": true, "sgn": true,
+	"mod": true, "bmod": true, "pmod": true,
 }
 
-// textCmdRe matches \text{content}, \mathrm{content}, etc. — unwraps the
-// braced argument, keeping only the inner text. This prevents subscript
-// conversion from mangling words like "prime" into ₚᵣᵢₘₑ.
-var textCmdRe = regexp.MustCompile(`\\(?:text|mathrm|mathbf|mathit|mathcal|mathbb|mathfrak|mathsf|mathtt|operatorname|textbf|textit)\{([^{}]*)}`)
+// ─── Symbol table (key = name WITHOUT backslash) ───
 
-func unwrapTextCommands(s string) string {
-	return textCmdRe.ReplaceAllString(s, "$1")
-}
-
-// extractBraced finds the content inside {…} starting at position pos.
-// Handles nested braces correctly. Returns the inner content and the
-// end position (index after closing }). Returns ("", pos) if no match.
-func extractBraced(s string, pos int) (content string, end int) {
-	if pos >= len(s) || s[pos] != '{' {
-		return "", pos
-	}
-	depth := 1
-	i := pos + 1
-	for i < len(s) && depth > 0 {
-		switch s[i] {
-		case '{':
-			depth++
-		case '}':
-			depth--
-		}
-		i++
-	}
-	if depth != 0 {
-		return "", pos // unmatched brace
-	}
-	return s[pos+1 : i-1], i
-}
-
-// renderFractions converts \frac{num}{den} and \dfrac{num}{den} to num/den.
-// Uses brace-aware parsing to handle nested braces correctly.
-func renderFractions(s string) string {
-	for {
-		idx := fracCmdIndex(s)
-		if idx < 0 {
-			break
-		}
-		// Find the opening brace of numerator
-		numStart := skipSpaces(s, idx)
-		if numStart >= len(s) || s[numStart] != '{' {
-			break
-		}
-		num, afterNum := extractBraced(s, numStart)
-		if afterNum == numStart {
-			break
-		}
-		denStart := skipSpaces(s, afterNum)
-		if denStart >= len(s) || s[denStart] != '{' {
-			break
-		}
-		den, afterDen := extractBraced(s, denStart)
-		if afterDen == denStart {
-			break
-		}
-
-		cmdStart := fracCmdStart(s, idx)
-		replacement := num + "/" + den
-		s = s[:cmdStart] + replacement + s[afterDen:]
-	}
-	return s
-}
-
-// fracCmdIndex finds the index of '{' right after \frac or \dfrac.
-func fracCmdIndex(s string) int {
-	for _, prefix := range []string{`\dfrac{`, `\frac{`} {
-		if i := strings.Index(s, prefix); i >= 0 {
-			return i + len(prefix) - 1 // index of '{'
-		}
-	}
-	return -1
-}
-
-func fracCmdStart(s string, braceIdx int) int {
-	// Walk back from braceIdx to find the \ that starts \frac or \dfrac
-	sub := s[:braceIdx+1]
-	for _, prefix := range []string{`\dfrac{`, `\frac{`} {
-		if strings.HasSuffix(sub, prefix) {
-			return len(sub) - len(prefix)
-		}
-	}
-	return 0
-}
-
-func skipSpaces(s string, i int) int {
-	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
-		i++
-	}
-	return i
-}
-
-// renderSquareRoots converts \sqrt{x} → √x and \sqrt[n]{x} → ⁿ√x.
-// Brace-aware for nested content.
-func renderSquareRoots(s string) string {
-	for {
-		idx := strings.Index(s, `\sqrt`)
-		if idx < 0 {
-			break
-		}
-		pos := idx + len(`\sqrt`)
-		var indexStr string
-
-		// Optional [n] index
-		if pos < len(s) && s[pos] == '[' {
-			endBracket := strings.IndexByte(s[pos:], ']')
-			if endBracket > 0 {
-				indexStr = s[pos+1 : pos+endBracket]
-				// Convert index to superscript
-				indexStr = toSuperscript(indexStr)
-				pos = pos + endBracket + 1
-			}
-		}
-
-		pos = skipSpaces(s, pos)
-		if pos >= len(s) || s[pos] != '{' {
-			break
-		}
-		content, afterContent := extractBraced(s, pos)
-		if afterContent == pos {
-			break
-		}
-
-		replacement := indexStr + "√" + content
-		s = s[:idx] + replacement + s[afterContent:]
-	}
-	return s
-}
-
-// renderOver converts \over (LaTeX infix fraction: {a \over b} → a/b).
-func renderOver(s string) string {
-	return overRe.ReplaceAllStringFunc(s, func(match string) string {
-		sub := overRe.FindStringSubmatch(match)
-		if len(sub) < 3 {
-			return match
-		}
-		return strings.TrimSpace(sub[1]) + "/" + strings.TrimSpace(sub[2])
-	})
-}
-
-var overRe = regexp.MustCompile(`\{([^{}]*)\s*\\over\s*([^{}]*)}`)
-
-// =====================================================================
-// Superscript / Subscript
-// =====================================================================
-
-var superscriptDigits = map[rune]rune{
-	'0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
-	'5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹',
-	'+': '⁺', '-': '⁻', '=': '⁼', '(': '⁽', ')': '⁾',
-	'n': 'ⁿ', 'i': 'ⁱ',
-}
-
-var subscriptDigits = map[rune]rune{
-	'0': '₀', '1': '₁', '2': '₂', '3': '₃', '4': '₄',
-	'5': '₅', '6': '₆', '7': '₇', '8': '₈', '9': '₉',
-	'+': '₊', '-': '₋', '=': '₌', '(': '₍', ')': '₎',
-	'a': 'ₐ', 'e': 'ₑ', 'o': 'ₒ', 'x': 'ₓ',
-	'h': 'ₕ', 'k': 'ₖ', 'l': 'ₗ', 'm': 'ₘ', 'n': 'ₙ',
-	'p': 'ₚ', 's': 'ₛ', 't': 'ₜ',
-	'i': 'ᵢ', 'j': 'ⱼ', 'r': 'ᵣ', 'u': 'ᵤ', 'v': 'ᵥ',
-}
-
-// renderSuperscripts converts ^{...} and ^x to superscript Unicode.
-// Brace-aware for nested content like ^{i\pi}.
-func renderSuperscripts(s string) string {
-	// Braced: ^{...}
-	s = renderPowOrSub(s, '^', toSuperscript)
-	// Single-char: ^x (not followed by { or \)
-	s = renderPowOrSubSingle(s, '^', toSuperscript)
-	return s
-}
-
-// renderSubscripts converts _{...} and _x to subscript Unicode.
-func renderSubscripts(s string) string {
-	// Braced: _{...}
-	s = renderPowOrSub(s, '_', toSubscript)
-	// Single-char: _x
-	s = renderPowOrSubSingle(s, '_', toSubscript)
-	return s
-}
-
-// renderPowOrSub handles ^{...} or _{...} with brace-aware parsing.
-func renderPowOrSub(s string, marker byte, convert func(string) string) string {
-	for {
-		idx := indexOfMarkerBrace(s, marker)
-		if idx < 0 {
-			break
-		}
-		braceStart := idx + 1
-		if braceStart >= len(s) || s[braceStart] != '{' {
-			break
-		}
-		content, afterContent := extractBraced(s, braceStart)
-		if afterContent == braceStart {
-			break
-		}
-		replacement := convert(content)
-		s = s[:idx] + replacement + s[afterContent:]
-	}
-	return s
-}
-
-// renderPowOrSubSingle handles ^x or _x (single char, no braces).
-var singlePowRe = regexp.MustCompile(`\^([^\\{_\s])`)
-var singleSubRe = regexp.MustCompile(`_([^\\{^\s])`)
-
-func renderPowOrSubSingle(s string, marker byte, convert func(string) string) string {
-	var re *regexp.Regexp
-	if marker == '^' {
-		re = singlePowRe
-	} else {
-		re = singleSubRe
-	}
-	return re.ReplaceAllStringFunc(s, func(match string) string {
-		sub := re.FindStringSubmatch(match)
-		if len(sub) < 2 {
-			return match
-		}
-		return convert(sub[1])
-	})
-}
-
-func indexOfMarkerBrace(s string, marker byte) int {
-	for i := 0; i < len(s)-1; i++ {
-		if s[i] == marker && i+1 < len(s) && s[i+1] == '{' {
-			return i
-		}
-	}
-	return -1
-}
-
-func toSuperscript(s string) string {
-	var buf strings.Builder
-	for _, r := range s {
-		if sr, ok := superscriptDigits[r]; ok {
-			buf.WriteRune(sr)
-		} else {
-			buf.WriteRune(r)
-		}
-	}
-	return buf.String()
-}
-
-func toSubscript(s string) string {
-	var buf strings.Builder
-	for _, r := range s {
-		if sr, ok := subscriptDigits[r]; ok {
-			buf.WriteRune(sr)
-		} else {
-			buf.WriteRune(r)
-		}
-	}
-	return buf.String()
-}
-
-// =====================================================================
-// Brace cleanup
-// =====================================================================
-
-// removeBraces iteratively strips the innermost {content} pairs.
-var innerBraceRe = regexp.MustCompile(`\{([^{}]*)}`)
-
-func removeBraces(s string) string {
-	for i := 0; i < 10; i++ {
-		next := innerBraceRe.ReplaceAllString(s, "$1")
-		if next == s {
-			break
-		}
-		s = next
-	}
-	return s
-}
-
-// multiSpaceRe collapses 3+ consecutive spaces to 2.
-var multiSpaceRe = regexp.MustCompile(` {3,}`)
-
-// cleanSpaces collapses multiple spaces and trims each line.
-func cleanSpaces(s string) string {
-	lines := strings.Split(s, "\n")
-	for i, line := range lines {
-		line = multiSpaceRe.ReplaceAllString(line, "  ")
-		line = strings.TrimSpace(line)
-		lines[i] = line
-	}
-	return strings.Join(lines, "\n")
-}
-
-// =====================================================================
-// Symbol tables
-// =====================================================================
-
-var unknownCmdRe = regexp.MustCompile(`\\([a-zA-Z]+)`)
-
-var greekLetters = map[string]string{
-	`\alpha`: "α", `\beta`: "β", `\gamma`: "γ", `\delta`: "δ",
-	`\epsilon`: "ε", `\varepsilon`: "ε", `\zeta`: "ζ", `\eta`: "η",
-	`\theta`: "θ", `\vartheta`: "ϑ", `\iota`: "ι", `\kappa`: "κ",
-	`\lambda`: "λ", `\mu`: "μ", `\nu`: "ν", `\xi`: "ξ",
-	`\pi`: "π", `\varpi`: "ϖ", `\rho`: "ρ", `\sigma`: "σ",
-	`\tau`: "τ", `\upsilon`: "υ", `\phi`: "φ", `\varphi`: "φ",
-	`\chi`: "χ", `\psi`: "ψ", `\omega`: "ω",
-	`\Gamma`: "Γ", `\Delta`: "Δ", `\Theta`: "Θ", `\Lambda`: "Λ",
-	`\Xi`: "Ξ", `\Pi`: "Π", `\Sigma`: "Σ", `\Upsilon`: "Υ",
-	`\Phi`: "Φ", `\Psi`: "Ψ", `\Omega`: "Ω",
-}
-
-// mergedOperators = operators + delimiters merged into a single map
-// so that longest-first replacement handles \left[ (7ch) > \le (3ch).
-var mergedOperators = map[string]string{
-	// Delimiters (longer keys first implicitly via longest-first sort)
-	`\left\{`: "{", `\right\}`: "}",
-	`\left(`: "(", `\right)`: ")",
-	`\left[`: "[", `\right]`: "]",
-	`\left|`: "|", `\right|`: "|",
-	`\left.`: "", `\right.`: "",
-	`\bigl(`: "(", `\bigr)`: ")",
-	`\Bigl(`: "(", `\Bigr)`: ")",
-	`\left\lvert`: "|", `\right\rvert`: "|",
-	`\left\langle`: "⟨", `\right\rangle`: "⟩",
-	// Bracket symbols
-	`\langle`: "⟨", `\rangle`: "⟩",
-	`\lfloor`: "⌊", `\rfloor`: "⌋",
-	`\lceil`: "⌈", `\rceil`: "⌉",
-	`\lbrace`: "{", `\rbrace`: "}",
-	`\lvert`: "|", `\rvert`: "|",
-	`\Vert`: "‖", `\vert`: "|",
-	// Core operators
-	`\sum`: "∑", `\prod`: "∏", `\coprod`: "∐",
-	`\oint`: "∮", `\iiint`: "∭", `\iint`: "∬", `\int`: "∫",
-	`\partial`: "∂", `\nabla`: "∇", `\infty`: "∞",
-	`\pm`: "±", `\mp`: "∓", `\times`: "×", `\div`: "÷",
-	`\cdot`: "·", `\circ`: "∘", `\bullet`: "•", `\star`: "★",
-	`\approx`: "≈", `\neq`: "≠", `\leq`: "≤", `\geq`: "≥",
-	`\le`: "≤", `\ge`: "≥", `\ll`: "≪", `\gg`: "≫",
-	`\equiv`: "≡", `\sim`: "∼", `\simeq`: "≃", `\propto`: "∝",
-	`\perp`: "⊥", `\parallel`: "∥", `\angle`: "∠",
-	`\triangle`: "△", `\square`: "□",
-	`\subseteq`: "⊆", `\supseteq`: "⊇", `\subset`: "⊂", `\supset`: "⊃",
-	`\notin`: "∉", `\in`: "∈",
-	`\cup`: "∪", `\cap`: "∩", `\emptyset`: "∅", `\varnothing`: "∅",
-	`\forall`: "∀", `\exists`: "∃", `\neg`: "¬", `\land`: "∧", `\lor`: "∨",
-	`\oplus`: "⊕", `\otimes`: "⊗", `\odot`: "⊙",
-	`\hbar`: "ℏ", `\ell`: "ℓ", `\Re`: "ℜ", `\Im`: "ℑ",
-	`\aleph`: "ℵ", `\wp`: "℘", `\prime`: "′",
-	`\dagger`: "†", `\ddagger`: "‡",
-	`\cdots`: "⋯", `\ldots`: "…", `\vdots`: "⋮", `\ddots`: "⋱",
-	// Additional operators
-	`\mid`:     "∣",
-	`\implies`: "⟹", `\iff`: "⟺", `\impliedby`: "⟸",
-	`\therefore`: "∴", `\because`: "∵",
-	`\surd`: "√",
-	`\cong`: "≅", `\doteq`: "≐",
-	`\lesssim`: "≲", `\gtrsim`: "≳",
-	`\prec`: "≺", `\succ`: "≻",
-	`\bowtie`: "⋈",
-	`\uplus`:  "⊎", `\setminus`: "∖",
-	`\wr`:      "≀",
-	`\diamond`: "◇",
-	`\Join`:    "⋈",
-	`\bigcirc`: "◯",
-	`\amalg`:   "∐",
-	`\sharp`:   "♯", `\flat`: "♭", `\natural`: "♮",
-	`\Box`: "□", `\Diamond`: "◇",
-	`\clubsuit`: "♣", `\diamondsuit`: "♦", `\heartsuit`: "♥", `\spadesuit`: "♠",
-	// Sizing — just strip these
-	`\big`: "", `\Big`: "", `\bigg`: "", `\Bigg`: "",
-	// Escaped special chars
-	`\%`: "%", `\&`: "&", `\#`: "#", `\_`: "_",
-	`\{`: "{", `\}`: "}",
-}
-
-var arrows = map[string]string{
-	`\rightarrow`: "→", `\to`: "→", `\leftarrow`: "←", `\gets`: "←",
-	`\leftrightarrow`: "↔",
-	`\Rightarrow`:     "⇒", `\Leftarrow`: "⇐", `\Leftrightarrow`: "⇔",
-	`\uparrow`: "↑", `\downarrow`: "↓", `\updownarrow`: "↕",
-	`\Uparrow`: "⇑", `\Downarrow`: "⇓", `\Updownarrow`: "⇕",
-	`\mapsto`: "↦", `\hookrightarrow`: "↪",
-	`\nearrow`: "↗", `\searrow`: "↘", `\swarrow`: "↙", `\nwarrow`: "↖",
-	`\rightharpoonup`: "⇀", `\leftharpoonup`: "↼",
+var symbols = map[string]string{
+	// Greek lowercase
+	"alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ",
+	"epsilon": "ε", "varepsilon": "ε", "zeta": "ζ", "eta": "η",
+	"theta": "θ", "vartheta": "ϑ", "iota": "ι", "kappa": "κ",
+	"lambda": "λ", "mu": "μ", "nu": "ν", "xi": "ξ",
+	"pi": "π", "varpi": "ϖ", "rho": "ρ", "sigma": "σ",
+	"tau": "τ", "upsilon": "υ", "phi": "φ", "varphi": "φ",
+	"chi": "χ", "psi": "ψ", "omega": "ω",
+	// Greek uppercase
+	"Gamma": "Γ", "Delta": "Δ", "Theta": "Θ", "Lambda": "Λ",
+	"Xi": "Ξ", "Pi": "Π", "Sigma": "Σ", "Upsilon": "Υ",
+	"Phi": "Φ", "Psi": "Ψ", "Omega": "Ω",
+	// Operators
+	"sum": "∑", "prod": "∏", "coprod": "∐",
+	"oint": "∮", "iiint": "∭", "iint": "∬", "int": "∫",
+	"partial": "∂", "nabla": "∇", "infty": "∞",
+	"pm": "±", "mp": "∓", "times": "×", "div": "÷",
+	"cdot": "·", "circ": "∘", "bullet": "•", "star": "★",
+	"approx": "≈", "neq": "≠", "leq": "≤", "geq": "≥",
+	"le": "≤", "ge": "≥", "ll": "≪", "gg": "≫",
+	"equiv": "≡", "sim": "∼", "simeq": "≃", "propto": "∝",
+	"perp": "⊥", "parallel": "∥", "angle": "∠",
+	"triangle": "△", "square": "□",
+	"subseteq": "⊆", "supseteq": "⊇", "subset": "⊂", "supset": "⊃",
+	"notin": "∉", "in": "∈",
+	"cup": "∪", "cap": "∩", "emptyset": "∅", "varnothing": "∅",
+	"forall": "∀", "exists": "∃", "neg": "¬", "land": "∧", "lor": "∨",
+	"oplus": "⊕", "otimes": "⊗", "odot": "⊙",
+	"hbar": "ℏ", "ell": "ℓ", "Re": "ℜ", "Im": "ℑ",
+	"aleph": "ℵ", "wp": "℘", "prime": "′",
+	"dagger": "†", "ddagger": "‡",
+	"cdots": "⋯", "ldots": "…", "vdots": "⋮", "ddots": "⋱",
+	"mid": "∣", "vert": "|", "Vert": "‖",
+	"implies": "⟹", "iff": "⟺", "impliedby": "⟸",
+	"therefore": "∴", "because": "∵",
+	"surd": "√", "cong": "≅", "doteq": "≐",
+	"lesssim": "≲", "gtrsim": "≳",
+	"prec": "≺", "succ": "≻", "bowtie": "⋈",
+	"uplus": "⊎", "setminus": "∖", "wr": "≀",
+	"diamond": "◇", "Join": "⋈", "bigcirc": "◯", "amalg": "∐",
+	"sharp": "♯", "flat": "♭", "natural": "♮",
+	"Box": "□", "Diamond": "◇",
+	"clubsuit": "♣", "diamondsuit": "♦", "heartsuit": "♥", "spadesuit": "♠",
+	// Brackets
+	"langle": "⟨", "rangle": "⟩",
+	"lfloor": "⌊", "rfloor": "⌋",
+	"lceil": "⌈", "rceil": "⌉",
+	"lbrace": "{", "rbrace": "}",
+	"lvert": "|", "rvert": "|",
+	// Arrows
+	"rightarrow": "→", "to": "→", "leftarrow": "←", "gets": "←",
+	"leftrightarrow": "↔",
+	"Rightarrow":     "⇒", "Leftarrow": "⇐", "Leftrightarrow": "⇔",
+	"uparrow": "↑", "downarrow": "↓", "updownarrow": "↕",
+	"Uparrow": "⇑", "Downarrow": "⇓", "Updownarrow": "⇕",
+	"mapsto": "↦", "hookrightarrow": "↪",
+	"nearrow": "↗", "searrow": "↘", "swarrow": "↙", "nwarrow": "↖",
+	"rightharpoonup": "⇀", "leftharpoonup": "↼",
+	// Display style — strip
+	"displaystyle": "", "textstyle": "", "scriptstyle": "",
+	"limits": "", "nolimits": "",
 }

--- a/channel/math_test.go
+++ b/channel/math_test.go
@@ -1,0 +1,318 @@
+package channel
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------- latexToUnicode tests ----------
+
+func TestLatexToUnicode_GreekLetters(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`\alpha`, "α"},
+		{`\beta + \gamma`, "β + γ"},
+		{`\Delta x = \Sigma f_i`, "Δ x = Σ fᵢ"},
+		{`\pi r^2`, "π r²"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if got != tt.want {
+			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLatexToUnicode_Operators(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`\sum_{i=1}^{n}`, "∑ᵢ₌₁ⁿ"},
+		{`\int_0^1 f(x) dx`, "∫₀¹ f(x) dx"},
+		{`x \leq y \neq z`, "x ≤ y ≠ z"},
+		{`\infty + \pm`, "∞ + ±"},
+		{`a \in \emptyset`, "a ∈ ∅"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if got != tt.want {
+			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLatexToUnicode_Arrows(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`x \rightarrow y`, "x → y"},
+		{`A \Rightarrow B`, "A ⇒ B"},
+		{`x \mapsto f(x)`, "x ↦ f(x)"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if got != tt.want {
+			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLatexToUnicode_Fractions(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`\frac{1}{2}`, "1/2"},
+		{`\frac{a+b}{c-d}`, "a+b/c-d"},
+		{`\dfrac{\pi}{2}`, "π/2"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if got != tt.want {
+			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLatexToUnicode_SquareRoots(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`\sqrt{x}`, "√x"},
+		{`\sqrt[3]{8}`, "3√8"},
+		{`\sqrt{a^2 + b^2}`, "√a² + b²"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if got != tt.want {
+			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLatexToUnicode_Superscripts(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`x^{2}`, "x²"},
+		{`E = mc^{2}`, "E = mc²"},
+		{`2^{10}`, "2¹⁰"},
+		{`x^{n+1}`, "xⁿ⁺¹"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if got != tt.want {
+			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLatexToUnicode_Subscripts(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`x_{1}`, "x₁"},
+		{`a_{ij}`, "aᵢⱼ"},
+		{`v_{0} = 0`, "v₀ = 0"},
+		{`x_n`, "xₙ"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if got != tt.want {
+			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
+	// Einstein's mass-energy equivalence
+	got := latexToUnicode(`E = mc^{2}`)
+	want := "E = mc²"
+	if got != want {
+		t.Errorf("Einstein: got %q, want %q", got, want)
+	}
+
+	// Quadratic formula parts
+	got = latexToUnicode(`x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}`)
+	if !strings.Contains(got, "√b²") || !strings.Contains(got, "±") {
+		t.Errorf("Quadratic: got %q, expected √ and ±", got)
+	}
+
+	// Euler's identity
+	got = latexToUnicode(`e^{i\pi} + 1 = 0`)
+	if !strings.Contains(got, "eⁱπ") {
+		t.Errorf("Euler: got %q, expected eⁱπ", got)
+	}
+}
+
+func TestLatexToUnicode_NoMath(t *testing.T) {
+	// Plain text should pass through unchanged
+	input := "Hello, world! No math here."
+	got := latexToUnicode(input)
+	if got != input {
+		t.Errorf("plain text: got %q, want %q", got, input)
+	}
+}
+
+func TestLatexToUnicode_EscapeChars(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`\%`, "%"},
+		{`\#`, "#"},
+		{`\_`, "_"},
+		{`\{`, "{"},
+		{`\}`, "}"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if got != tt.want {
+			t.Errorf("escape(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// ---------- renderMathBlocks tests ----------
+
+func TestRenderMathBlocks_BlockMath(t *testing.T) {
+	input := `Some text before.
+
+$$
+E = mc^{2}
+$$
+
+Some text after.`
+
+	got := renderMathBlocks(input, 80)
+
+	if !strings.Contains(got, "```") {
+		t.Error("expected block math to be wrapped in code block")
+	}
+	if !strings.Contains(got, "E = mc²") {
+		t.Errorf("block math not rendered correctly: %q", got)
+	}
+	if !strings.Contains(got, "Some text before") {
+		t.Error("surrounding text should be preserved")
+	}
+}
+
+func TestRenderMathBlocks_InlineMath(t *testing.T) {
+	input := `The value of $\pi$ is approximately 3.14.`
+	got := renderMathBlocks(input, 80)
+
+	if !strings.Contains(got, "π") {
+		t.Errorf("inline math not rendered: %q", got)
+	}
+	if strings.Contains(got, "$") {
+		t.Errorf("inline dollar signs should be consumed: %q", got)
+	}
+}
+
+func TestRenderMathBlocks_MixedContent(t *testing.T) {
+	input := `# Math Test
+
+The area of a circle is $A = \pi r^{2}$.
+
+$$
+\int_0^1 f(x) dx
+$$
+
+And $\alpha + \beta = \gamma$.`
+
+	got := renderMathBlocks(input, 80)
+
+	if !strings.Contains(got, "A = π r²") {
+		t.Errorf("inline math in mixed content: %q", got)
+	}
+	if !strings.Contains(got, "∫₀¹ f(x) dx") {
+		t.Errorf("block math in mixed content: %q", got)
+	}
+	if !strings.Contains(got, "α + β = γ") {
+		t.Errorf("second inline math: %q", got)
+	}
+}
+
+func TestRenderMathBlocks_NoMatch(t *testing.T) {
+	input := "Regular text with $10 price and $20 total."
+	got := renderMathBlocks(input, 80)
+	// $10 and $20 have digits right after $, no closing $ — should not match
+	if got != input {
+		t.Errorf("non-math dollar signs should be preserved: got %q", got)
+	}
+}
+
+func TestRenderMathBlocks_EmptyBlock(t *testing.T) {
+	input := "$$$$\n\n$$"
+	got := renderMathBlocks(input, 80)
+	// Empty block should pass through unchanged
+	if got != input {
+		t.Errorf("empty block should pass through: got %q", got)
+	}
+}
+
+func TestRenderMathBlocks_WidthTruncation(t *testing.T) {
+	// Very long formula should be truncated
+	longFormula := strings.Repeat(`\alpha + \beta`, 50)
+	input := "$$\n" + longFormula + "\n$$"
+
+	got := renderMathBlocks(input, 40)
+
+	// Each line in the code block should not exceed 40 display columns
+	lines := strings.Split(got, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "```") {
+			continue
+		}
+		// We just check it doesn't panic and produces output
+		_ = i
+	}
+}
+
+func TestHasMath(t *testing.T) {
+	if !hasMath("$x^2$") {
+		t.Error("expected inline math detected")
+	}
+	if !hasMath("$$E=mc^2$$") {
+		t.Error("expected block math detected")
+	}
+	if hasMath("no math here $10") {
+		t.Error("expected no math for plain dollar sign")
+	}
+	if hasMath("plain text") {
+		t.Error("expected no math for plain text")
+	}
+}
+
+func TestLatexToUnicode_Dots(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`x_1, x_2, \ldots, x_n`, "x₁, x₂, …, xₙ"},
+		{`\cdots`, "⋯"},
+		{`\vdots`, "⋮"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if got != tt.want {
+			t.Errorf("dots(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLatexToUnicode_WhitespaceCommands(t *testing.T) {
+	input := `a \quad b \qquad c`
+	got := latexToUnicode(input)
+	// \quad → "  ", \qquad → "    "
+	if !strings.Contains(got, "a") || !strings.Contains(got, "b") || !strings.Contains(got, "c") {
+		t.Errorf("whitespace commands: got %q", got)
+	}
+}

--- a/channel/math_test.go
+++ b/channel/math_test.go
@@ -84,7 +84,7 @@ func TestLatexToUnicode_SquareRoots(t *testing.T) {
 		want  string
 	}{
 		{`\sqrt{x}`, "√x"},
-		{`\sqrt[3]{8}`, "3√8"},
+		{`\sqrt[3]{8}`, "³√8"},
 		{`\sqrt{a^2 + b^2}`, "√a² + b²"},
 	}
 	for _, tt := range tests {
@@ -149,6 +149,34 @@ func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
 	got = latexToUnicode(`e^{i\pi} + 1 = 0`)
 	if !strings.Contains(got, "eⁱπ") {
 		t.Errorf("Euler: got %q, expected eⁱπ", got)
+	}
+
+	// Maxwell's equations — the key test that motivated the rewrite
+	got = latexToUnicode(`\nabla \cdot E = \frac{\rho}{\epsilon_0}`)
+	// Key assertions: no stray braces, no "frac" remnant, has ∇ and / (fraction)
+	if strings.Contains(got, "{") || strings.Contains(got, "frac") {
+		t.Errorf("Maxwell Gauss 1 has stray braces/frac: got %q", got)
+	}
+	if !strings.Contains(got, "∇") || !strings.Contains(got, "E =") || !strings.Contains(got, "/") {
+		t.Errorf("Maxwell Gauss 1: got %q", got)
+	}
+
+	got = latexToUnicode(`\nabla \times B = \mu_0 J + \mu_0 \epsilon_0 \frac{\partial E}{\partial t}`)
+	if strings.Contains(got, "{") || strings.Contains(got, "frac") {
+		t.Errorf("Maxwell Ampere has stray braces/frac: got %q", got)
+	}
+	if !strings.Contains(got, "∇ × B") || !strings.Contains(got, "∂ E/∂ t") {
+		t.Errorf("Maxwell Ampere: got %q", got)
+	}
+
+	// Nested frac: \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+	got = latexToUnicode(`\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}`)
+	if !strings.Contains(got, "±") || !strings.Contains(got, "√") || !strings.Contains(got, "/2a") {
+		t.Errorf("Nested quadratic: got %q", got)
+	}
+	// Should NOT contain stray braces or "frac"
+	if strings.Contains(got, "{") || strings.Contains(got, "frac") {
+		t.Errorf("Nested quadratic has stray braces/frac: got %q", got)
 	}
 }
 

--- a/channel/math_test.go
+++ b/channel/math_test.go
@@ -169,6 +169,61 @@ func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
 		t.Errorf("Maxwell Ampere: got %q", got)
 	}
 
+	// ---- User-reported bugs (real LLM output) ----
+
+	// Bug: \left[ was rendered as ≤ft[ because \le matched first
+	got = latexToUnicode(`\left[ -\hbar^2/2m \nabla^2 + V(r) \right]`)
+	if strings.Contains(got, "≤ft") || strings.Contains(got, "\\left") {
+		t.Errorf("\\left[ bug: got %q", got)
+	}
+	if !strings.Contains(got, "[") || !strings.Contains(got, "]") {
+		t.Errorf("\\left/right brackets: got %q", got)
+	}
+
+	// Bug: \left( not rendered
+	got = latexToUnicode(`n! \sim \sqrt{2\pi n} \left( n/e \right)^n`)
+	if strings.Contains(got, "≤ft") || strings.Contains(got, "\\left") {
+		t.Errorf("\\left( bug: got %q", got)
+	}
+
+	// Bug: \mid not rendered
+	got = latexToUnicode(`P(A \mid B) = \frac{P(B \mid A) P(A)}{P(B)}`)
+	if strings.Contains(got, "{") || strings.Contains(got, "frac") {
+		t.Errorf("Bayes stray braces: got %q", got)
+	}
+	if !strings.Contains(got, "P(A") || !strings.Contains(got, "/P(B)") {
+		t.Errorf("Bayes: got %q", got)
+	}
+	// \mid should be replaced (not left as literal "mid")
+	if strings.Contains(got, "mid") {
+		t.Errorf("\\mid not replaced: got %q", got)
+	}
+
+	// Bug: \text{prime} inside _{} was subscripted to ₜₑₓₜₚᵣᵢₘₑ
+	got = latexToUnicode(`\prod_{\text{prime}}`)
+	// \text{prime} should unwrap to plain "prime" before subscript
+	// So the subscript should be ₚᵣᵢₘₑ (all letters subscripted) NOT ₜₑₓₜₚᵣᵢₘₑ
+	if strings.Contains(got, "ₜₑₓₜ") {
+		t.Errorf("\\text subscript bug: got %q, should NOT contain ₜₑₓₜ", got)
+	}
+	// Should contain subscript p (ₚ) from "prime"
+	if !strings.Contains(got, "ₚ") {
+		t.Errorf("\\text subscript missing: got %q", got)
+	}
+	// Should NOT contain literal word "text"
+	if strings.Contains(got, "text") {
+		t.Errorf("\\text not unwrapped: got %q", got)
+	}
+
+	// Bug: \\ line breaks not handled
+	got = latexToUnicode(`f(x) = \begin{cases} x^2 \\ x+1 \end{cases}`)
+	if !strings.Contains(got, "\n") {
+		t.Errorf("line break: got %q, expected newline", got)
+	}
+	if strings.Contains(got, "begin") || strings.Contains(got, "end") || strings.Contains(got, "cases") {
+		t.Errorf("env remnants: got %q", got)
+	}
+
 	// Nested frac: \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
 	got = latexToUnicode(`\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}`)
 	if !strings.Contains(got, "±") || !strings.Contains(got, "√") || !strings.Contains(got, "/2a") {

--- a/channel/math_test.go
+++ b/channel/math_test.go
@@ -244,6 +244,112 @@ func TestLatexToUnicode_NoMath(t *testing.T) {
 	}
 }
 
+func TestLatexToUnicode_AlignmentMarkers(t *testing.T) {
+	// &= should become just =
+	got := latexToUnicode(`\sin(α + β) &= \sinα\cosβ + \cosα\sinβ`)
+	if strings.Contains(got, "&=") {
+		t.Errorf("&= not stripped: got %q", got)
+	}
+	if !strings.Contains(got, "= sin") {
+		t.Errorf("alignment: got %q", got)
+	}
+	// Multi-line with & alignment
+	got = latexToUnicode(`f(x) &= x^2 \\ g(x) &= x + 1`)
+	if strings.Contains(got, "&") {
+		t.Errorf("& remnant: got %q", got)
+	}
+}
+
+func TestLatexToUnicode_MathFunctions(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`\sin(x)`, "sin(x)"},
+		{`\cos^2(x) + \sin^2(x) = 1`, "cos²(x) + sin²(x) = 1"},
+		{`\log_{10}(x)`, "log₁₀(x)"},
+		{`\lim_{x \to \infty}`, "limₓ → ∞"},
+		{`\exp(i\theta)`, "exp(iθ)"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if got != tt.want {
+			t.Errorf("mathfunc(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLatexToUnicode_Accents(t *testing.T) {
+	tests := []struct {
+		input   string
+		contain string
+	}{
+		{`\hat{x}`, "x̂"},
+		{`\vec{F}`, "F⃗"},
+		{`\bar{x}`, "x̄"},
+		{`\dot{x}`, "ẋ"},
+		{`\ddot{x}`, "ẍ"},
+		{`\tilde{n}`, "ñ"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if !strings.Contains(got, tt.contain) {
+			t.Errorf("accent(%q) = %q, expected %q", tt.input, got, tt.contain)
+		}
+	}
+}
+
+func TestLatexToUnicode_Brackets(t *testing.T) {
+	tests := []struct {
+		input   string
+		contain string
+	}{
+		{`\langle x, y \rangle`, "⟨ x, y ⟩"},
+		{`\lfloor x \rfloor`, "⌊ x ⌋"},
+		{`\lceil x \rceil`, "⌈ x ⌉"},
+	}
+	for _, tt := range tests {
+		got := latexToUnicode(tt.input)
+		if !strings.Contains(got, tt.contain) {
+			t.Errorf("bracket(%q) = %q, expected %q", tt.input, got, tt.contain)
+		}
+	}
+}
+
+func TestLatexToUnicode_Binomial(t *testing.T) {
+	got := latexToUnicode(`\binom{n}{k}`)
+	if !strings.Contains(got, "(n k)") {
+		t.Errorf("binomial: got %q", got)
+	}
+}
+
+func TestLatexToUnicode_LineBreaks(t *testing.T) {
+	got := latexToUnicode(`x^2 + y^2 \\ = r^2`)
+	if !strings.Contains(got, "\n") {
+		t.Errorf("linebreak: got %q", got)
+	}
+}
+
+func TestLatexToUnicode_Environments(t *testing.T) {
+	got := latexToUnicode(`\begin{cases} x & y \\ z & w \end{cases}`)
+	if strings.Contains(got, "begin") || strings.Contains(got, "end") {
+		t.Errorf("env not stripped: got %q", got)
+	}
+}
+
+func TestLatexToUnicode_Schrodinger(t *testing.T) {
+	got := latexToUnicode(`i\hbar \frac{\partial}{\partial t} \Psi(r, t) = \left[ -\frac{\hbar^2}{2m}\nabla^2 + V(r) \right] \Psi(r, t)`)
+	if strings.Contains(got, "{") || strings.Contains(got, "frac") {
+		t.Errorf("Schrödinger stray braces: got %q", got)
+	}
+	if !strings.Contains(got, "iℏ") || !strings.Contains(got, "∂/∂ t") {
+		t.Errorf("Schrödinger content: got %q", got)
+	}
+	if strings.Contains(got, "≤ft") {
+		t.Errorf("Schrödinger \\left[ bug: got %q", got)
+	}
+}
+
 func TestLatexToUnicode_EscapeChars(t *testing.T) {
 	tests := []struct {
 		input string

--- a/channel/math_test.go
+++ b/channel/math_test.go
@@ -563,3 +563,94 @@ func TestLatexToUnicode_MatrixRendering(t *testing.T) {
 		t.Errorf("matrix should have newlines: %q", got)
 	}
 }
+
+func TestLatexToUnicode_MatrixMultiColumn(t *testing.T) {
+	src := `\begin{bmatrix}
+a_{11} & a_{12} & a_{13} \\
+a_{21} & a_{22} & a_{23} \\
+a_{31} & a_{32} & a_{33}
+\end{bmatrix}`
+	got := renderLaTeX(src)
+	lines := strings.Split(got, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), got)
+	}
+	// No blank lines
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			t.Errorf("blank line at %d", i)
+		}
+	}
+	// Columns should be aligned: split by spaces, column positions match
+	// Each line has the pattern: a₁₁ <spaces> a₁₂ <spaces> a₁₃
+	// The second column (a₁₂, a₂₂, a₃₂) should start at the same display col
+	col2Start := func(line string) int {
+		// Find second group of non-space after first group
+		inFirst := false
+		spaceAfterFirst := false
+		w := 0
+		for _, r := range line {
+			if r != ' ' {
+				if spaceAfterFirst {
+					return w
+				}
+				inFirst = true
+			} else if inFirst {
+				spaceAfterFirst = true
+			}
+			w++
+		}
+		return -1
+	}
+	c0 := col2Start(lines[0])
+	c1 := col2Start(lines[1])
+	c2 := col2Start(lines[2])
+	if c0 < 0 || c1 < 0 || c2 < 0 {
+		t.Fatalf("could not find column 2 in output:\n%s", got)
+	}
+	if c1 != c0 || c2 != c0 {
+		t.Errorf("column 2 not aligned: line0=%d line1=%d line2=%d\n%s", c0, c1, c2, got)
+	}
+	// Verify no env remnants
+	if strings.Contains(got, "begin") || strings.Contains(got, "end") || strings.Contains(got, "bmatrix") {
+		t.Errorf("env remnants: %q", got)
+	}
+}
+
+func TestLatexToUnicode_FullMatrixEquation(t *testing.T) {
+	src := `\begin{bmatrix}
+a_{11} & a_{12} & a_{13} \\
+a_{21} & a_{22} & a_{23} \\
+a_{31} & a_{32} & a_{33}
+\end{bmatrix}
+\begin{bmatrix}
+x_1 \\ x_2 \\ x_3
+\end{bmatrix}
+=
+\begin{bmatrix}
+a_{11}x_1 + a_{12}x_2 + a_{13}x_3 \\
+a_{21}x_1 + a_{22}x_2 + a_{23}x_3 \\
+a_{31}x_1 + a_{32}x_2 + a_{33}x_3
+\end{bmatrix}`
+	got := renderLaTeX(src)
+	// Should produce 10 lines: 3 (matrix1) + 3 (vector) + 1 (=) + 3 (result)
+	lines := strings.Split(got, "\n")
+	if len(lines) != 10 {
+		t.Fatalf("expected 10 lines, got %d:\n%s", len(lines), got)
+	}
+	// No blank lines
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			t.Errorf("blank line at %d", i)
+		}
+	}
+	// Matrix 3x3 columns aligned
+	// Vector lines have no & (no alignment marker)
+	// Result lines have no & (single column)
+	if !strings.Contains(lines[0], "a₁₁") || !strings.Contains(lines[0], "a₁₃") {
+		t.Errorf("matrix row 0: %q", lines[0])
+	}
+	if !strings.Contains(lines[6], "=") {
+		t.Errorf("expected = on line 6: %q", lines[6])
+	}
+}

--- a/channel/math_test.go
+++ b/channel/math_test.go
@@ -633,24 +633,23 @@ a_{21}x_1 + a_{22}x_2 + a_{23}x_3 \\
 a_{31}x_1 + a_{32}x_2 + a_{33}x_3
 \end{bmatrix}`
 	got := renderLaTeX(src)
-	// Should produce 10 lines: 3 (matrix1) + 3 (vector) + 1 (=) + 3 (result)
+	// Side-by-side rendering: 3 lines (all matrices rendered horizontally)
 	lines := strings.Split(got, "\n")
-	if len(lines) != 10 {
-		t.Fatalf("expected 10 lines, got %d:\n%s", len(lines), got)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (side-by-side), got %d:\n%s", len(lines), got)
 	}
-	// No blank lines
+	// All lines should have brackets
 	for i, line := range lines {
-		if strings.TrimSpace(line) == "" {
-			t.Errorf("blank line at %d", i)
+		if !strings.Contains(line, "[") || !strings.Contains(line, "]") {
+			t.Errorf("line %d missing brackets: %q", i, line)
 		}
 	}
-	// Matrix 3x3 columns aligned
-	// Vector lines have no & (no alignment marker)
-	// Result lines have no & (single column)
-	if !strings.Contains(lines[0], "a₁₁") || !strings.Contains(lines[0], "a₁₃") {
-		t.Errorf("matrix row 0: %q", lines[0])
+	// Middle line should have =
+	if !strings.Contains(lines[1], "=") {
+		t.Errorf("middle line should have =: %q", lines[1])
 	}
-	if !strings.Contains(lines[6], "=") {
-		t.Errorf("expected = on line 6: %q", lines[6])
+	// First and third lines should NOT have =
+	if strings.Contains(lines[0], "=") || strings.Contains(lines[2], "=") {
+		t.Errorf("= should only be on middle line:\n%s", got)
 	}
 }

--- a/channel/math_test.go
+++ b/channel/math_test.go
@@ -3,6 +3,8 @@ package channel
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/x/ansi"
 )
 
 // ---------- latexToUnicode tests ----------
@@ -18,9 +20,9 @@ func TestLatexToUnicode_GreekLetters(t *testing.T) {
 		{`\pi r^2`, "π r²"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if got != tt.want {
-			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("renderLaTeX(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }
@@ -37,9 +39,9 @@ func TestLatexToUnicode_Operators(t *testing.T) {
 		{`a \in \emptyset`, "a ∈ ∅"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if got != tt.want {
-			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("renderLaTeX(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }
@@ -54,9 +56,9 @@ func TestLatexToUnicode_Arrows(t *testing.T) {
 		{`x \mapsto f(x)`, "x ↦ f(x)"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if got != tt.want {
-			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("renderLaTeX(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }
@@ -71,9 +73,9 @@ func TestLatexToUnicode_Fractions(t *testing.T) {
 		{`\dfrac{\pi}{2}`, "π/2"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if got != tt.want {
-			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("renderLaTeX(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }
@@ -88,9 +90,9 @@ func TestLatexToUnicode_SquareRoots(t *testing.T) {
 		{`\sqrt{a^2 + b^2}`, "√a² + b²"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if got != tt.want {
-			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("renderLaTeX(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }
@@ -106,9 +108,9 @@ func TestLatexToUnicode_Superscripts(t *testing.T) {
 		{`x^{n+1}`, "xⁿ⁺¹"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if got != tt.want {
-			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("renderLaTeX(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }
@@ -124,35 +126,35 @@ func TestLatexToUnicode_Subscripts(t *testing.T) {
 		{`x_n`, "xₙ"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if got != tt.want {
-			t.Errorf("latexToUnicode(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("renderLaTeX(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }
 
 func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
 	// Einstein's mass-energy equivalence
-	got := latexToUnicode(`E = mc^{2}`)
+	got := renderLaTeX(`E = mc^{2}`)
 	want := "E = mc²"
 	if got != want {
 		t.Errorf("Einstein: got %q, want %q", got, want)
 	}
 
 	// Quadratic formula parts
-	got = latexToUnicode(`x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}`)
+	got = renderLaTeX(`x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}`)
 	if !strings.Contains(got, "√b²") || !strings.Contains(got, "±") {
 		t.Errorf("Quadratic: got %q, expected √ and ±", got)
 	}
 
 	// Euler's identity
-	got = latexToUnicode(`e^{i\pi} + 1 = 0`)
+	got = renderLaTeX(`e^{i\pi} + 1 = 0`)
 	if !strings.Contains(got, "eⁱπ") {
 		t.Errorf("Euler: got %q, expected eⁱπ", got)
 	}
 
 	// Maxwell's equations — the key test that motivated the rewrite
-	got = latexToUnicode(`\nabla \cdot E = \frac{\rho}{\epsilon_0}`)
+	got = renderLaTeX(`\nabla \cdot E = \frac{\rho}{\epsilon_0}`)
 	// Key assertions: no stray braces, no "frac" remnant, has ∇ and / (fraction)
 	if strings.Contains(got, "{") || strings.Contains(got, "frac") {
 		t.Errorf("Maxwell Gauss 1 has stray braces/frac: got %q", got)
@@ -161,7 +163,7 @@ func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
 		t.Errorf("Maxwell Gauss 1: got %q", got)
 	}
 
-	got = latexToUnicode(`\nabla \times B = \mu_0 J + \mu_0 \epsilon_0 \frac{\partial E}{\partial t}`)
+	got = renderLaTeX(`\nabla \times B = \mu_0 J + \mu_0 \epsilon_0 \frac{\partial E}{\partial t}`)
 	if strings.Contains(got, "{") || strings.Contains(got, "frac") {
 		t.Errorf("Maxwell Ampere has stray braces/frac: got %q", got)
 	}
@@ -172,7 +174,7 @@ func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
 	// ---- User-reported bugs (real LLM output) ----
 
 	// Bug: \left[ was rendered as ≤ft[ because \le matched first
-	got = latexToUnicode(`\left[ -\hbar^2/2m \nabla^2 + V(r) \right]`)
+	got = renderLaTeX(`\left[ -\hbar^2/2m \nabla^2 + V(r) \right]`)
 	if strings.Contains(got, "≤ft") || strings.Contains(got, "\\left") {
 		t.Errorf("\\left[ bug: got %q", got)
 	}
@@ -181,13 +183,13 @@ func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
 	}
 
 	// Bug: \left( not rendered
-	got = latexToUnicode(`n! \sim \sqrt{2\pi n} \left( n/e \right)^n`)
+	got = renderLaTeX(`n! \sim \sqrt{2\pi n} \left( n/e \right)^n`)
 	if strings.Contains(got, "≤ft") || strings.Contains(got, "\\left") {
 		t.Errorf("\\left( bug: got %q", got)
 	}
 
 	// Bug: \mid not rendered
-	got = latexToUnicode(`P(A \mid B) = \frac{P(B \mid A) P(A)}{P(B)}`)
+	got = renderLaTeX(`P(A \mid B) = \frac{P(B \mid A) P(A)}{P(B)}`)
 	if strings.Contains(got, "{") || strings.Contains(got, "frac") {
 		t.Errorf("Bayes stray braces: got %q", got)
 	}
@@ -200,7 +202,7 @@ func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
 	}
 
 	// Bug: \text{prime} inside _{} was subscripted to ₜₑₓₜₚᵣᵢₘₑ
-	got = latexToUnicode(`\prod_{\text{prime}}`)
+	got = renderLaTeX(`\prod_{\text{prime}}`)
 	// \text{prime} should unwrap to plain "prime" before subscript
 	// So the subscript should be ₚᵣᵢₘₑ (all letters subscripted) NOT ₜₑₓₜₚᵣᵢₘₑ
 	if strings.Contains(got, "ₜₑₓₜ") {
@@ -216,7 +218,7 @@ func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
 	}
 
 	// Bug: \\ line breaks not handled
-	got = latexToUnicode(`f(x) = \begin{cases} x^2 \\ x+1 \end{cases}`)
+	got = renderLaTeX(`f(x) = \begin{cases} x^2 \\ x+1 \end{cases}`)
 	if !strings.Contains(got, "\n") {
 		t.Errorf("line break: got %q, expected newline", got)
 	}
@@ -225,7 +227,7 @@ func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
 	}
 
 	// Nested frac: \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
-	got = latexToUnicode(`\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}`)
+	got = renderLaTeX(`\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}`)
 	if !strings.Contains(got, "±") || !strings.Contains(got, "√") || !strings.Contains(got, "/2a") {
 		t.Errorf("Nested quadratic: got %q", got)
 	}
@@ -238,7 +240,7 @@ func TestLatexToUnicode_ComplexExpressions(t *testing.T) {
 func TestLatexToUnicode_NoMath(t *testing.T) {
 	// Plain text should pass through unchanged
 	input := "Hello, world! No math here."
-	got := latexToUnicode(input)
+	got := renderLaTeX(input)
 	if got != input {
 		t.Errorf("plain text: got %q, want %q", got, input)
 	}
@@ -246,7 +248,7 @@ func TestLatexToUnicode_NoMath(t *testing.T) {
 
 func TestLatexToUnicode_AlignmentMarkers(t *testing.T) {
 	// &= should become just =
-	got := latexToUnicode(`\sin(α + β) &= \sinα\cosβ + \cosα\sinβ`)
+	got := renderLaTeX(`\sin(α + β) &= \sinα\cosβ + \cosα\sinβ`)
 	if strings.Contains(got, "&=") {
 		t.Errorf("&= not stripped: got %q", got)
 	}
@@ -254,7 +256,7 @@ func TestLatexToUnicode_AlignmentMarkers(t *testing.T) {
 		t.Errorf("alignment: got %q", got)
 	}
 	// Multi-line with & alignment
-	got = latexToUnicode(`f(x) &= x^2 \\ g(x) &= x + 1`)
+	got = renderLaTeX(`f(x) &= x^2 \\ g(x) &= x + 1`)
 	if strings.Contains(got, "&") {
 		t.Errorf("& remnant: got %q", got)
 	}
@@ -272,7 +274,7 @@ func TestLatexToUnicode_MathFunctions(t *testing.T) {
 		{`\exp(i\theta)`, "exp(iθ)"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if got != tt.want {
 			t.Errorf("mathfunc(%q) = %q, want %q", tt.input, got, tt.want)
 		}
@@ -292,7 +294,7 @@ func TestLatexToUnicode_Accents(t *testing.T) {
 		{`\tilde{n}`, "ñ"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if !strings.Contains(got, tt.contain) {
 			t.Errorf("accent(%q) = %q, expected %q", tt.input, got, tt.contain)
 		}
@@ -309,7 +311,7 @@ func TestLatexToUnicode_Brackets(t *testing.T) {
 		{`\lceil x \rceil`, "⌈ x ⌉"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if !strings.Contains(got, tt.contain) {
 			t.Errorf("bracket(%q) = %q, expected %q", tt.input, got, tt.contain)
 		}
@@ -317,28 +319,28 @@ func TestLatexToUnicode_Brackets(t *testing.T) {
 }
 
 func TestLatexToUnicode_Binomial(t *testing.T) {
-	got := latexToUnicode(`\binom{n}{k}`)
+	got := renderLaTeX(`\binom{n}{k}`)
 	if !strings.Contains(got, "(n k)") {
 		t.Errorf("binomial: got %q", got)
 	}
 }
 
 func TestLatexToUnicode_LineBreaks(t *testing.T) {
-	got := latexToUnicode(`x^2 + y^2 \\ = r^2`)
+	got := renderLaTeX(`x^2 + y^2 \\ = r^2`)
 	if !strings.Contains(got, "\n") {
 		t.Errorf("linebreak: got %q", got)
 	}
 }
 
 func TestLatexToUnicode_Environments(t *testing.T) {
-	got := latexToUnicode(`\begin{cases} x & y \\ z & w \end{cases}`)
+	got := renderLaTeX(`\begin{cases} x & y \\ z & w \end{cases}`)
 	if strings.Contains(got, "begin") || strings.Contains(got, "end") {
 		t.Errorf("env not stripped: got %q", got)
 	}
 }
 
 func TestLatexToUnicode_Schrodinger(t *testing.T) {
-	got := latexToUnicode(`i\hbar \frac{\partial}{\partial t} \Psi(r, t) = \left[ -\frac{\hbar^2}{2m}\nabla^2 + V(r) \right] \Psi(r, t)`)
+	got := renderLaTeX(`i\hbar \frac{\partial}{\partial t} \Psi(r, t) = \left[ -\frac{\hbar^2}{2m}\nabla^2 + V(r) \right] \Psi(r, t)`)
 	if strings.Contains(got, "{") || strings.Contains(got, "frac") {
 		t.Errorf("Schrödinger stray braces: got %q", got)
 	}
@@ -362,7 +364,7 @@ func TestLatexToUnicode_EscapeChars(t *testing.T) {
 		{`\}`, "}"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if got != tt.want {
 			t.Errorf("escape(%q) = %q, want %q", tt.input, got, tt.want)
 		}
@@ -490,7 +492,7 @@ func TestLatexToUnicode_Dots(t *testing.T) {
 		{`\vdots`, "⋮"},
 	}
 	for _, tt := range tests {
-		got := latexToUnicode(tt.input)
+		got := renderLaTeX(tt.input)
 		if got != tt.want {
 			t.Errorf("dots(%q) = %q, want %q", tt.input, got, tt.want)
 		}
@@ -499,9 +501,65 @@ func TestLatexToUnicode_Dots(t *testing.T) {
 
 func TestLatexToUnicode_WhitespaceCommands(t *testing.T) {
 	input := `a \quad b \qquad c`
-	got := latexToUnicode(input)
+	got := renderLaTeX(input)
 	// \quad → "  ", \qquad → "    "
 	if !strings.Contains(got, "a") || !strings.Contains(got, "b") || !strings.Contains(got, "c") {
 		t.Errorf("whitespace commands: got %q", got)
+	}
+}
+
+func TestLatexToUnicode_MultiLineAlignment(t *testing.T) {
+	// Integration by parts - step-by-step derivation
+	got := renderLaTeX(`\int_0^\pi x \sin x \, dx &= [-x\cos x]_0^\pi + \int_0^\pi \cos x \, dx \\ &= \pi + [\sin x]_0^\pi \\ &= \pi`)
+	lines := strings.Split(got, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), got)
+	}
+	// All = signs should be at the same display column
+	eqDisplayCol := func(line string) int {
+		idx := strings.Index(line, "=")
+		if idx < 0 {
+			return -1
+		}
+		return ansi.StringWidth(line[:idx])
+	}
+	col0 := eqDisplayCol(lines[0])
+	col1 := eqDisplayCol(lines[1])
+	col2 := eqDisplayCol(lines[2])
+	if col0 < 0 || col1 < 0 || col2 < 0 {
+		t.Fatalf("missing = in output:\n%s", got)
+	}
+	if col1 != col0 {
+		t.Errorf("line 2 = at display col %d, expected %d\n%s", col1, col0, got)
+	}
+	if col2 != col0 {
+		t.Errorf("line 3 = at display col %d, expected %d\n%s", col2, col0, got)
+	}
+}
+
+func TestLatexToUnicode_TrigIdentityAlignment(t *testing.T) {
+	got := renderLaTeX(`\sin(\alpha + \beta) &= \sin\alpha\cos\beta + \cos\alpha\sin\beta \\ \sin(\alpha - \beta) &= \sin\alpha\cos\beta - \cos\alpha\sin\beta`)
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), got)
+	}
+	pos0 := strings.Index(lines[0], "=")
+	pos1 := strings.Index(lines[1], "=")
+	if pos0 < 0 || pos1 < 0 {
+		t.Fatalf("missing =:\n%s", got)
+	}
+	if pos1 != pos0 {
+		t.Errorf("= not aligned: line1=%d line2=%d\n%s", pos0, pos1, got)
+	}
+}
+
+func TestLatexToUnicode_MatrixRendering(t *testing.T) {
+	// Matrix should render each row on its own line
+	got := renderLaTeX(`\begin{bmatrix} a_{11} & a_{12} \\ a_{21} & a_{22} \end{bmatrix}`)
+	if strings.Contains(got, "begin") || strings.Contains(got, "end") {
+		t.Errorf("env remnants: %q", got)
+	}
+	if !strings.Contains(got, "\n") {
+		t.Errorf("matrix should have newlines: %q", got)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,4 @@ require (
 
 replace github.com/pgavlin/mermaid-ascii => github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055
 
-replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260521045008-2da5f6de378a
+replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260521051503-dc28980c812f

--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,4 @@ require (
 
 replace github.com/pgavlin/mermaid-ascii => github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055
 
-replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260519030000-f946139d29b6
+replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260521033821-f9d01d4944f2

--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,4 @@ require (
 
 replace github.com/pgavlin/mermaid-ascii => github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055
 
-replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260521041348-609bc6fbce91
+replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260521045008-2da5f6de378a

--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,4 @@ require (
 
 replace github.com/pgavlin/mermaid-ascii => github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055
 
-replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260521033821-f9d01d4944f2
+replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260521035225-da5ac8cc751e

--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,4 @@ require (
 
 replace github.com/pgavlin/mermaid-ascii => github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055
 
-replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260521035225-da5ac8cc751e
+replace github.com/muesli/reflow => github.com/Chronostasys/reflow v0.3.1-0.20260521041348-609bc6fbce91

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055 h1:t5hOy3vbSmXZ+VLHIvk5RiVym82QnEoOe3qWOe38SrQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055/go.mod h1:k0/VCoO+6S9CkqpfQA04++cjZkWLidbyW+ZgRfCGNJY=
-github.com/Chronostasys/reflow v0.3.1-0.20260521045008-2da5f6de378a h1:hfphJBB2TYLn3m4/k6c2WlDegLNgoAeOH6PzLgoKkj4=
-github.com/Chronostasys/reflow v0.3.1-0.20260521045008-2da5f6de378a/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
+github.com/Chronostasys/reflow v0.3.1-0.20260521051503-dc28980c812f h1:dCkdA2voQHf7k7ezhA+CsSJwT5ySfTLfsTsvp7fPphc=
+github.com/Chronostasys/reflow v0.3.1-0.20260521051503-dc28980c812f/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
 github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
 github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt9lgKAkVrIBtWf33d9GpVA=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055 h1:t5hOy3vbSmXZ+VLHIvk5RiVym82QnEoOe3qWOe38SrQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055/go.mod h1:k0/VCoO+6S9CkqpfQA04++cjZkWLidbyW+ZgRfCGNJY=
-github.com/Chronostasys/reflow v0.3.1-0.20260521033821-f9d01d4944f2 h1:lDKdD0sCPvEqsGhxw0ji2DHGG3Rk228UVNw95lNieMA=
-github.com/Chronostasys/reflow v0.3.1-0.20260521033821-f9d01d4944f2/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
+github.com/Chronostasys/reflow v0.3.1-0.20260521035225-da5ac8cc751e h1:BoK6lDLrnlp5QP3uIyy/gR1TQOETcc2zUJC4g9xMC6g=
+github.com/Chronostasys/reflow v0.3.1-0.20260521035225-da5ac8cc751e/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
 github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
 github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt9lgKAkVrIBtWf33d9GpVA=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055 h1:t5hOy3vbSmXZ+VLHIvk5RiVym82QnEoOe3qWOe38SrQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055/go.mod h1:k0/VCoO+6S9CkqpfQA04++cjZkWLidbyW+ZgRfCGNJY=
-github.com/Chronostasys/reflow v0.3.1-0.20260519030000-f946139d29b6 h1:MfY07Sdjh94WTcQI+JsUC77mJDT5rY0ZEZb9pfK71gk=
-github.com/Chronostasys/reflow v0.3.1-0.20260519030000-f946139d29b6/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
+github.com/Chronostasys/reflow v0.3.1-0.20260521033821-f9d01d4944f2 h1:lDKdD0sCPvEqsGhxw0ji2DHGG3Rk228UVNw95lNieMA=
+github.com/Chronostasys/reflow v0.3.1-0.20260521033821-f9d01d4944f2/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
 github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
 github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt9lgKAkVrIBtWf33d9GpVA=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055 h1:t5hOy3vbSmXZ+VLHIvk5RiVym82QnEoOe3qWOe38SrQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055/go.mod h1:k0/VCoO+6S9CkqpfQA04++cjZkWLidbyW+ZgRfCGNJY=
-github.com/Chronostasys/reflow v0.3.1-0.20260521041348-609bc6fbce91 h1:LxPRRkUiscA3ma2uOBo9ngCN0H6AJp9VgNx+O0JcyhQ=
-github.com/Chronostasys/reflow v0.3.1-0.20260521041348-609bc6fbce91/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
+github.com/Chronostasys/reflow v0.3.1-0.20260521045008-2da5f6de378a h1:hfphJBB2TYLn3m4/k6c2WlDegLNgoAeOH6PzLgoKkj4=
+github.com/Chronostasys/reflow v0.3.1-0.20260521045008-2da5f6de378a/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
 github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
 github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt9lgKAkVrIBtWf33d9GpVA=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055 h1:t5hOy3vbSmXZ+VLHIvk5RiVym82QnEoOe3qWOe38SrQ=
 github.com/Chronostasys/mermaid-ascii v0.0.0-20260416173126-a903e2a57055/go.mod h1:k0/VCoO+6S9CkqpfQA04++cjZkWLidbyW+ZgRfCGNJY=
-github.com/Chronostasys/reflow v0.3.1-0.20260521035225-da5ac8cc751e h1:BoK6lDLrnlp5QP3uIyy/gR1TQOETcc2zUJC4g9xMC6g=
-github.com/Chronostasys/reflow v0.3.1-0.20260521035225-da5ac8cc751e/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
+github.com/Chronostasys/reflow v0.3.1-0.20260521041348-609bc6fbce91 h1:LxPRRkUiscA3ma2uOBo9ngCN0H6AJp9VgNx+O0JcyhQ=
+github.com/Chronostasys/reflow v0.3.1-0.20260521041348-609bc6fbce91/go.mod h1:mEMWZ0nzoGlTCHkXp5ljOWhHi1tjvtDGh7wuT1Thhsk=
 github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
 github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0 h1:mklaPbT4f/EiDr1Q+zPrEt9lgKAkVrIBtWf33d9GpVA=

--- a/tools/worktree.go
+++ b/tools/worktree.go
@@ -24,7 +24,7 @@ so agents don't conflict on the same files. Also supports listing and cleanup.
 ### init
 Create a new git worktree for the current agent. Registers it in the global registry.
 - Every session gets its own worktree — all agents are equal peers.
-- Returns the worktree path. You should then Cd to it.
+ Returns the worktree path and auto-cd into it.
 
 Parameters: {"action": "init", "role": "peer", "instance": "debug", "task": "fix auth bug"}
 
@@ -87,15 +87,9 @@ func (t *WorktreeTool) executeInit(ctx *ToolContext, params WorktreeParams) (*To
 		return nil, fmt.Errorf("worktree init: %w", err)
 	}
 
-	// Experimental feature gate: worktree creation requires config opt-in.
-	if !ctx.AutoWorktreeEnabled {
-		return NewResult(
-			"⚠️ Worktree 是实验性功能，默认关闭。\n" +
-				"如需启用自动 worktree 隔离，请在 /settings 中设置 `auto_worktree = true`，\n" +
-				"或在 config.json 中设置：\n" +
-				`  "agent": {"experimental": {"auto_worktree": true}}` +
-				"\n\n当前已启用 peer 感知——你可以看到其他 agent 并与之通信。"), nil
-	}
+	// auto_worktree gate only controls automatic creation (AutoDetectAndInit).
+	// Explicit Worktree(init) calls always create the worktree — the agent
+	// consciously chose to call this tool, regardless of the config setting.
 
 	sessionKey := ctx.Channel + ":" + ctx.ChatID
 	role := params.Role
@@ -147,10 +141,12 @@ func (t *WorktreeTool) executeInit(ctx *ToolContext, params WorktreeParams) (*To
 	if ctx.SetCurrentDir != nil {
 		ctx.SetCurrentDir(worktreePath)
 	}
+	// Update ToolContext.CurrentDir for immediate effect in subsequent tool calls.
+	ctx.CurrentDir = worktreePath
 
 	msg := fmt.Sprintf("Worktree created successfully.\n"+
 		"- Repo: %s\n- Worktree: %s\n- Branch: %s\n- Role: %s%s\n\n"+
-		"You are now working in an isolated worktree. Other agents in the same repo will not see your changes until merge.",
+		"已自动 cd 到 worktree 目录。你现在在隔离的工作区中工作，其他 agent 不会看到你的更改，直到合并。",
 		repoPath, worktreePath, branch, role, dirtyWarning)
 
 	peers := GlobalWorktreeRegistry.GetPeers(repoPath, sessionKey)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,16 +17,37 @@ initWebVitals()
 
 function App() {
   const [authed, setAuthed] = useState<boolean | null>(null)
-  const { t } = useTranslation()
+  const { t, setLocale } = useTranslation()
 
   useEffect(() => {
     // Check if already logged in by trying to fetch history
     fetch('/api/history')
       .then((r) => {
         setAuthed(r.ok)
+        // Sync theme from server so it matches even if localStorage is stale
+        if (r.ok) {
+          fetch('/api/settings')
+            .then((sr) => sr.json())
+            .then((data) => {
+              if (data.ok && data.settings) {
+                const s = data.settings
+                if (s.theme && s.theme !== savedTheme) {
+                  localStorage.setItem('xbot-theme', s.theme)
+                  document.documentElement.setAttribute('data-theme', s.theme)
+                }
+                if (s.language) {
+                  localStorage.setItem('xbot-language', s.language)
+                  setLocale(s.language)
+                }
+                if (s.font_size) localStorage.setItem('xbot-font-size', s.font_size)
+                if (s.image_brightness) localStorage.setItem('xbot-image-brightness', String(s.image_brightness))
+              }
+            })
+            .catch(() => {/* ignore */})
+        }
       })
       .catch(() => setAuthed(false))
-  }, [])
+  }, [setLocale])
 
   if (authed === null) {
     const theme = savedTheme

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -1073,15 +1073,18 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
         data-testid="messages-container"
       >
         {messages.length === 0 && !loading && (
-          <div className="text-center py-20 animate-fade-in select-none">
-            <div className="text-7xl mb-8 opacity-15">🤖</div>
+          <div className="text-center py-20 animate-fade-in select-none empty-state-container">
+            <div className="empty-state-icon-wrapper">
+              <div className="empty-state-icon-bg"></div>
+              <div className="empty-state-icon">🤖</div>
+            </div>
             <p className="text-xl font-semibold mb-3" style={{ color: 'var(--text-primary)', letterSpacing: '-0.02em' }}>{t('startConversation')}</p>
             <p className="text-sm mb-12" style={{ color: 'var(--text-tertiary)', maxWidth: 320, margin: '0 auto 48px' }}>{t('sendFirstMessage')}</p>
-            <div className="flex flex-col items-center gap-3" style={{ color: 'var(--text-secondary)' }}>
-              <div className="px-5 py-2.5 rounded-xl text-xs font-medium flex items-center gap-2" style={{ background: 'var(--bg-secondary)', border: '0.5px solid var(--border)' }}>
+            <div className="flex flex-col items-center gap-3">
+              <div className="empty-state-action-btn">
                <span>⌨️</span> {t("searchKbHint")}
               </div>
-              <div className="px-5 py-2.5 rounded-xl text-xs font-medium flex items-center gap-2" style={{ background: 'var(--bg-secondary)', border: '0.5px solid var(--border)' }}>
+              <div className="empty-state-action-btn">
                <span>⚡</span> {t("commandHint")}
               </div>
             </div>

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -1073,20 +1073,20 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
         data-testid="messages-container"
       >
         {messages.length === 0 && !loading && (
-          <div className="text-center py-20 animate-fade-in">
-            <div className="text-5xl mb-4 opacity-30">🤖</div>
-            <p className="text-slate-400 text-base font-medium mb-2">{t('startConversation')}</p>
-            <p className="text-slate-500 text-sm mb-8">{t('sendFirstMessage')}</p>
-            <div className="flex flex-col items-center gap-2 text-xs text-slate-600">
-              <span className="px-3 py-1 rounded-full bg-slate-800/50 border border-slate-700/50">
-                {t("searchKbHint")}
-              </span>
-              <span className="px-3 py-1 rounded-full bg-slate-800/50 border border-slate-700/50">
-                {t("commandHint")}
-              </span>
+          <div className="text-center py-20 animate-fade-in select-none">
+            <div className="text-7xl mb-8 opacity-15">🤖</div>
+            <p className="text-xl font-semibold mb-3" style={{ color: 'var(--text-primary)', letterSpacing: '-0.02em' }}>{t('startConversation')}</p>
+            <p className="text-sm mb-12" style={{ color: 'var(--text-tertiary)', maxWidth: 320, margin: '0 auto 48px' }}>{t('sendFirstMessage')}</p>
+            <div className="flex flex-col items-center gap-3" style={{ color: 'var(--text-secondary)' }}>
+              <div className="px-5 py-2.5 rounded-xl text-xs font-medium flex items-center gap-2" style={{ background: 'var(--bg-secondary)', border: '0.5px solid var(--border)' }}>
+               <span>⌨️</span> {t("searchKbHint")}
+              </div>
+              <div className="px-5 py-2.5 rounded-xl text-xs font-medium flex items-center gap-2" style={{ background: 'var(--bg-secondary)', border: '0.5px solid var(--border)' }}>
+               <span>⚡</span> {t("commandHint")}
+              </div>
             </div>
           </div>
-        )}
+         )}
 
         {/* Virtualized message list */}
         {turns.length > 0 && (

--- a/web/src/LoginPage.tsx
+++ b/web/src/LoginPage.tsx
@@ -81,23 +81,24 @@ export default function LoginPage({ onLogin }: LoginPageProps) {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-slate-900 px-4">
+    <div className="flex items-center justify-center min-h-screen px-4 login-container" style={{ background: 'var(--bg-base)' }}>
       <div className="w-full max-w-sm">
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-white mb-2">🤖 {t('appName')}</h1>
-          <p className="text-slate-400 text-sm">{t('appSubtitle')}</p>
+          <h1 className="text-3xl font-bold mb-2" style={{ color: 'var(--text-primary)', letterSpacing: '-0.02em' }}>🤖 {t('appName')}</h1>
+          <p className="text-sm" style={{ color: 'var(--text-tertiary)' }}>{t('appSubtitle')}</p>
         </div>
 
         <form
           onSubmit={handleSubmit}
-          className="bg-slate-800 rounded-xl p-6 shadow-lg border border-slate-700"
+          className="rounded-2xl p-8 shadow-lg"
+          style={{ background: 'var(--bg-secondary)', border: '0.5px solid var(--border)' }}
         >
-          <h2 className="text-lg font-semibold text-white mb-4">
+          <h2 className="text-lg font-semibold mb-5" style={{ color: 'var(--text-primary)' }}>
             {showFeishu ? t('feishuAccountLogin') : isRegister ? t('createAccount') : t('login')}
           </h2>
 
           {error && (
-            <div className="bg-red-900/30 border border-red-800 text-red-300 text-sm rounded-lg px-3 py-2 mb-4">
+            <div className="rounded-xl px-3 py-2 mb-4 text-sm" style={{ background: 'var(--xbot-bg-danger)', border: '0.5px solid var(--xbot-border-danger)', color: 'var(--xbot-text-danger)' }}>
               {error}
             </div>
           )}
@@ -105,12 +106,13 @@ export default function LoginPage({ onLogin }: LoginPageProps) {
           {showFeishu ? (
             <>
               <div className="mb-4">
-                <label className="block text-sm text-slate-300 mb-1">{t('feishuUserId')}</label>
+                <label className="block text-sm mb-1.5" style={{ color: 'var(--text-secondary)' }}>{t('feishuUserId')}</label>
                 <input
                   type="text"
                   value={feishuUserId}
                   onChange={(e) => setFeishuUserId(e.target.value)}
-                  className="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                  className="w-full rounded-xl px-3.5 py-3 text-sm focus:outline-none"
+                  style={{ background: 'var(--xbot-bg-input)', border: '0.5px solid var(--border)', color: 'var(--text-primary)' }}
                   placeholder={t('feishuPlaceholder')}
                   required
                   maxLength={128}
@@ -118,31 +120,33 @@ export default function LoginPage({ onLogin }: LoginPageProps) {
               </div>
 
               <div className="mb-6">
-                <label className="block text-sm text-slate-300 mb-1">{t('feishuPasswordLabel')}</label>
+                <label className="block text-sm mb-1.5" style={{ color: 'var(--text-secondary)' }}>{t('feishuPasswordLabel')}</label>
                 <input
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                  className="w-full rounded-xl px-3.5 py-3 text-sm focus:outline-none"
+                  style={{ background: 'var(--xbot-bg-input)', border: '0.5px solid var(--border)', color: 'var(--text-primary)' }}
                   placeholder={t('feishuPassword')}
                   required
                   maxLength={128}
                 />
               </div>
 
-              <p className="text-xs text-slate-500 mb-4">
+              <p className="text-xs mb-4" style={{ color: 'var(--text-tertiary)' }}>
                 {t('feishuBindHint')}
               </p>
             </>
           ) : (
             <>
               <div className="mb-4">
-                <label className="block text-sm text-slate-300 mb-1">{t('username')}</label>
+                <label className="block text-sm mb-1.5" style={{ color: 'var(--text-secondary)' }}>{t('username')}</label>
                 <input
                   type="text"
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
-                  className="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                  className="w-full rounded-xl px-3.5 py-3 text-sm focus:outline-none"
+                  style={{ background: 'var(--xbot-bg-input)', border: '0.5px solid var(--border)', color: 'var(--text-primary)' }}
                   placeholder={t('enterUsername')}
                   required
                   maxLength={64}
@@ -150,12 +154,13 @@ export default function LoginPage({ onLogin }: LoginPageProps) {
               </div>
 
               <div className="mb-6">
-                <label className="block text-sm text-slate-300 mb-1">{t('password')}</label>
+                <label className="block text-sm mb-1.5" style={{ color: 'var(--text-secondary)' }}>{t('password')}</label>
                 <input
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-400 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                  className="w-full rounded-xl px-3.5 py-3 text-sm focus:outline-none"
+                  style={{ background: 'var(--xbot-bg-input)', border: '0.5px solid var(--border)', color: 'var(--text-primary)' }}
                   placeholder={t('enterPassword')}
                   required
                   maxLength={128}
@@ -167,30 +172,33 @@ export default function LoginPage({ onLogin }: LoginPageProps) {
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 text-white font-medium py-2 rounded-lg transition-colors"
+            className="w-full font-semibold py-3 rounded-xl transition-all"
+            style={{ background: loading ? 'var(--text-placeholder)' : 'var(--accent)', color: '#fff' }}
             aria-label={loading ? t('loading') : showFeishu ? t('feishuLogin') : isRegister ? t('register') : t('login')}
           >
             {loading ? '...' : showFeishu ? t('feishuLogin') : isRegister ? t('register') : t('login')}
           </button>
 
           {!showFeishu && !inviteOnly && (
-            <div className="mt-4 text-center">
+            <div className="mt-5 text-center">
               <button
                 type="button"
                 onClick={() => { setIsRegister(!isRegister); setError('') }}
-                className="text-sm text-blue-400 hover:text-blue-300"
+                className="text-sm transition-colors"
+                style={{ color: 'var(--accent)' }}
               >
                 {isRegister ? t('hasAccount') : t('noAccount')}
               </button>
             </div>
           )}
 
-          <div className="mt-4 text-center">
+          <div className="mt-5 text-center">
             {showFeishu ? (
               <button
                 type="button"
                 onClick={() => { setShowFeishu(false); setError('') }}
-                className="text-xs text-slate-500 hover:text-slate-400"
+                className="text-xs transition-colors"
+                style={{ color: 'var(--text-tertiary)' }}
               >
                 {t('backToPasswordLogin')}
               </button>
@@ -198,7 +206,8 @@ export default function LoginPage({ onLogin }: LoginPageProps) {
               <button
                 type="button"
                 onClick={() => { setShowFeishu(true); setError('') }}
-                className="text-xs text-slate-500 hover:text-slate-400"
+                className="text-xs transition-colors"
+                style={{ color: 'var(--text-tertiary)' }}
               >
                 {t('loginViaFeishu')}
               </button>

--- a/web/src/LoginPage.tsx
+++ b/web/src/LoginPage.tsx
@@ -173,7 +173,7 @@ export default function LoginPage({ onLogin }: LoginPageProps) {
             type="submit"
             disabled={loading}
             className="w-full font-semibold py-3 rounded-xl transition-all"
-            style={{ background: loading ? 'var(--text-placeholder)' : 'var(--accent)', color: '#fff' }}
+            style={{ background: loading ? 'var(--text-placeholder)' : 'linear-gradient(180deg, #5bb8ff 0%, #0055b3 100%)', color: '#fff', boxShadow: loading ? 'none' : '0 1px 3px rgba(0,0,0,0.15), 0 4px 16px rgba(0,85,179,0.35)' }}
             aria-label={loading ? t('loading') : showFeishu ? t('feishuLogin') : isRegister ? t('register') : t('login')}
           >
             {loading ? '...' : showFeishu ? t('feishuLogin') : isRegister ? t('register') : t('login')}

--- a/web/src/components/AssistantTurn.tsx
+++ b/web/src/components/AssistantTurn.tsx
@@ -6,10 +6,14 @@ import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import { getCodeBlockProps } from './CodeBlock'
 import Lightbox from './Lightbox'
+import type { PluggableList } from 'unified'
 
 // Pre-built plugins array for Markdown rendering
-const remarkPluginsList = [remarkGfm, remarkMath]
-const rehypePluginsList = [rehypeKatex]
+// remark-math: single-dollar inline math disabled to prevent false positives
+//   (e.g. "$景$" in Chinese text triggers KaTeX unicodeTextInMathMode warnings → infinite re-render)
+// rehype-katex: suppress strict warnings to prevent console spam causing layout thrash
+const remarkPluginsList: PluggableList = [remarkGfm, [remarkMath, { singleDollarTextMath: false }]]
+const rehypePluginsList: PluggableList = [[rehypeKatex, { strict: false, trust: false, throwOnError: false }]]
 import MessageActions from './MessageActions'
 import MessageReactions from './MessageReactions'
 import type { WsProgressPayload, IterationSnapshot } from './ProgressPanel'

--- a/web/src/components/ProgressPanel.tsx
+++ b/web/src/components/ProgressPanel.tsx
@@ -254,7 +254,9 @@ export default function ProgressPanel({ progress, liveIterations, loading }: Pro
 
           {isActive && (
             <div className="iteration-item">
-              <div className="iteration-header">#{progress.iteration}</div>
+              {progress.iteration > 0 && (
+                <div className="iteration-header">#{progress.iteration}</div>
+              )}
 
               {shouldShowCurrentThinking && (
                 <div className="iteration-block iteration-reasoning">
@@ -263,7 +265,13 @@ export default function ProgressPanel({ progress, liveIterations, loading }: Pro
                 </div>
               )}
 
-              {progress.phase === 'thinking' && !progress.thinking && <BouncingDots text="thinking…" />}
+              {/* Initial thinking state — show premium orb instead of plain dots */}
+              {progress.phase === 'thinking' && !progress.thinking && progress.iteration === 0 && !hasActiveTools && (
+                <ThinkingOrb />
+              )}
+
+              {/* Subsequent thinking with no content — compact dots */}
+              {progress.phase === 'thinking' && !progress.thinking && (progress.iteration > 0 || hasActiveTools) && <BouncingDots text="thinking…" />}
 
               {hasActiveTools && activeTools.map((tool, i) => (
                 <div key={`${tool.name}-${i}`} className="iteration-tool">
@@ -306,7 +314,7 @@ export default function ProgressPanel({ progress, liveIterations, loading }: Pro
               <SubAgentTree agents={progress.sub_agents} />
             </div>
           )}
-          {progress.token_usage && <TokenUsageBar tokenUsage={progress.token_usage} />}
+          {progress.token_usage && progress.token_usage.total_tokens > 0 && (progress.iteration > 0 || (progress.token_usage.completion_tokens ?? 0) > 200) && <TokenUsageBar tokenUsage={progress.token_usage} />}
           {progress.todos && progress.todos.length > 0 && <TodoList todos={progress.todos} />}
         </div>
       </div>

--- a/web/src/components/ProgressPanel.tsx
+++ b/web/src/components/ProgressPanel.tsx
@@ -59,8 +59,8 @@ interface ProgressPanelProps {
 
 function SubAgentIcon({ status }: { status: string }) {
   switch (status) {
-    case 'done': return <span className="text-green-400">✅</span>
-    case 'error': return <span className="text-red-400">❌</span>
+    case 'done': return <span>✅</span>
+    case 'error': return <span>❌</span>
     case 'pending': return <span className="subagent-pulse">⏳</span>
     default: return <span className="subagent-spin">🔄</span>
   }
@@ -76,30 +76,18 @@ function SubAgentNode({ node, depth = 0 }: { node: WsSubAgent; depth?: number })
     <div className="subagent-node" style={{ marginLeft: depth > 0 ? '16px' : 0 }}>
       <div
         className={`flex items-center gap-2 px-2 py-1.5 rounded-lg cursor-pointer transition-colors ${
-          isRunning
-            ? 'subagent-node-running'
-            : isPending
-              ? 'subagent-node-pending'
-              : 'hover:bg-slate-700/30'
+          isRunning ? 'subagent-node-running' : isPending ? 'subagent-node-pending' : 'subagent-node-idle'
         }`}
         onClick={() => hasChildren && setExpanded(!expanded)}
       >
         <SubAgentIcon status={node.status} />
-        <span className="font-medium text-xs text-slate-200 flex-shrink-0">{node.role}</span>
-        {node.desc && (
-          <span className="text-[11px] text-slate-400 truncate flex-1">{node.desc}</span>
-        )}
-        {hasChildren && (
-          <span className={`text-slate-500 text-xs transition-transform ${expanded ? 'rotate-90' : ''}`}>
-            ▸
-          </span>
-        )}
+        <span className="subagent-role">{node.role}</span>
+        {node.desc && <span className="subagent-desc">{node.desc}</span>}
+        {hasChildren && <span className={`subagent-chevron ${expanded ? 'subagent-chevron-open' : ''}`}>▸</span>}
       </div>
       {expanded && hasChildren && (
         <div className="mt-0.5">
-          {node.children!.map((child, i) => (
-            <SubAgentNode key={`${child.role}-${i}`} node={child} depth={depth + 1} />
-          ))}
+          {node.children!.map((child, i) => <SubAgentNode key={`${child.role}-${i}`} node={child} depth={depth + 1} />)}
         </div>
       )}
     </div>
@@ -110,9 +98,7 @@ export function SubAgentTree({ agents }: { agents: WsSubAgent[] }) {
   if (!agents || agents.length === 0) return null
   return (
     <div className="subagent-tree">
-      {agents.map((agent, i) => (
-        <SubAgentNode key={`${agent.role}-${i}`} node={agent} />
-      ))}
+      {agents.map((agent, i) => <SubAgentNode key={`${agent.role}-${i}`} node={agent} />)}
     </div>
   )
 }
@@ -120,27 +106,27 @@ export function SubAgentTree({ agents }: { agents: WsSubAgent[] }) {
 function ThinkingOrb() {
   const { t } = useTranslation()
   return (
-    <div className="flex items-center gap-3 px-2 py-1">
+    <div className="thinking-orb-row">
       <div className="thinking-orb">
         <div className="thinking-orb-ring thinking-orb-ring-1" />
         <div className="thinking-orb-ring thinking-orb-ring-2" />
         <div className="thinking-orb-ring thinking-orb-ring-3" />
         <div className="thinking-orb-core" />
       </div>
-      <span className="text-[11px] text-slate-500 italic animate-pulse">{t("thinking")}</span>
+      <span className="thinking-label">{t("thinking")}</span>
     </div>
   )
 }
 
 export function BouncingDots({ text }: { text?: string }) {
   return (
-    <div className="flex items-center gap-2 px-2 py-1">
+    <div className="bouncing-dots-row">
       <span className="thinking-dots">
         <span className="thinking-dot" style={{ animationDelay: '0ms' }} />
         <span className="thinking-dot" style={{ animationDelay: '160ms' }} />
         <span className="thinking-dot" style={{ animationDelay: '320ms' }} />
       </span>
-      {text && <span className="text-[11px] text-slate-500 italic">{text}</span>}
+      {text && <span className="bouncing-dots-text">{text}</span>}
     </div>
   )
 }
@@ -151,18 +137,18 @@ export const CompletedIteration = memo(function CompletedIteration({ snap }: { s
   const hasTools = (snap.tools ?? []).length > 0
   const isEmpty = !hasThinking && !hasReasoning && !hasTools
   return (
-    <div className="px-3 py-2 border-b border-slate-700/30 last:border-b-0">
-      <div className="flex items-center gap-1 text-[11px] text-slate-600/90 font-mono mb-1">#{snap.iteration}</div>
+    <div className="iteration-item">
+      <div className="iteration-header">#{snap.iteration}</div>
       {hasReasoning && (
-        <div className="px-2 py-1.5 mb-1 rounded bg-indigo-500/10 border-l-2 border-indigo-500/40">
-          <div className="text-[10px] text-indigo-400/70 font-medium mb-0.5">💭 Reasoning</div>
-          <div className="text-xs text-indigo-300/90 whitespace-pre-wrap break-words">{snap.reasoning}</div>
+        <div className="iteration-block iteration-reasoning">
+          <div className="iteration-block-label">💭 Reasoning</div>
+          <div className="iteration-block-text">{snap.reasoning}</div>
         </div>
       )}
       {hasThinking && (
-        <div className="px-2 py-1.5 mb-1 rounded bg-amber-500/10 border-l-2 border-amber-500/40">
-          <div className="text-[10px] text-amber-400/70 font-medium mb-0.5">💡 Thinking</div>
-          <div className="text-xs text-amber-300/80 italic whitespace-pre-wrap break-words">{snap.thinking}</div>
+        <div className="iteration-block iteration-thinking">
+          <div className="iteration-block-label">💡 Thinking</div>
+          <div className="iteration-block-text italic">{snap.thinking}</div>
         </div>
       )}
       {hasTools && (
@@ -170,15 +156,13 @@ export const CompletedIteration = memo(function CompletedIteration({ snap }: { s
           {(snap.tools ?? []).map((tool, i) => {
             const icon = tool.status === 'error' ? '❌' : '✅'
             return (
-              <div key={`${snap.iteration}-${i}`} className="px-2 py-1 text-sm">
+              <div key={`${snap.iteration}-${i}`} className="iteration-tool">
                 <div className="flex items-center gap-2">
                   <span>{icon}</span>
-                  <span className="font-mono text-xs text-slate-400 flex-1 truncate">{tool.label || tool.name}</span>
-                  {tool.elapsed_ms != null && tool.elapsed_ms > 0 && <span className="text-xs text-slate-500 font-mono">{formatElapsed(tool.elapsed_ms)}</span>}
+                  <span className="iteration-tool-name">{tool.label || tool.name}</span>
+                  {tool.elapsed_ms != null && tool.elapsed_ms > 0 && <span className="iteration-tool-time">{formatElapsed(tool.elapsed_ms)}</span>}
                 </div>
-                {tool.summary && (
-                  <div className="text-[10px] text-slate-500 truncate pl-5 mt-0.5">{tool.summary}</div>
-                )}
+                {tool.summary && <div className="iteration-tool-summary">{tool.summary}</div>}
               </div>
             )
           })}
@@ -198,24 +182,12 @@ function formatTokenCount(n: number): string {
 
 function TokenUsageBar({ tokenUsage }: { tokenUsage: NonNullable<WsProgressPayload['token_usage']> }) {
   return (
-    <div className="flex items-center gap-3 px-3 py-1.5 text-[11px] font-mono text-slate-500 border-t border-slate-700/30 mt-1">
-      <span className="flex items-center gap-1">
-        <span className="text-blue-400">in</span>
-        <span>{formatTokenCount(tokenUsage.prompt_tokens)}</span>
-      </span>
-      <span className="flex items-center gap-1">
-        <span className="text-green-400">out</span>
-        <span>{formatTokenCount(tokenUsage.completion_tokens)}</span>
-      </span>
-      <span className="flex items-center gap-1">
-        <span className="text-slate-400">total</span>
-        <span className="text-slate-300">{formatTokenCount(tokenUsage.total_tokens)}</span>
-      </span>
+    <div className="token-usage-bar">
+      <span className="token-usage-item"><span className="token-label-in">in</span> {formatTokenCount(tokenUsage.prompt_tokens)}</span>
+      <span className="token-usage-item"><span className="token-label-out">out</span> {formatTokenCount(tokenUsage.completion_tokens)}</span>
+      <span className="token-usage-item"><span className="token-label-total">total</span> <span className="token-value">{formatTokenCount(tokenUsage.total_tokens)}</span></span>
       {tokenUsage.cache_hit_tokens > 0 && (
-        <span className="flex items-center gap-1">
-          <span className="text-amber-400">cache</span>
-          <span>{formatTokenCount(tokenUsage.cache_hit_tokens)}</span>
-        </span>
+        <span className="token-usage-item"><span className="token-label-cache">cache</span> {formatTokenCount(tokenUsage.cache_hit_tokens)}</span>
       )}
     </div>
   )
@@ -227,37 +199,31 @@ function TodoList({ todos }: { todos: NonNullable<WsProgressPayload['todos']> })
   const progress = total > 0 ? (done / total) * 100 : 0
 
   return (
-    <div className="px-3 py-2 border-t border-slate-700/30">
-      <div className="flex items-center justify-between mb-1.5">
-        <span className="text-[11px] font-medium text-slate-400">📋 TODO {done}/{total}</span>
-        <span className="text-[10px] text-slate-500">{Math.round(progress)}%</span>
+    <div className="todo-section">
+      <div className="todo-header">
+        <span className="todo-title">📋 TODO {done}/{total}</span>
+        <span className="todo-percent">{Math.round(progress)}%</span>
       </div>
-      <div className="w-full bg-slate-700/50 rounded-full h-1.5 mb-2">
-        <div
-          className="bg-gradient-to-r from-blue-500 to-green-400 h-1.5 rounded-full transition-all duration-500 ease-out"
-          style={{ width: `${progress}%` }}
-        />
+      <div className="todo-progress-track">
+        <div className="todo-progress-bar" style={{ width: `${progress}%` }} />
       </div>
-      <div className="space-y-0.5 max-h-32 overflow-y-auto">
+      <div className="todo-items">
         {todos.map(todo => (
-          <div key={todo.id} className="flex items-center gap-2 text-xs">
-            <span className={todo.done ? 'text-green-400' : 'text-slate-500'}>
-              {todo.done ? '✅' : '⬜'}
-            </span>
-            <span className={`truncate ${todo.done ? 'text-slate-500 line-through' : 'text-slate-300'}`}>
-              {todo.text}
-            </span>
+          <div key={todo.id} className={`todo-item ${todo.done ? 'todo-item-done' : ''}`}>
+            <span className="todo-check">{todo.done ? '✅' : '⬜'}</span>
+            <span className="todo-text">{todo.text}</span>
           </div>
         ))}
       </div>
     </div>
   )
 }
+
 export default function ProgressPanel({ progress, liveIterations, loading }: ProgressPanelProps) {
   if (!progress && loading) {
     return (
       <div className="flex justify-start">
-        <div className="bg-slate-800/80 border border-slate-700/50 rounded-2xl px-5 py-4 backdrop-blur-sm shadow-lg shadow-blue-500/5">
+        <div className="progress-card progress-card-thinking">
           <ThinkingOrb />
         </div>
       </div>
@@ -274,7 +240,6 @@ export default function ProgressPanel({ progress, liveIterations, loading }: Pro
   const seenThinkings = new Set(displayLiveIterations.map(s => (s.thinking || '').trim()).filter(Boolean))
   const shouldShowCurrentThinking = currentThinking.length > 0 && !seenThinkings.has(currentThinking)
 
-  // Track whether the current iteration shows any visible content
   const hasVisibleContent = shouldShowCurrentThinking
     || hasActiveTools
     || (progress.phase === 'thinking' && !progress.thinking)
@@ -283,28 +248,30 @@ export default function ProgressPanel({ progress, liveIterations, loading }: Pro
 
   return (
     <div className="flex justify-start progress-fade-in">
-      <div className={`max-w-[80%] w-full rounded-xl border overflow-hidden ${isActive ? 'border-blue-800/50 bg-slate-800/90 progress-panel-active' : 'border-slate-700 bg-slate-800'}`}>
-        <div className="divide-y divide-slate-700/30">
+      <div className={`progress-card ${isActive ? 'progress-card-active' : 'progress-card-done'}`}>
+        <div className="progress-inner">
           {displayLiveIterations.map(snap => <CompletedIteration key={snap.iteration} snap={snap} />)}
 
           {isActive && (
-            <div className="px-3 py-2">
-              <div className="flex items-center gap-1 text-[11px] text-slate-600/90 font-mono mb-1">#{progress.iteration}</div>
+            <div className="iteration-item">
+              <div className="iteration-header">#{progress.iteration}</div>
 
               {shouldShowCurrentThinking && (
-                <div className="px-2 py-1.5 mb-1 rounded bg-indigo-500/10 border-l-2 border-indigo-500/40">
-                  <div className="text-[10px] text-indigo-400/70 font-medium mb-0.5">💭 Reasoning</div>
-                  <div className="text-xs text-indigo-300/90 whitespace-pre-wrap break-words">{progress.thinking}</div>
+                <div className="iteration-block iteration-reasoning">
+                  <div className="iteration-block-label">💭 Reasoning</div>
+                  <div className="iteration-block-text">{progress.thinking}</div>
                 </div>
               )}
 
               {progress.phase === 'thinking' && !progress.thinking && <BouncingDots text="thinking…" />}
 
               {hasActiveTools && activeTools.map((tool, i) => (
-                <div key={`${tool.name}-${i}`} className="flex items-center gap-2 px-2 py-1 text-sm">
-                  <span className="tool-pulse">⏳</span>
-                  <span className="font-mono text-xs text-slate-400 flex-1 truncate">{tool.label || tool.name}</span>
-                  {tool.elapsed_ms > 0 && <span className="text-xs text-slate-500 font-mono shrink-0">{formatElapsed(tool.elapsed_ms)}</span>}
+                <div key={`${tool.name}-${i}`} className="iteration-tool">
+                  <div className="flex items-center gap-2">
+                    <span className="tool-pulse">⏳</span>
+                    <span className="iteration-tool-name">{tool.label || tool.name}</span>
+                    {tool.elapsed_ms > 0 && <span className="iteration-tool-time">{formatElapsed(tool.elapsed_ms)}</span>}
+                  </div>
                 </div>
               ))}
 
@@ -313,40 +280,34 @@ export default function ProgressPanel({ progress, liveIterations, loading }: Pro
                 const last = completed.length > 0 ? completed[completed.length - 1] : null
                 if (!last) return <BouncingDots text="executing…" />
                 return (
-                  <div className="flex items-center gap-2 px-2 py-1 text-sm">
-                    <span>{last.status === 'done' ? '✅' : '❌'}</span>
-                    <span className="font-mono text-xs flex-1 truncate text-slate-400">{last.label || last.name}</span>
-                    {last.elapsed_ms != null && last.elapsed_ms > 0 && <span className="text-xs text-slate-500 font-mono shrink-0">{formatElapsed(last.elapsed_ms)}</span>}
+                  <div className="iteration-tool">
+                    <div className="flex items-center gap-2">
+                      <span>{last.status === 'done' ? '✅' : '❌'}</span>
+                      <span className="iteration-tool-name">{last.label || last.name}</span>
+                      {last.elapsed_ms != null && last.elapsed_ms > 0 && <span className="iteration-tool-time">{formatElapsed(last.elapsed_ms)}</span>}
+                    </div>
                   </div>
                 )
               })()}
 
               {['compressing', 'retrying'].includes(progress.phase) && (
-                <div className="flex items-center gap-1.5 px-2 py-1 text-xs text-slate-500">
+                <div className="iteration-phase-text">
                   <span>{progress.phase === 'compressing' ? '📦' : '🔄'}</span>
                   <span>{progress.phase}…</span>
                 </div>
               )}
 
-              {/* Catch-all: nothing matched above → show animated dots */}
               {!hasVisibleContent && <BouncingDots />}
             </div>
           )}
 
-          {/* SubAgent tree */}
           {progress.sub_agents && progress.sub_agents.length > 0 && (
-            <div className="px-3 py-2 border-t border-slate-700/30">
+            <div className="progress-sub-section">
               <SubAgentTree agents={progress.sub_agents} />
             </div>
           )}
-          {/* Token usage */}
-          {progress.token_usage && (
-            <TokenUsageBar tokenUsage={progress.token_usage} />
-          )}
-          {/* TODO list */}
-          {progress.todos && progress.todos.length > 0 && (
-            <TodoList todos={progress.todos} />
-          )}
+          {progress.token_usage && <TokenUsageBar tokenUsage={progress.token_usage} />}
+          {progress.todos && progress.todos.length > 0 && <TodoList todos={progress.todos} />}
         </div>
       </div>
     </div>

--- a/web/src/components/settings/AppearanceTab.tsx
+++ b/web/src/components/settings/AppearanceTab.tsx
@@ -20,7 +20,7 @@ export default function AppearanceTab({ showToast, onNicknameChange, onSavingCha
   const { t, setLocale } = useTranslation()
   const { config: soundConfig, updateConfig: updateSoundConfig, toggleEnabled: toggleSoundEnabled } = useSoundFeedback()
 
-  // Load settings from server on mount
+  // Load settings from server on mount — sync to localStorage for next page load
   useEffect(() => {
     fetchSettings().then((s) => {
       setTheme(s.theme as Theme)
@@ -29,22 +29,37 @@ export default function AppearanceTab({ showToast, onNicknameChange, onSavingCha
       setLanguage(s.language as Language)
       const ib = s.image_brightness !== undefined ? Number(s.image_brightness) : undefined
       if (ib !== undefined && !isNaN(ib)) setImageBrightness(ib)
+      // Sync server settings → localStorage so App.tsx reads correctly on refresh
+      localStorage.setItem('xbot-theme', s.theme)
+      localStorage.setItem('xbot-font-size', s.font_size)
+      localStorage.setItem('xbot-language', s.language)
+      if (s.nickname) localStorage.setItem('xbot-nickname', s.nickname)
+      if (ib !== undefined) localStorage.setItem('xbot-image-brightness', String(ib))
     })
   }, [])
 
-  // Apply theme
+  // Apply theme + persist to localStorage so App.tsx reads it on next load
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
+    localStorage.setItem('xbot-theme', theme)
   }, [theme])
 
-  // Apply font size
+  // Apply font size + persist
   useEffect(() => {
     document.documentElement.style.setProperty('--xbot-font-size', FONT_SIZE_MAP[fontSize])
+    localStorage.setItem('xbot-font-size', fontSize)
   }, [fontSize])
 
-  // Apply image brightness
+  // Apply language + persist
+  useEffect(() => {
+    setLocale(language)
+    localStorage.setItem('xbot-language', language)
+  }, [language, setLocale])
+
+  // Apply image brightness + persist
   useEffect(() => {
     document.documentElement.style.setProperty('--xbot-img-brightness', String(imageBrightness))
+    localStorage.setItem('xbot-image-brightness', String(imageBrightness))
   }, [imageBrightness])
 
   const handleSave = useCallback(async (updates: Partial<UserSettings>) => {

--- a/web/src/components/settings/AppearanceTab.tsx
+++ b/web/src/components/settings/AppearanceTab.tsx
@@ -154,19 +154,21 @@ export default function AppearanceTab({ showToast, onNicknameChange, onSavingCha
             onBlur={() => {
               handleSave({ theme, font_size: fontSize, nickname, language, image_brightness: imageBrightness })
             }}
-            className="flex-1 accent-indigo-500"
+            className="flex-1"
+                style={{ accentColor: 'var(--accent)' }}
           />
-          <span className="text-xs text-slate-400 w-10 text-right">{imageBrightness.toFixed(1)}</span>
+          <span className="text-xs w-10 text-right" style={{ color: 'var(--text-tertiary)' }}>{imageBrightness.toFixed(1)}</span>
         </div>
-        <p className="text-xs text-slate-500 mt-1">{t('imageBrightnessHint')}</p>
+        <p className="text-xs mt-1" style={{ color: 'var(--text-tertiary)' }}>{t('imageBrightnessHint')}</p>
       </div>
 
       {/* Sound Feedback Settings */}
-      <div className="settings-item mt-4 pt-4 border-t border-slate-700/50">
+      <div className="settings-item mt-4 pt-4" style={{ borderTop: '1px solid var(--border)' }}>
         <div className="flex items-center justify-between mb-2">
           <label className="settings-label">{t('soundFeedback')}</label>
           <button
-            className={`px-3 py-1 text-xs rounded-full transition-colors ${soundConfig.enabled ? 'bg-blue-600 text-white' : 'bg-slate-700 text-slate-400'}`}
+            className={`px-3 py-1 text-xs rounded-full transition-colors`}
+            style={{ background: soundConfig.enabled ? 'var(--accent)' : 'var(--bg-hover)', color: soundConfig.enabled ? '#fff' : 'var(--text-tertiary)' }}
             onClick={toggleSoundEnabled}
             data-testid="sound-toggle"
           >
@@ -178,7 +180,7 @@ export default function AppearanceTab({ showToast, onNicknameChange, onSavingCha
           <div className="space-y-3 mt-2">
             {/* Volume */}
             <div className="flex items-center gap-3">
-              <label className="text-xs text-slate-400 w-16">{t('soundVolume')}</label>
+              <label className="text-xs w-16" style={{ color: 'var(--text-tertiary)' }}>{t('soundVolume')}</label>
               <input
                 type="range"
                 min="0.1"
@@ -186,14 +188,15 @@ export default function AppearanceTab({ showToast, onNicknameChange, onSavingCha
                 step="0.1"
                 value={soundConfig.volume}
                 onChange={(e) => updateSoundConfig({ volume: Number(e.target.value) })}
-                className="flex-1 accent-indigo-500"
+                className="flex-1"
+                style={{ accentColor: 'var(--accent)' }}
               />
-              <span className="text-xs text-slate-400 w-8 text-right">{Math.round(soundConfig.volume * 100)}%</span>
-            </div>
+              <span className="text-xs w-8 text-right" style={{ color: 'var(--text-tertiary)' }}>{Math.round(soundConfig.volume * 100)}%</span>
+             </div>
 
-            {/* Sent sound */}
-            <div className="flex items-center gap-3">
-              <label className="text-xs text-slate-400 w-16">{t('soundSent')}</label>
+             {/* Sent sound */}
+             <div className="flex items-center gap-3">
+              <label className="text-xs w-16" style={{ color: 'var(--text-tertiary)' }}>{t('soundSent')}</label>
               <select
                 className="settings-select text-xs flex-1"
                 value={soundConfig.sentSound}
@@ -208,7 +211,7 @@ export default function AppearanceTab({ showToast, onNicknameChange, onSavingCha
 
             {/* Receive sound */}
             <div className="flex items-center gap-3">
-              <label className="text-xs text-slate-400 w-16">{t('soundReceive')}</label>
+              <label className="text-xs w-16" style={{ color: 'var(--text-tertiary)' }}>{t('soundReceive')}</label>
               <select
                 className="settings-select text-xs flex-1"
                 value={soundConfig.receiveSound}
@@ -223,7 +226,7 @@ export default function AppearanceTab({ showToast, onNicknameChange, onSavingCha
 
             {/* Notify sound */}
             <div className="flex items-center gap-3">
-              <label className="text-xs text-slate-400 w-16">{t('soundNotify')}</label>
+              <label className="text-xs w-16" style={{ color: 'var(--text-tertiary)' }}>{t('soundNotify')}</label>
               <select
                 className="settings-select text-xs flex-1"
                 value={soundConfig.notifySound}
@@ -239,7 +242,7 @@ export default function AppearanceTab({ showToast, onNicknameChange, onSavingCha
         )}
       </div>
 
-      <div className="settings-item mt-4 pt-4 border-t border-slate-700/50">
+      <div className="settings-item mt-4 pt-4" style={{ borderTop: '1px solid var(--border)' }}>
         <div className="flex gap-2 flex-wrap">
           <button
             className="settings-btn-secondary text-xs"

--- a/web/src/components/settings/AppearanceTab.tsx
+++ b/web/src/components/settings/AppearanceTab.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from 'react'
 
 import type { ShowToastFn, Theme, FontSize, Language, UserSettings } from './shared'
-import { lsGet, fetchSettings, saveSettings, FONT_SIZE_MAP, DEFAULT_SETTINGS } from './shared'
+import { lsGet, fetchSettings, saveSettings, FONT_SIZE_MAP, DEFAULT_SETTINGS, LS_KEYS } from './shared'
 import { useTranslation } from '../../i18n'
 import { useSoundFeedback } from '../../hooks/useSoundFeedback'
 
@@ -48,6 +48,12 @@ export default function AppearanceTab({ showToast, onNicknameChange, onSavingCha
   }, [imageBrightness])
 
   const handleSave = useCallback(async (updates: Partial<UserSettings>) => {
+    // Persist each setting to localStorage so App.tsx can read it on next load
+    for (const [key, value] of Object.entries(updates)) {
+      if (value !== undefined && LS_KEYS[key]) {
+        localStorage.setItem(LS_KEYS[key], String(value))
+      }
+    }
     onSavingChange?.(true)
     const ok = await saveSettings(updates)
     onSavingChange?.(false)

--- a/web/src/components/settings/LLMTab.tsx
+++ b/web/src/components/settings/LLMTab.tsx
@@ -188,22 +188,22 @@ export default function LLMTab({ showToast }: LLMTabProps) {
       <div className={sectionTitleClass}>{t('llmTitle')}</div>
 
       {llmConfigLoading ? (
-        <div className="text-center py-6 text-slate-500 text-sm">加载中...</div>
+        <div className="settings-loading">加载中...</div>
       ) : llmConfig && !llmConfig.is_global ? (
         /* ── 个人配置：显示当前配置 + 模型切换 + 删除 ── */
         <>
-          <div className="text-xs text-slate-400 mb-3">
+          <div className="settings-desc">
             当前使用个人模型。可切换模型或删除配置以恢复系统默认。
           </div>
 
           <div className="settings-item">
             <label className="settings-label">提供商 Provider</label>
-            <div className="text-sm text-slate-300">{providerLabel}</div>
+            <div className="settings-value">{providerLabel}</div>
           </div>
 
           <div className="settings-item">
             <label className="settings-label">Base URL</label>
-            <div className="text-sm text-slate-400 font-mono break-all">{llmConfig.base_url}</div>
+            <div className="settings-value-mono">{llmConfig.base_url}</div>
           </div>
 
           <div className="settings-item">
@@ -220,11 +220,11 @@ export default function LLMTab({ showToast }: LLMTabProps) {
                 ))}
               </select>
             ) : (
-              <div className="text-sm text-slate-300">{llmConfig.model || '默认'}</div>
+              <div className="settings-value">{llmConfig.model || '默认'}</div>
             )}
           </div>
 
-          {llmError && <p className="text-xs text-red-400 mt-1 mb-2">{llmError}</p>}
+          {llmError && <p className="settings-error">{llmError}</p>}
 
           <div className="flex gap-2 mt-3">
             <button
@@ -240,18 +240,18 @@ export default function LLMTab({ showToast }: LLMTabProps) {
       ) : llmConfig && llmConfig.is_global ? (
         /* ── 全局配置：显示当前模型 + 添加配置入口 ── */
         <>
-          <div className="text-xs text-slate-400 mb-3">
+          <div className="settings-desc">
             当前使用系统全局模型。配置个人 LLM 后可自由选择模型。
           </div>
 
           {llmConfig.model && (
             <div className="settings-item">
               <label className="settings-label">当前模型 Model</label>
-              <div className="text-sm text-slate-300">{llmConfig.model}</div>
+              <div className="settings-value">{llmConfig.model}</div>
             </div>
           )}
 
-          {llmError && <p className="text-xs text-red-400 mt-1 mb-2">{llmError}</p>}
+          {llmError && <p className="settings-error">{llmError}</p>}
 
           <button
             className="settings-action-btn w-full mt-2"
@@ -263,7 +263,7 @@ export default function LLMTab({ showToast }: LLMTabProps) {
       ) : (
         /* ── 无配置：新增表单 ── */
         <>
-          <div className="text-xs text-slate-400 mb-3">
+          <div className="settings-desc">
             当前使用系统默认模型。配置个人 LLM 后可自由选择模型。
           </div>
 
@@ -300,7 +300,7 @@ export default function LLMTab({ showToast }: LLMTabProps) {
               value={llmFormApiKey}
               onChange={(e) => setLlmFormApiKey(e.target.value)}
             />
-            <p className="text-xs text-slate-600 mt-1">⚠️ API Key 仅存储在服务端，不会返回到前端</p>
+            <p className="settings-muted mt-1">⚠️ API Key 仅存储在服务端，不会返回到前端</p>
           </div>
 
           <div className="settings-item">
@@ -340,7 +340,7 @@ export default function LLMTab({ showToast }: LLMTabProps) {
             </select>
           </div>
 
-          {llmError && <p className="text-xs text-red-400 mt-1 mb-2">{llmError}</p>}
+          {llmError && <p className="settings-error">{llmError}</p>}
 
           <button
             className="settings-action-btn w-full mt-2"
@@ -354,7 +354,7 @@ export default function LLMTab({ showToast }: LLMTabProps) {
 
       {/* ── Max Context 设置（独立于 LLM 配置） ── */}
       {!llmConfigLoading && (
-        <div className="settings-item mt-4 border-t border-slate-700/30 pt-4">
+        <div className="settings-divider">
           <label className="settings-label">最大上下文 Max Context</label>
           <div className="flex items-center gap-2">
             <input
@@ -374,7 +374,7 @@ export default function LLMTab({ showToast }: LLMTabProps) {
               {llmMaxContextSaving ? '⏳' : '💾'} 保存
             </button>
           </div>
-          <div className="text-[11px] text-slate-500 mt-1">
+          <div className="settings-muted mt-1">
             Token 数量，0 表示使用系统默认值。值越大，可用的对话上下文越长，但消耗的 Token 越多。
           </div>
         </div>

--- a/web/src/components/settings/MarketTab.tsx
+++ b/web/src/components/settings/MarketTab.tsx
@@ -131,12 +131,12 @@ export default function MarketTab() {
 
       {marketSubTab === 'browse' && (
         marketLoading ? (
-          <div className="text-center py-8 text-slate-500">
+          <div className="settings-loading">
             <div className="market-spinner" />
             <p className="text-xs mt-2">加载中...</p>
           </div>
         ) : marketEntries.length === 0 ? (
-          <div className="text-center py-8 text-slate-500">
+          <div className="settings-loading">
             <p className="text-3xl mb-3">📭</p>
             <p className="text-sm">暂无可用条目</p>
           </div>
@@ -170,12 +170,12 @@ export default function MarketTab() {
 
       {marketSubTab === 'mine' && (
         marketLoading ? (
-          <div className="text-center py-8 text-slate-500">
+          <div className="settings-loading">
             <div className="market-spinner" />
             <p className="text-xs mt-2">加载中...</p>
           </div>
         ) : myMarketEntries.length === 0 ? (
-          <div className="text-center py-8 text-slate-500">
+          <div className="settings-loading">
             <p className="text-3xl mb-3">📭</p>
             <p className="text-sm">暂无自己的{marketType === 'skill' ? ' Skill' : ' Agent'}</p>
           </div>

--- a/web/src/components/settings/PresetsTab.tsx
+++ b/web/src/components/settings/PresetsTab.tsx
@@ -101,7 +101,7 @@ export default function PresetsTab({ onPresetsChange }: PresetsTabProps) {
     />
     <div className={sectionClass}>
       <div className={sectionTitleClass}>{t('presetsTitle')} Preset Commands</div>
-      <p className="text-xs text-slate-500 mb-3">
+      <p className="settings-desc mb-3">
         配置常用指令，在聊天输入框上方快速触发。最多 20 条。
       </p>
 
@@ -140,7 +140,7 @@ export default function PresetsTab({ onPresetsChange }: PresetsTabProps) {
               value={editingPreset.content}
               onChange={(e) => setEditingPreset({ ...editingPreset, content: e.target.value })}
             />
-            <p className="text-xs text-slate-600 mt-1">{editingPreset.content.length}/2000</p>
+            <p className="settings-muted mt-1">{editingPreset.content.length}/2000</p>
           </div>
           <div className="settings-item">
             <label className="settings-label flex items-center gap-2">
@@ -172,7 +172,7 @@ export default function PresetsTab({ onPresetsChange }: PresetsTabProps) {
         /* ── 列表视图 ── */
         <>
           {presetList.length === 0 ? (
-            <div className="text-center py-6 text-slate-500">
+            <div className="settings-loading">
               <p className="text-2xl mb-2">📭</p>
               <p className="text-sm">{t('noPresets')}</p>
             </div>

--- a/web/src/components/settings/SessionsTab.tsx
+++ b/web/src/components/settings/SessionsTab.tsx
@@ -50,7 +50,7 @@ export default function SessionsTab() {
   return (
     <div className={sectionClass}>
       <div className={sectionTitleClass}>{t("chatRooms")}</div>
-      <p className="text-xs text-slate-500 mb-3">
+      <p className="settings-desc mb-3">
         所有对话都是 ChatRoom — 人↔Agent、Agent↔Agent 统一管理。
       </p>
 
@@ -75,54 +75,45 @@ export default function SessionsTab() {
       {selectedSession ? (
         /* ── 查看 ChatRoom 消息 ── */
         <div>
-          <div className="flex items-center gap-2 mb-3 p-2 rounded-lg bg-slate-800/50">
-            <span className={`text-xs px-1.5 py-0.5 rounded ${
-              selectedSession.type === 'main'
-                ? 'bg-emerald-900/50 text-emerald-400'
-                : 'bg-indigo-900/50 text-indigo-400'
-            }`}>
+          <div className="settings-session-card">
+            <span className="settings-badge" style={selectedSession.type === 'main' ? { background: 'rgba(34,197,94,0.15)', color: '#16a34a' } : { background: 'rgba(99,102,241,0.15)', color: '#6366f1' }}>
               {selectedSession.type === 'main' ? '👤 主会话' : '🤖 Agent'}
             </span>
-            <span className="text-sm font-medium text-slate-200">
+            <span className="settings-value" style={{ fontSize: 14 }}>
               {selectedSession.label}
             </span>
             {selectedSession.members && (
-              <span className="text-xs text-slate-500">
+              <span className="settings-muted">
                 {selectedSession.members}
               </span>
             )}
             {selectedSession.type !== 'main' && (
-              <span className={`ml-auto text-xs px-1.5 py-0.5 rounded ${
-                selectedSession.running
-                  ? 'bg-green-900/50 text-green-400'
-                  : 'bg-slate-700 text-slate-400'
-              }`}>
+              <span className={`settings-badge ml-auto ${selectedSession.running ? 'settings-badge-active' : 'settings-badge-inactive'}`}>
                 {selectedSession.running ? '运行中' : '已完成'}
               </span>
             )}
           </div>
 
           {sessionMessagesLoading ? (
-            <div className="text-center py-4 text-slate-500 text-sm">{t('loadingDots')}</div>
+            <div className="settings-loading" style={{ padding: '16px 0' }}>{t('loadingDots')}</div>
           ) : sessionMessages.length === 0 ? (
-            <div className="text-center py-4 text-slate-500 text-sm">{t('noMessages')}</div>
+            <div className="settings-loading" style={{ padding: '16px 0' }}>{t('noMessages')}</div>
           ) : (
             <div className="space-y-2 max-h-[400px] overflow-y-auto">
               {sessionMessages.map((msg, i) => (
                 <div
                   key={i}
-                  className={`p-2 rounded-lg text-sm ${
-                    msg.role === 'user'
-                      ? 'bg-blue-900/20 border-l-2 border-blue-500 ml-4'
-                      : msg.role === 'system'
-                      ? 'bg-yellow-900/20 border-l-2 border-yellow-500 mr-4 text-xs'
-                      : 'bg-slate-800/50 border-l-2 border-indigo-500 mr-4'
-                  }`}
+                  className="settings-session-item"
+                  style={{
+                    borderLeftColor: msg.role === 'user' ? '#3b82f6' : msg.role === 'system' ? '#eab308' : '#6366f1',
+                    marginLeft: msg.role === 'user' ? '16px' : '0',
+                    marginRight: msg.role !== 'user' ? '16px' : '0',
+                  }}
                 >
-                  <div className="text-xs text-slate-500 mb-1">
+                  <div className="settings-muted mb-1">
                     {msg.role === 'user' ? '👤 User' : msg.role === 'system' ? '⚙️ System' : '🤖 Assistant'}
                   </div>
-                  <div className="text-slate-300 whitespace-pre-wrap break-words" style={{maxHeight: '200px', overflowY: 'auto'}}>
+                  <div className="settings-value" style={{ fontSize: 13, whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: '200px', overflowY: 'auto' }}>
                     {msg.content}
                   </div>
                 </div>
@@ -133,48 +124,40 @@ export default function SessionsTab() {
       ) : (
         /* ── ChatRoom 列表 ── */
         sessionsLoading ? (
-          <div className="text-center py-6 text-slate-500 text-sm">{t('loadingDots')}</div>
-        ) : sessions.length === 0 ? (
-          <div className="text-center py-6 text-slate-500">
-            <p className="text-2xl mb-2">📭</p>
-            <p className="text-sm">{t('noChatRooms')}</p>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {sessions.map((s) => (
+           <div className="settings-loading">{t('loadingDots')}</div>
+          ) : sessions.length === 0 ? (
+           <div className="settings-loading">
+             <p className="text-2xl mb-2">📭</p>
+             <p style={{ fontSize: 14 }}>{t('noChatRooms')}</p>
+           </div>
+          ) : (
+           <div className="space-y-2">
+             {sessions.map((s) => (
               <div
                 key={s.id}
-                className="p-3 rounded-lg bg-slate-800/50 hover:bg-slate-700/50 cursor-pointer transition-colors"
+                className="settings-list-item"
                 onClick={() => setSelectedSession(s)}
               >
                 <div className="flex items-center gap-2">
-                  <span className={`text-xs px-1.5 py-0.5 rounded ${
-                    s.type === 'main'
-                      ? 'bg-emerald-900/50 text-emerald-400'
-                      : 'bg-indigo-900/50 text-indigo-400'
-                  }`}>
-                    {s.type === 'main' ? '👤' : '🤖'}
+                  <span className="settings-badge" style={s.type === 'main' ? { background: 'rgba(34,197,94,0.15)', color: '#16a34a' } : { background: 'rgba(99,102,241,0.15)', color: '#6366f1' }}>
+                   {s.type === 'main' ? '👤' : '🤖'}
                   </span>
-                  <span className="text-sm font-medium text-slate-200">{s.label}</span>
+                  <span className="settings-value" style={{ fontSize: 14 }}>{s.label}</span>
                   {s.members && (
-                    <span className="text-xs text-slate-500">{s.members}</span>
+                   <span className="settings-muted">{s.members}</span>
                   )}
                   {s.type !== 'main' && (
-                    <span className={`ml-auto text-xs px-1.5 py-0.5 rounded ${
-                      s.running
-                        ? 'bg-green-900/50 text-green-400'
-                        : 'bg-slate-700 text-slate-400'
-                    }`}>
-                      {s.running ? '运行中' : '已完成'}
-                    </span>
+                   <span className={`settings-badge ml-auto ${s.running ? 'settings-badge-active' : 'settings-badge-inactive'}`}>
+                     {s.running ? '运行中' : '已完成'}
+                   </span>
                   )}
                 </div>
                 {s.preview && (
-                  <div className="text-xs text-slate-500 mt-1 truncate">{s.preview}</div>
+                  <div className="settings-muted mt-1 truncate">{s.preview}</div>
                 )}
               </div>
-            ))}
-          </div>
+             ))}
+           </div>
         )
       )}
     </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -58,4 +58,5 @@
 @import "./styles/bookmark.css";
 @import "./styles/confirm.css";
 @import "./styles/login.css";
+@import "./styles/progress.css";
 @import "./styles/theme.css";

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -57,4 +57,5 @@
 @import "./styles/settings.css";
 @import "./styles/bookmark.css";
 @import "./styles/confirm.css";
+@import "./styles/login.css";
 @import "./styles/theme.css";

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -78,6 +78,7 @@ body {
   --xbot-bg-surface: var(--bg-secondary);
   --xbot-text-code: var(--accent);
   --xbot-bg-code: rgba(0,0,0,0.4);
+  --xbot-color-error: #dc2626;
   --xbot-bg-copy-btn: var(--bg-hover);
   --xbot-bg-copy-btn-hover: var(--bg-active);
   --xbot-img-brightness: 1;

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -88,7 +88,7 @@ body {
 [data-theme="light"] {
   --bg-base: #ffffff; --bg-secondary: #f2f2f7; --bg-tertiary: #e5e5ea; --bg-elevated: #d1d1d6;
   --bg-hover: rgba(0,0,0,0.04); --bg-active: rgba(0,0,0,0.08);
-  --text-primary: #1d1d1f; --text-secondary: #86868b; --text-tertiary: #aeaeb2; --text-placeholder: #c7c7cc;
+  --text-primary: #1d1d1f; --text-secondary: #6e6e73; --text-tertiary: #8e8e93; --text-placeholder: #c7c7cc;
   --accent: #007aff; --accent-secondary: #5856d6; --accent-hover: #0071e3;
   --border: rgba(0,0,0,0.08); --border-hover: rgba(0,0,0,0.15);
   --glass-bg: rgba(255,255,255,0.72); --glass-border: rgba(0,0,0,0.08); --glass-blur: 40px;

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -136,3 +136,10 @@ body {
 .toast-error { background: rgba(255,69,58,0.15); color: #ff453a; border: 1px solid rgba(255,69,58,0.2); }
 button { font-family: inherit; }
 fieldset { border-width: 0; }
+
+/* ─── Premium Micro-interactions ─── */
+a, button, [role="button"], input, select, textarea, [tabindex] {
+  transition: color 0.15s ease, background-color 0.15s ease, border-color 0.2s ease, box-shadow 0.2s ease, opacity 0.15s ease, transform 0.1s ease;
+}
+button:active { transform: scale(0.98); }
+button:disabled { transform: none; }

--- a/web/src/styles/chat/onboarding.css
+++ b/web/src/styles/chat/onboarding.css
@@ -2,7 +2,7 @@
 .onboarding-overlay {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: 9998;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/web/src/styles/chat/onboarding.css
+++ b/web/src/styles/chat/onboarding.css
@@ -1,4 +1,4 @@
-/* Onboarding overlay */
+/* Onboarding overlay — premium frosted glass */
 .onboarding-overlay {
   position: fixed;
   inset: 0;
@@ -6,45 +6,54 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  animation: fadeInBackdrop 0.3s ease;
 }
 
 .onboarding-card {
   width: 90%;
   max-width: 400px;
-  background: rgba(30, 41, 59, 0.95);
-  backdrop-filter: blur(12px);
-  border: 1px solid rgba(100, 116, 139, 0.3);
-  border-radius: 16px;
-  padding: 32px 24px 24px;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  background: rgba(28, 28, 30, 0.92);
+  backdrop-filter: blur(40px) saturate(180%);
+  -webkit-backdrop-filter: blur(40px) saturate(180%);
+  border: 0.5px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  padding: 36px 28px 28px;
   display: flex;
   flex-direction: column;
   align-items: center;
+  animation: onboardingCardIn 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes onboardingCardIn {
+  from { opacity: 0; transform: scale(0.95) translateY(10px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
 }
 
 .onboarding-step-indicator {
   display: flex;
   gap: 8px;
-  margin-bottom: 24px;
+  margin-bottom: 28px;
 }
 
 .onboarding-step-dot {
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
-  background: rgba(100, 116, 139, 0.4);
-  transition: background 0.2s, transform 0.2s;
+  background: rgba(255, 255, 255, 0.15);
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .onboarding-step-dot.active {
-  background: #3b82f6;
-  transform: scale(1.3);
+  background: #007AFF;
+  transform: scale(1.4);
+  box-shadow: 0 0 12px 3px rgba(0, 122, 255, 0.5);
 }
 
 .onboarding-step-dot.done {
-  background: #22c55e;
+  background: #30d158;
 }
 
 .onboarding-step-content {
@@ -52,115 +61,135 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  margin-bottom: 24px;
+  margin-bottom: 28px;
 }
 
 .onboarding-step-icon {
-  font-size: 48px;
-  margin-bottom: 16px;
+  font-size: 52px;
+  margin-bottom: 20px;
 }
 
 .onboarding-step-title {
   font-size: 18px;
   font-weight: 600;
-  color: #e2e8f0;
-  margin: 0 0 8px;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+  margin: 0 0 10px;
 }
 
 .onboarding-step-desc {
   font-size: 14px;
-  color: #94a3b8;
+  color: var(--text-secondary);
+  line-height: 1.5;
   margin: 0;
 }
 
 .onboarding-actions {
   display: flex;
-  gap: 8px;
+  gap: 10px;
   width: 100%;
   justify-content: center;
   flex-wrap: wrap;
 }
 
 .onboarding-btn {
-  padding: 8px 16px;
-  border-radius: 8px;
-  font-size: 13px;
+  padding: 10px 20px;
+  border-radius: 12px;
+  font-size: 14px;
   font-weight: 500;
+  letter-spacing: -0.01em;
   border: none;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition: all 0.2s ease;
 }
+
+.onboarding-btn:active { transform: scale(0.96); }
 
 .onboarding-btn-skip {
   background: transparent;
-  color: #64748b;
+  color: var(--text-tertiary);
   margin-right: auto;
 }
 
 .onboarding-btn-skip:hover {
-  color: #94a3b8;
+  color: var(--text-secondary);
 }
 
 .onboarding-btn-prev {
-  background: rgba(71, 85, 105, 0.5);
-  color: #cbd5e1;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-secondary);
 }
 
 .onboarding-btn-prev:hover {
-  background: rgba(71, 85, 105, 0.7);
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .onboarding-btn-next {
-  background: #3b82f6;
+  background: linear-gradient(180deg, #5bb8ff 0%, #0055b3 100%);
   color: #fff;
   margin-left: auto;
+  box-shadow: 0 2px 10px rgba(0, 85, 179, 0.4);
 }
 
 .onboarding-btn-next:hover {
-  background: #007AFF;
+  box-shadow: 0 4px 18px rgba(0, 85, 179, 0.55);
 }
 
 /* Light theme */
 [data-theme="light"] .onboarding-overlay {
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
 }
 
 [data-theme="light"] .onboarding-card {
-  background: rgba(255, 255, 255, 0.95);
-  border-color: rgba(203, 213, 225, 0.6);
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.15);
+  background: rgba(255, 255, 255, 0.85);
+  border-color: rgba(0, 0, 0, 0.06);
+}
+
+[data-theme="light"] .onboarding-step-dot {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="light"] .onboarding-step-dot.active {
+  background: #007AFF;
+  box-shadow: 0 0 8px rgba(0, 122, 255, 0.25);
+}
+
+[data-theme="light"] .onboarding-step-dot.done {
+  background: #34c759;
 }
 
 [data-theme="light"] .onboarding-step-title {
-  color: #1e293b;
+  color: #1d1d1f;
 }
 
 [data-theme="light"] .onboarding-step-desc {
-  color: #64748b;
+  color: #86868b;
 }
 
 [data-theme="light"] .onboarding-btn-skip {
-  color: #94a3b8;
+  color: #aeaeb2;
 }
 
 [data-theme="light"] .onboarding-btn-skip:hover {
-  color: #64748b;
+  color: #86868b;
 }
 
 [data-theme="light"] .onboarding-btn-prev {
-  background: rgba(241, 245, 249, 0.8);
-  color: #475569;
+  background: rgba(0, 0, 0, 0.04);
+  color: #86868b;
 }
 
 [data-theme="light"] .onboarding-btn-prev:hover {
-  background: rgba(226, 232, 240, 0.8);
+  background: rgba(0, 0, 0, 0.08);
 }
 
 [data-theme="light"] .onboarding-btn-next {
-  background: #007AFF;
-  color: #fff;
+  background: linear-gradient(180deg, #5bb8ff 0%, #0055b3 100%) !important;
+  box-shadow: 0 2px 12px rgba(0, 85, 179, 0.35) !important;
 }
 
 [data-theme="light"] .onboarding-btn-next:hover {
-  background: #007AFF;
+  box-shadow: 0 4px 16px rgba(0, 122, 255, 0.3);
 }

--- a/web/src/styles/confirm.css
+++ b/web/src/styles/confirm.css
@@ -87,7 +87,7 @@
 
 [data-theme="light"] .confirm-dialog-btn-cancel {
   background: #e2e8f0;
-  color: var(--xbot-border-light);
+  color: #475569;
 }
 [data-theme="light"] .confirm-dialog-btn-cancel:hover {
   background: #cbd5e1;

--- a/web/src/styles/login.css
+++ b/web/src/styles/login.css
@@ -1,7 +1,73 @@
 /* ========================================================================== */
-/* Login Page Styles                                                         */
+/* Login Page Styles — Apple Futuristic                                        */
 /* ========================================================================== */
 
-/* Login-specific styles are global light theme overrides for input fields. */
-/* See base.css for [data-theme=light] input.bg-slate-700, */
-/* select.bg-slate-700, and placeholder-slate-400::placeholder rules. */
+/* Login container: pure black, full-screen centered */
+.login-container {
+  background: #000 !important;
+}
+
+/* Login form card: elevated glass */
+.login-container form {
+  background: rgba(28, 28, 30, 0.95) !important;
+  border: 0.5px solid rgba(255, 255, 255, 0.08) !important;
+  border-radius: 20px !important;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5) !important;
+}
+
+/* Input fields in login: deeper recessed look */
+.login-container input {
+  background: rgba(0, 0, 0, 0.3) !important;
+  border: 0.5px solid rgba(255, 255, 255, 0.1) !important;
+  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s !important;
+}
+
+.login-container input::placeholder {
+  color: var(--text-placeholder) !important;
+}
+
+.login-container input:focus {
+  background: rgba(0, 0, 0, 0.45) !important;
+  border-color: #007AFF !important;
+  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.15) !important;
+  outline: none !important;
+}
+
+/* Submit button: Apple blue */
+.login-container button[type="submit"] {
+  background: #007AFF !important;
+  font-weight: 600 !important;
+  font-size: 15px !important;
+  letter-spacing: -0.01em !important;
+  transition: opacity 0.15s, transform 0.1s !important;
+}
+
+.login-container button[type="submit"]:hover {
+  background: #0a84ff !important;
+}
+
+.login-container button[type="submit"]:active {
+  transform: scale(0.98) !important;
+}
+
+/* ─── Light Mode ─── */
+[data-theme="light"] .login-container {
+  background: #f5f5f7 !important;
+}
+
+[data-theme="light"] .login-container form {
+  background: rgba(255, 255, 255, 0.95) !important;
+  border-color: rgba(0, 0, 0, 0.06) !important;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.08) !important;
+}
+
+[data-theme="light"] .login-container input {
+  background: rgba(0, 0, 0, 0.03) !important;
+  border-color: rgba(0, 0, 0, 0.08) !important;
+}
+
+[data-theme="light"] .login-container input:focus {
+  background: rgba(0, 0, 0, 0.05) !important;
+  border-color: #007AFF !important;
+  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1) !important;
+}

--- a/web/src/styles/login.css
+++ b/web/src/styles/login.css
@@ -2,27 +2,56 @@
 /* Login Page Styles — Apple Futuristic Premium                                */
 /* ========================================================================== */
 
-/* Login container: pure black, full-screen centered */
+/* Login container: dark gradient with subtle depth */
 .login-container {
-  background: #000 !important;
+  background: radial-gradient(ellipse at 50% 30%, rgba(0,122,255,0.06) 0%, #000 60%) !important;
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Decorative ambient orbs */
+.login-container::before {
+  content: '';
+  position: absolute;
+  width: 400px;
+  height: 400px;
+  top: -100px;
+  right: -100px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(0,122,255,0.08) 0%, transparent 70%);
+  pointer-events: none;
+}
+.login-container::after {
+  content: '';
+  position: absolute;
+  width: 300px;
+  height: 300px;
+  bottom: -80px;
+  left: -80px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(100,60,255,0.06) 0%, transparent 70%);
+  pointer-events: none;
 }
 
 /* Login form card: elevated glass with layered shadow */
 .login-container form {
   background: rgba(28, 28, 30, 0.92) !important;
   border: 0.5px solid rgba(255, 255, 255, 0.1) !important;
-  border-radius: 20px !important;
+  border-radius: 24px !important;
   box-shadow:
     0 0 0 0.5px rgba(255,255,255,0.05),
+    0 0 80px rgba(0,122,255,0.06),
     0 4px 16px rgba(0,0,0,0.3),
     0 20px 60px rgba(0,0,0,0.4),
     0 40px 80px rgba(0,0,0,0.2) !important;
   backdrop-filter: blur(40px) saturate(180%) !important;
   -webkit-backdrop-filter: blur(40px) saturate(180%) !important;
+  position: relative;
+  z-index: 1;
 }
 
 /* Input fields: recessed with precise borders */

--- a/web/src/styles/login.css
+++ b/web/src/styles/login.css
@@ -1,73 +1,117 @@
 /* ========================================================================== */
-/* Login Page Styles — Apple Futuristic                                        */
+/* Login Page Styles — Apple Futuristic Premium                                */
 /* ========================================================================== */
 
 /* Login container: pure black, full-screen centered */
 .login-container {
   background: #000 !important;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-/* Login form card: elevated glass */
+/* Login form card: elevated glass with layered shadow */
 .login-container form {
-  background: rgba(28, 28, 30, 0.95) !important;
-  border: 0.5px solid rgba(255, 255, 255, 0.08) !important;
+  background: rgba(28, 28, 30, 0.92) !important;
+  border: 0.5px solid rgba(255, 255, 255, 0.1) !important;
   border-radius: 20px !important;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5) !important;
+  box-shadow:
+    0 0 0 0.5px rgba(255,255,255,0.05),
+    0 4px 16px rgba(0,0,0,0.3),
+    0 20px 60px rgba(0,0,0,0.4),
+    0 40px 80px rgba(0,0,0,0.2) !important;
+  backdrop-filter: blur(40px) saturate(180%) !important;
+  -webkit-backdrop-filter: blur(40px) saturate(180%) !important;
 }
 
-/* Input fields in login: deeper recessed look */
+/* Input fields: recessed with precise borders */
 .login-container input {
-  background: rgba(0, 0, 0, 0.3) !important;
-  border: 0.5px solid rgba(255, 255, 255, 0.1) !important;
-  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s !important;
+  background: rgba(0, 0, 0, 0.35) !important;
+  border: 1px solid rgba(255, 255, 255, 0.08) !important;
+  border-radius: 12px !important;
+  padding: 11px 14px !important;
+  font-size: 15px !important;
+  letter-spacing: -0.01em !important;
+  transition: border-color 0.25s ease, background 0.2s ease, box-shadow 0.25s ease !important;
 }
 
 .login-container input::placeholder {
   color: var(--text-placeholder) !important;
+  opacity: 1 !important;
 }
 
 .login-container input:focus {
-  background: rgba(0, 0, 0, 0.45) !important;
-  border-color: #007AFF !important;
-  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.15) !important;
+  background: rgba(0, 0, 0, 0.5) !important;
+  border-color: rgba(0, 122, 255, 0.6) !important;
+  box-shadow: 0 0 0 3.5px rgba(0, 122, 255, 0.12) !important;
   outline: none !important;
 }
 
-/* Submit button: Apple blue */
+/* Submit button: premium Apple blue with depth */
 .login-container button[type="submit"] {
-  background: #007AFF !important;
+  background: linear-gradient(180deg, #339dff 0%, #0066d6 100%) !important;
+  border-radius: 12px !important;
   font-weight: 600 !important;
   font-size: 15px !important;
   letter-spacing: -0.01em !important;
-  transition: opacity 0.15s, transform 0.1s !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.25), 0 4px 16px rgba(0,102,214,0.35) !important;
+  transition: all 0.2s ease !important;
 }
 
 .login-container button[type="submit"]:hover {
-  background: #0a84ff !important;
+  background: linear-gradient(180deg, #52b0ff 0%, #0077ee 100%) !important;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.25), 0 8px 24px rgba(0,102,214,0.4) !important;
 }
 
 .login-container button[type="submit"]:active {
   transform: scale(0.98) !important;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2), 0 2px 8px rgba(0,122,255,0.2) !important;
+}
+
+/* Link hover states */
+.login-container a, .login-container button:not([type="submit"]) {
+  transition: color 0.15s ease, opacity 0.15s ease !important;
+}
+.login-container a:hover, .login-container button:not([type="submit"]):hover {
+  opacity: 0.8 !important;
 }
 
 /* ─── Light Mode ─── */
 [data-theme="light"] .login-container {
-  background: #f5f5f7 !important;
+  background: linear-gradient(135deg, #dfe6f0 0%, #f2f2f7 50%, #e8e8f0 100%) !important;
 }
 
 [data-theme="light"] .login-container form {
-  background: rgba(255, 255, 255, 0.95) !important;
+  background: rgba(255, 255, 255, 0.82) !important;
   border-color: rgba(0, 0, 0, 0.06) !important;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.08) !important;
+  box-shadow:
+    0 0 0 0.5px rgba(0,0,0,0.03),
+    0 4px 16px rgba(0,0,0,0.04),
+    0 20px 60px rgba(0,0,0,0.06),
+    0 40px 80px rgba(0,0,0,0.03) !important;
+  backdrop-filter: blur(40px) saturate(180%) !important;
+  -webkit-backdrop-filter: blur(40px) saturate(180%) !important;
 }
 
 [data-theme="light"] .login-container input {
   background: rgba(0, 0, 0, 0.03) !important;
-  border-color: rgba(0, 0, 0, 0.08) !important;
+  border-color: rgba(0, 0, 0, 0.1) !important;
+  border-radius: 12px !important;
+}
+
+[data-theme="light"] .login-container input::placeholder {
+  color: var(--text-placeholder) !important;
 }
 
 [data-theme="light"] .login-container input:focus {
   background: rgba(0, 0, 0, 0.05) !important;
-  border-color: #007AFF !important;
-  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1) !important;
+  border-color: rgba(0, 122, 255, 0.5) !important;
+  box-shadow: 0 0 0 3.5px rgba(0, 122, 255, 0.08) !important;
 }
+
+[data-theme="light"] .login-container button[type="submit"] {
+  background: linear-gradient(180deg, #339dff 0%, #0066d6 100%) !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1), 0 4px 16px rgba(0,102,214,0.25) !important;
+}
+

--- a/web/src/styles/progress.css
+++ b/web/src/styles/progress.css
@@ -16,9 +16,13 @@
 }
 .progress-card-thinking {
   border-radius: 20px;
-  padding: 16px 20px;
-  border-color: rgba(0, 122, 255, 0.15);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  padding: 20px 24px;
+  border-color: rgba(0, 122, 255, 0.2);
+  background: linear-gradient(135deg, rgba(0, 122, 255, 0.04) 0%, var(--bg-secondary) 100%) !important;
+  box-shadow:
+    0 0 0 0.5px rgba(0, 122, 255, 0.08),
+    0 4px 20px rgba(0, 0, 0, 0.12),
+    0 12px 40px rgba(0, 122, 255, 0.06);
 }
 .progress-card-active {
   border-color: rgba(0, 122, 255, 0.25);
@@ -133,9 +137,11 @@
   padding: 4px 8px;
 }
 .thinking-label {
-  font-size: 12px;
-  color: var(--text-tertiary);
+  font-size: 13px;
+  color: var(--text-secondary);
   font-style: italic;
+  font-weight: 500;
+  letter-spacing: 0.02em;
   animation: thinking-label-pulse 2s ease-in-out infinite;
 }
 @keyframes thinking-label-pulse {
@@ -268,41 +274,45 @@
   white-space: nowrap;
 }
 
-/* ---- Thinking Orb animation (retained from original) ---- */
+/* ---- Thinking Orb animation — Premium 10/10 ---- */
 .thinking-orb {
   position: relative;
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   flex-shrink: 0;
 }
 .thinking-orb-core {
   position: absolute;
   top: 50%; left: 50%;
-  width: 8px; height: 8px;
-  margin: -4px 0 0 -4px;
-  background: #007AFF;
+  width: 14px; height: 14px;
+  margin: -7px 0 0 -7px;
+  background: radial-gradient(circle at 35% 35%, #b4dfff 0%, #5bb8ff 25%, #007AFF 55%, #003d7a 100%);
   border-radius: 50%;
-  box-shadow: 0 0 8px rgba(0,122,255,0.5);
+  box-shadow:
+    0 0 8px 3px rgba(91,184,255,0.7),
+    0 0 20px 6px rgba(0,122,255,0.35),
+    0 0 40px 10px rgba(0,122,255,0.12);
   animation: orb-pulse 2s ease-in-out infinite;
 }
 .thinking-orb-ring {
   position: absolute;
   top: 50%; left: 50%;
-  border: 1.5px solid rgba(0,122,255,0.2);
+  border: 2px solid rgba(91,184,255,0.4);
   border-radius: 50%;
-  animation: orb-ring-expand 2.5s ease-out infinite;
+  animation: orb-ring-expand 2.8s ease-out infinite;
+  box-shadow: 0 0 8px rgba(91,184,255,0.15);
 }
-.thinking-orb-ring-1 { width: 16px; height: 16px; margin: -8px 0 0 -8px; animation-delay: 0s; }
-.thinking-orb-ring-2 { width: 16px; height: 16px; margin: -8px 0 0 -8px; animation-delay: 0.8s; }
-.thinking-orb-ring-3 { width: 16px; height: 16px; margin: -8px 0 0 -8px; animation-delay: 1.6s; }
+.thinking-orb-ring-1 { width: 18px; height: 18px; margin: -9px 0 0 -9px; animation-delay: 0s; }
+.thinking-orb-ring-2 { width: 18px; height: 18px; margin: -9px 0 0 -9px; animation-delay: 0.9s; }
+.thinking-orb-ring-3 { width: 18px; height: 18px; margin: -9px 0 0 -9px; animation-delay: 1.8s; }
 
 @keyframes orb-pulse {
-  0%, 100% { opacity: 0.7; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.2); }
+  0%, 100% { opacity: 0.8; transform: scale(1); box-shadow: 0 0 6px 2px rgba(0,122,255,0.5), 0 0 16px 4px rgba(0,122,255,0.2); }
+  50% { opacity: 1; transform: scale(1.15); box-shadow: 0 0 10px 3px rgba(0,122,255,0.7), 0 0 24px 6px rgba(0,122,255,0.3); }
 }
 @keyframes orb-ring-expand {
-  0% { width: 10px; height: 10px; margin: -5px 0 0 -5px; opacity: 0.6; border-color: rgba(0,122,255,0.4); }
-  100% { width: 28px; height: 28px; margin: -14px 0 0 -14px; opacity: 0; border-color: rgba(0,122,255,0); }
+  0% { width: 12px; height: 12px; margin: -6px 0 0 -6px; opacity: 0.7; border-color: rgba(0,122,255,0.5); }
+  100% { width: 36px; height: 36px; margin: -18px 0 0 -18px; opacity: 0; border-color: rgba(0,122,255,0); }
 }
 
 /* ---- Thinking dots animation ---- */
@@ -344,7 +354,19 @@
   box-shadow: 0 4px 20px rgba(0, 122, 255, 0.04);
 }
 [data-theme="light"] .progress-card-thinking {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
+  background: linear-gradient(135deg, rgba(0, 122, 255, 0.03) 0%, rgba(255,255,255,0.85) 100%) !important;
+  border-color: rgba(0, 122, 255, 0.12) !important;
+  box-shadow:
+    0 0 0 0.5px rgba(0, 0, 0, 0.04),
+    0 4px 20px rgba(0, 0, 0, 0.04),
+    0 12px 40px rgba(0, 122, 255, 0.04) !important;
+}
+[data-theme="light"] .thinking-label {
+  color: #3a3a3c;
+}
+[data-theme="light"] .thinking-orb-core {
+  background: radial-gradient(circle, #7cc4ff 0%, #007AFF 60%, #004080 100%);
+  box-shadow: 0 0 6px 2px rgba(0,122,255,0.4), 0 0 14px 4px rgba(0,122,255,0.15);
 }
 [data-theme="light"] .iteration-reasoning {
   background: rgba(88, 86, 214, 0.04);

--- a/web/src/styles/progress.css
+++ b/web/src/styles/progress.css
@@ -1,254 +1,369 @@
 /* ========================================================================== */
-/* SubAgent Tree Styles                                                      */
+/* Progress Panel — Premium Apple Style                                        */
 /* ========================================================================== */
 
-/* ========================================================================== */
-/* SubAgent Tree Styles                                                       */
-/* ========================================================================== */
-
-@keyframes subagent-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+/* ---- Card ---- */
+.progress-card {
+  max-width: 80%;
+  width: 100%;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+.progress-card-thinking {
+  border-radius: 20px;
+  padding: 16px 20px;
+  border-color: rgba(0, 122, 255, 0.15);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+.progress-card-active {
+  border-color: rgba(0, 122, 255, 0.25);
+  box-shadow: 0 4px 20px rgba(0, 122, 255, 0.06);
+  animation: progress-card-pulse 2.5s ease-in-out infinite;
+}
+.progress-card-done {
+  opacity: 0.85;
 }
 
-@keyframes subagent-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+@keyframes progress-card-pulse {
+  0%, 100% { border-color: rgba(0, 122, 255, 0.2); box-shadow: 0 4px 20px rgba(0, 122, 255, 0.04); }
+  50% { border-color: rgba(0, 122, 255, 0.4); box-shadow: 0 4px 24px rgba(0, 122, 255, 0.1); }
 }
 
-.subagent-pulse {
-  animation: subagent-pulse 1.5s ease-in-out infinite;
-  display: inline-block;
-}
-
-.subagent-spin {
-  animation: subagent-spin 2s linear infinite;
-  display: inline-block;
-}
-
-.subagent-tree {
+.progress-inner {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+}
+.progress-inner > .iteration-item { border-bottom: 0.5px solid var(--border); }
+.progress-inner > .iteration-item:last-child { border-bottom: none; }
+
+/* ---- Iteration ---- */
+.iteration-item {
+  padding: 10px 14px;
+}
+.iteration-header {
+  font-size: 11px;
+  font-family: 'SF Mono', ui-monospace, monospace;
+  color: var(--text-tertiary);
+  margin-bottom: 6px;
+  opacity: 0.7;
 }
 
-.subagent-node {
-  position: relative;
+/* Reasoning/Thinking blocks */
+.iteration-block {
+  padding: 8px 10px;
+  margin-bottom: 6px;
+  border-radius: 8px;
+  border-left: 2.5px solid;
+}
+.iteration-reasoning {
+  background: rgba(88, 86, 214, 0.08);
+  border-left-color: rgba(88, 86, 214, 0.5);
+}
+.iteration-thinking {
+  background: rgba(255, 159, 10, 0.06);
+  border-left-color: rgba(255, 159, 10, 0.5);
+}
+.iteration-block-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 3px;
+}
+.iteration-reasoning .iteration-block-label { color: rgba(88, 86, 214, 0.7); }
+.iteration-thinking .iteration-block-label { color: rgba(255, 159, 10, 0.7); }
+.iteration-block-text {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.iteration-block-text.italic { font-style: italic; }
+
+/* Tool rows */
+.iteration-tool {
+  padding: 4px 8px;
+  font-size: 13px;
+}
+.iteration-tool-name {
+  font-family: 'SF Mono', ui-monospace, monospace;
+  font-size: 12px;
+  color: var(--text-secondary);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.iteration-tool-time {
+  font-family: 'SF Mono', ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+.iteration-tool-summary {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  padding-left: 20px;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.subagent-node-running {
-  background: rgba(59, 130, 246, 0.08);
-  border-left: 2px solid rgba(59, 130, 246, 0.4);
+/* Phase text (compressing/retrying) */
+.iteration-phase-text {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--text-tertiary);
 }
 
-.subagent-node-pending {
-  background: rgba(148, 163, 184, 0.05);
-  border-left: 2px solid rgba(148, 163, 184, 0.3);
+/* ---- Thinking Orb & Dots ---- */
+.thinking-orb-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 8px;
 }
-
-/* ========================================================================== */
-/* SubAgent Animations                                                       */
-/* ========================================================================== */
-
-/* ========================================================================== */
-/* SubAgent Animations                                                         */
-/* ========================================================================== */
-
-.subagent-spin {
-  display: inline-block;
-  animation: subagent-rotate 2s linear infinite;
+.thinking-label {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  animation: thinking-label-pulse 2s ease-in-out infinite;
 }
-
-@keyframes subagent-rotate {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-.subagent-pulse {
-  display: inline-block;
-  animation: subagent-pulse-anim 1.5s ease-in-out infinite;
-}
-
-@keyframes subagent-pulse-anim {
-  0%, 100% { opacity: 0.5; }
+@keyframes thinking-label-pulse {
+  0%, 100% { opacity: 0.6; }
   50% { opacity: 1; }
 }
 
-.subagent-node-running {
-  background: rgba(59, 130, 246, 0.08);
-  border-left: 2px solid rgba(59, 130, 246, 0.4);
+.bouncing-dots-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+}
+.bouncing-dots-text {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-style: italic;
 }
 
-.subagent-node-pending {
-  border-left: 2px solid rgba(100, 116, 139, 0.3);
+/* ---- SubAgent Tree ---- */
+.subagent-node-idle {
+  border-radius: 6px;
+  transition: background 0.15s ease;
+}
+.subagent-node-idle:hover { background: rgba(255, 255, 255, 0.03); }
+.subagent-role {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+  flex-shrink: 0;
+}
+.subagent-desc {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+.subagent-chevron {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  transition: transform 0.15s ease;
+  display: inline-block;
+}
+.subagent-chevron-open { transform: rotate(90deg); }
+
+.progress-sub-section {
+  padding: 8px 14px;
+  border-top: 0.5px solid var(--border);
 }
 
-/* ========================================================================== */
-/* Enhanced Thinking Animation (Orb)                                         */
-/* ========================================================================== */
+/* ---- Token Usage Bar ---- */
+.token-usage-bar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 14px;
+  font-size: 11px;
+  font-family: 'SF Mono', ui-monospace, monospace;
+  color: var(--text-tertiary);
+  border-top: 0.5px solid var(--border);
+}
+.token-usage-item { display: flex; align-items: center; gap: 3px; }
+.token-label-in { color: #5bb8ff; font-weight: 500; }
+.token-label-out { color: #30d158; font-weight: 500; }
+.token-label-total { color: var(--text-tertiary); }
+.token-label-cache { color: #ff9f0a; font-weight: 500; }
+.token-value { color: var(--text-primary); font-weight: 500; }
 
-/* ========================================================================== */
-/* Enhanced Thinking Animation (Orb)                                           */
-/* ========================================================================== */
+/* ---- TODO Section ---- */
+.todo-section {
+  padding: 10px 14px;
+  border-top: 0.5px solid var(--border);
+}
+.todo-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.todo-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.01em;
+}
+.todo-percent {
+  font-size: 10px;
+  font-family: 'SF Mono', ui-monospace, monospace;
+  color: var(--text-tertiary);
+}
+.todo-progress-track {
+  width: 100%;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.06);
+  margin-bottom: 10px;
+  overflow: hidden;
+}
+.todo-progress-bar {
+  height: 100%;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #5bb8ff 0%, #30d158 100%);
+  transition: width 0.5s ease-out;
+  box-shadow: 0 0 8px rgba(91, 184, 255, 0.3);
+}
+.todo-items {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 128px;
+  overflow-y: auto;
+}
+.todo-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+.todo-item-done .todo-text {
+  text-decoration: line-through;
+  color: var(--text-tertiary);
+}
+.todo-check { flex-shrink: 0; }
+.todo-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
+/* ---- Thinking Orb animation (retained from original) ---- */
 .thinking-orb {
   position: relative;
   width: 28px;
   height: 28px;
   flex-shrink: 0;
 }
-
 .thinking-orb-core {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 8px;
-  height: 8px;
-  background: radial-gradient(circle, #60a5fa, #3b82f6);
+  top: 50%; left: 50%;
+  width: 8px; height: 8px;
+  margin: -4px 0 0 -4px;
+  background: #007AFF;
   border-radius: 50%;
-  transform: translate(-50%, -50%);
-  box-shadow: 0 0 8px rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 8px rgba(0,122,255,0.5);
+  animation: orb-pulse 2s ease-in-out infinite;
 }
-
-.thinking-orb-sm .thinking-orb-core {
-  width: 6px;
-  height: 6px;
-}
-
 .thinking-orb-ring {
   position: absolute;
-  top: 50%;
-  left: 50%;
+  top: 50%; left: 50%;
+  border: 1.5px solid rgba(0,122,255,0.2);
   border-radius: 50%;
-  border: 1.5px solid transparent;
-  transform: translate(-50%, -50%);
+  animation: orb-ring-expand 2.5s ease-out infinite;
 }
+.thinking-orb-ring-1 { width: 16px; height: 16px; margin: -8px 0 0 -8px; animation-delay: 0s; }
+.thinking-orb-ring-2 { width: 16px; height: 16px; margin: -8px 0 0 -8px; animation-delay: 0.8s; }
+.thinking-orb-ring-3 { width: 16px; height: 16px; margin: -8px 0 0 -8px; animation-delay: 1.6s; }
 
-.thinking-orb-ring-1 {
-  width: 100%;
-  height: 100%;
-  border-top-color: rgba(96, 165, 250, 0.8);
-  border-right-color: rgba(96, 165, 250, 0.3);
-  animation: orb-spin 1.2s linear infinite;
-}
-
-.thinking-orb-ring-2 {
-  width: 80%;
-  height: 80%;
-  border-bottom-color: rgba(34, 197, 94, 0.6);
-  border-left-color: rgba(34, 197, 94, 0.2);
-  animation: orb-spin 1.8s linear infinite reverse;
-}
-
-.thinking-orb-ring-3 {
-  width: 60%;
-  height: 60%;
-  border-top-color: rgba(168, 85, 247, 0.5);
-  animation: orb-spin 2.4s linear infinite;
-}
-
-@keyframes orb-spin {
-  from { transform: translate(-50%, -50%) rotate(0deg); }
-  to { transform: translate(-50%, -50%) rotate(360deg); }
-}
-
-/* ========================================================================== */
-/* Enhanced Thinking Dots                                                    */
-/* ========================================================================== */
-
-/* ========================================================================== */
-/* Enhanced Thinking Dots                                                      */
-/* ========================================================================== */
-
-.thinking-dots {
-  display: flex;
-  gap: 4px;
-  align-items: center;
-}
-
-.thinking-dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: #64748b;
-  animation: dot-wave 1.4s ease-in-out infinite;
-}
-
-@keyframes dot-wave {
-  0%, 80%, 100% {
-    transform: scale(0.6);
-    opacity: 0.4;
-  }
-  40% {
-    transform: scale(1);
-    opacity: 1;
-    background: #60a5fa;
-    box-shadow: 0 0 6px rgba(96, 165, 250, 0.5);
-  }
-}
-
-/* ========================================================================== */
-/* Enhanced Tool Pulse Animation                                             */
-/* ========================================================================== */
-
-/* ========================================================================== */
-/* Enhanced Tool Pulse Animation                                               */
-/* ========================================================================== */
-
-.tool-pulse {
-  display: inline-block;
-  animation: tool-glow 2s ease-in-out infinite;
-}
-
-@keyframes tool-glow {
+@keyframes orb-pulse {
   0%, 100% { opacity: 0.7; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.15); box-shadow: 0 0 4px rgba(59, 130, 246, 0.3); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+@keyframes orb-ring-expand {
+  0% { width: 10px; height: 10px; margin: -5px 0 0 -5px; opacity: 0.6; border-color: rgba(0,122,255,0.4); }
+  100% { width: 28px; height: 28px; margin: -14px 0 0 -14px; opacity: 0; border-color: rgba(0,122,255,0); }
+}
+
+/* ---- Thinking dots animation ---- */
+.thinking-dots {
+  display: inline-flex;
+  gap: 3px;
+}
+.thinking-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: thinking-dot-bounce 1.4s ease-in-out infinite;
+}
+@keyframes thinking-dot-bounce {
+  0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1.1); }
+}
+
+/* SubAgent spinner/pulse */
+.subagent-spin { display: inline-block; animation: subagent-spin-anim 1.2s linear infinite; }
+@keyframes subagent-spin-anim { to { transform: rotate(360deg); } }
+.subagent-pulse { display: inline-block; animation: subagent-pulse-anim 1.5s ease-in-out infinite; }
+@keyframes subagent-pulse-anim {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+.subagent-node-running {
+  background: rgba(0, 122, 255, 0.06);
+  border-radius: 6px;
+}
+.subagent-node-pending {
+  background: rgba(255, 159, 10, 0.04);
+  border-radius: 6px;
 }
 
 /* ---- Light Theme Overrides ---- */
+[data-theme="light"] .progress-card-active {
+  box-shadow: 0 4px 20px rgba(0, 122, 255, 0.04);
+}
+[data-theme="light"] .progress-card-thinking {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
+}
+[data-theme="light"] .iteration-reasoning {
+  background: rgba(88, 86, 214, 0.04);
+  border-left-color: rgba(88, 86, 214, 0.35);
+}
+[data-theme="light"] .iteration-thinking {
+  background: rgba(255, 159, 10, 0.04);
+  border-left-color: rgba(255, 159, 10, 0.35);
+}
+[data-theme="light"] .iteration-reasoning .iteration-block-label { color: rgba(88, 86, 214, 0.6); }
+[data-theme="light"] .iteration-thinking .iteration-block-label { color: rgba(255, 159, 10, 0.55); }
+[data-theme="light"] .subagent-node-idle:hover { background: rgba(0, 0, 0, 0.03); }
+[data-theme="light"] .subagent-node-running { background: rgba(0, 122, 255, 0.04); }
+[data-theme="light"] .subagent-node-pending { background: rgba(255, 159, 10, 0.03); }
+[data-theme="light"] .todo-progress-track { background: rgba(0, 0, 0, 0.06); }
+[data-theme="light"] .todo-progress-bar { box-shadow: 0 0 6px rgba(0, 122, 255, 0.15); }
+[data-theme="light"] .token-label-in { color: #007AFF; }
+[data-theme="light"] .token-label-out { color: #34c759; }
+[data-theme="light"] .token-label-cache { color: #ff9f0a; }
 
-/* Thinking orb — softer glow for light backgrounds */
-[data-theme="light"] .thinking-orb-core {
-  background: radial-gradient(circle, #3b82f6, #2563eb);
-  box-shadow: 0 0 6px rgba(59, 130, 246, 0.4);
-}
-[data-theme="light"] .thinking-orb-ring-1 {
-  border-top-color: rgba(59, 130, 246, 0.7);
-  border-right-color: rgba(59, 130, 246, 0.2);
-}
-[data-theme="light"] .thinking-orb-ring-2 {
-  border-bottom-color: rgba(22, 163, 74, 0.5);
-  border-left-color: rgba(22, 163, 74, 0.15);
-}
-[data-theme="light"] .thinking-orb-ring-3 {
-  border-top-color: rgba(126, 34, 206, 0.4);
-}
 
-[data-theme="light"] .thinking-dot {
-  background: #a8a29e;
-}
-[data-theme="light"] .thinking-dot {
-  animation-name: dot-wave-light;
-}
-@keyframes dot-wave-light {
-  0%, 80%, 100% {
-    transform: scale(0.6);
-    opacity: 0.4;
-    background: #a8a29e;
-  }
-  40% {
-    transform: scale(1);
-    opacity: 1;
-    background: #2563eb;
-    box-shadow: 0 0 4px rgba(37, 99, 235, 0.3);
-  }
-}
-
-/* SubAgent nodes */
-[data-theme="light"] .subagent-node-running {
-  background: rgba(37, 99, 235, 0.06);
-  border-left-color: rgba(37, 99, 235, 0.3);
-}
-[data-theme="light"] .subagent-node-pending {
-  border-left-color: rgba(168, 162, 158, 0.4);
-}
+/* ========================================================================== */

--- a/web/src/styles/settings.css
+++ b/web/src/styles/settings.css
@@ -84,9 +84,18 @@
 .settings-content textarea {
   background: var(--bg-base) !important;
   border: 1px solid var(--border) !important;
-  border-radius: var(--radius-sm) !important;
+  border-radius: 10px !important;
   color: var(--text-primary) !important; font-size: 13px !important;
-  outline: none !important; transition: border-color 0.15s !important;
+  padding: 8px 12px !important;
+  outline: none !important; transition: border-color 0.2s, box-shadow 0.2s !important;
+  -webkit-appearance: none !important;
+  appearance: none !important;
+}
+.settings-content select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238e8e93' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E") !important;
+  background-repeat: no-repeat !important;
+  background-position: right 10px center !important;
+  padding-right: 30px !important;
 }
 .settings-content input:focus,
 .settings-content select:focus,
@@ -98,13 +107,15 @@
 .settings-content button[type="submit"],
 .settings-content .btn-primary,
 .settings-content .save-btn {
-  background: var(--accent) !important; color: #fff !important;
+  background: linear-gradient(180deg, #5bb8ff 0%, #0055b3 100%) !important; color: #fff !important;
   border: none !important; border-radius: var(--radius-md) !important;
-  transition: filter 0.15s !important;
+  font-weight: 500 !important; letter-spacing: -0.01em !important;
+  box-shadow: 0 2px 8px rgba(0,85,179,0.25) !important;
+  transition: all 0.2s ease !important;
 }
 .settings-content button[type="submit"]:hover,
 .settings-content .btn-primary:hover,
-.settings-content .save-btn:hover { filter: brightness(1.1) !important; }
+.settings-content .save-btn:hover { box-shadow: 0 4px 16px rgba(0,85,179,0.35) !important; transform: translateY(-1px) !important; }
 
 .settings-panel h2, .settings-panel .panel-title {
   font-size: 17px !important; font-weight: 600 !important;

--- a/web/src/styles/settings.css
+++ b/web/src/styles/settings.css
@@ -124,3 +124,120 @@
 }
 
 @media (max-width: 768px) { .settings-panel { width: 100vw !important; } }
+
+/* ═══ Settings Utility Classes — Theme-Aware ═══ */
+.settings-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+.settings-value {
+  font-size: 14px;
+  color: var(--text-primary);
+}
+.settings-value-mono {
+  font-size: 14px;
+  color: var(--text-secondary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  word-break: break-all;
+}
+.settings-muted {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.settings-loading {
+  text-align: center;
+  padding: 24px 0;
+  color: var(--text-tertiary);
+  font-size: 14px;
+}
+.settings-error {
+  font-size: 12px;
+  color: var(--xbot-color-error, #dc2626);
+  margin-top: 4px;
+  margin-bottom: 8px;
+}
+.settings-divider {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.settings-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.settings-action-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+}
+.settings-action-danger {
+  color: var(--xbot-color-error, #dc2626);
+  border-color: rgba(220, 38, 38, 0.3);
+}
+.settings-action-danger:hover {
+  background: rgba(220, 38, 38, 0.1);
+  border-color: var(--xbot-color-error, #dc2626);
+}
+.settings-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 500;
+}
+.settings-badge-active {
+  background: rgba(34, 197, 94, 0.15);
+  color: #16a34a;
+}
+.settings-badge-inactive {
+  background: var(--bg-base);
+  color: var(--text-tertiary);
+}
+[data-theme="light"] .settings-badge-active {
+  background: rgba(34, 197, 94, 0.12);
+  color: #15803d;
+}
+.settings-session-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 10px;
+  background: var(--bg-base);
+  margin-bottom: 12px;
+}
+.settings-session-item {
+  padding: 12px;
+  border-radius: 10px;
+  background: var(--bg-base);
+  border-left: 3px solid var(--accent);
+  margin-right: 16px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.settings-session-item:hover {
+  background: var(--bg-hover);
+}
+.settings-list-item {
+  padding: 12px;
+  border-radius: 10px;
+  background: var(--bg-base);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.settings-list-item:hover {
+  background: var(--bg-hover);
+}

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -295,3 +295,73 @@
 }
 [data-theme="light"] .onboarding-step-title { color: #1d1d1f !important; }
 [data-theme="light"] .onboarding-step-desc { color: #86868b !important; }
+
+/* ═══ EMPTY STATE — Premium 10/10 ═══ */
+.empty-state-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-top: 10vh;
+}
+.empty-state-icon-wrapper {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  margin-bottom: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.empty-state-icon-bg {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 40%, rgba(0,122,255,0.12) 0%, rgba(0,122,255,0.04) 50%, transparent 70%);
+  animation: empty-icon-breathe 4s ease-in-out infinite;
+}
+.empty-state-icon {
+  position: relative;
+  font-size: 56px;
+  line-height: 1;
+  opacity: 0.7;
+  z-index: 1;
+  filter: drop-shadow(0 0 12px rgba(0,122,255,0.3));
+}
+.empty-state-action-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 14px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border: 0.5px solid var(--border);
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+}
+.empty-state-action-btn:hover {
+  background: var(--bg-tertiary, var(--bg-secondary));
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(0,122,255,0.12);
+  color: var(--text-primary);
+}
+
+@keyframes empty-icon-breathe {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.08); opacity: 0.8; }
+}
+
+[data-theme="light"] .empty-state-icon-bg {
+  background: radial-gradient(circle at 40% 40%, rgba(0,122,255,0.08) 0%, rgba(0,122,255,0.02) 50%, transparent 70%);
+}
+[data-theme="light"] .empty-state-icon {
+  opacity: 0.45;
+}
+[data-theme="light"] .empty-state-action-btn:hover {
+  box-shadow: 0 2px 12px rgba(0,122,255,0.08);
+}

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -82,7 +82,7 @@
 .input-bar textarea:focus {
   background: rgba(0,0,0,0.4) !important;
   outline: none !important;
-  box-shadow: none !important;
+  box-shadow: 0 0 0 2px rgba(0,122,255,0.3) !important;
 }
 .input-bar textarea::placeholder { color: var(--text-tertiary) !important; }
 
@@ -144,12 +144,13 @@
 .header-bar [class*="bg-red"] { background: rgba(255,69,58,0.15) !important; border: none !important; box-shadow: none !important; }
 
 /* ═══ ONBOARDING ═══ */
-.onboarding-card, .onboarding-overlay {
+/* Only style the card — overlay must keep position:fixed from onboarding.css */
+.onboarding-card {
   background: #1c1c1e !important;
   border: none !important;
   border-radius: var(--radius-xl) !important;
   box-shadow: 0 20px 60px rgba(0,0,0,0.5) !important;
-  position: relative; overflow: hidden;
+  overflow: hidden;
 }
 .onboarding-card::before { display: none !important; }
 
@@ -202,6 +203,7 @@
 }
 [data-theme="light"] .input-bar textarea:focus {
   background: rgba(0,0,0,0.06) !important;
+  box-shadow: 0 0 0 2px rgba(0,122,255,0.2) !important;
 }
 [data-theme="light"] .user-msg {
   background: #007AFF !important;
@@ -248,9 +250,8 @@
 /* Scrollbar */
 [data-theme="light"] ::-webkit-scrollbar-thumb { background: rgba(0,0,0,0.12) !important; }
 [data-theme="light"] ::-webkit-scrollbar-thumb:hover { background: rgba(0,0,0,0.2) !important; }
-/* Onboarding — override the !important dark bg from theme.css */
-[data-theme="light"] .onboarding-card,
-[data-theme="light"] .onboarding-overlay {
+/* Onboarding — only style the card, keep overlay fixed */
+[data-theme="light"] .onboarding-card {
   background: rgba(255,255,255,0.95) !important;
   border-color: rgba(0,0,0,0.08) !important;
   box-shadow: 0 20px 60px rgba(0,0,0,0.1) !important;

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -86,57 +86,74 @@
 }
 .input-bar textarea::placeholder { color: var(--text-tertiary) !important; }
 
-/* ═══ SEND BUTTON — Clean circle, no glow ═══ */
+/* ═══ SEND BUTTON — Apple blue circle with depth ═══ */
 .input-bar button[type="submit"],
 .input-bar .send-btn {
-  background: #007AFF !important;
+  background: linear-gradient(180deg, #339dff 0%, #0066d6 100%) !important;
   border: none !important;
   color: #fff !important;
   width: 30px !important;
   height: 30px !important;
   border-radius: 50% !important;
-  box-shadow: none !important;
-  transition: opacity 0.15s !important;
+  box-shadow: 0 1px 3px rgba(0,102,214,0.35) !important;
+  transition: all 0.2s ease !important;
   animation: none !important;
 }
 .input-bar button[type="submit"]:hover,
-.input-bar .send-btn:hover { opacity: 0.85 !important; transform: none !important; animation: none !important; }
+.input-bar .send-btn:hover { 
+  box-shadow: 0 2px 8px rgba(0,102,214,0.45) !important;
+  transform: scale(1.05) !important;
+  animation: none !important; 
+}
 .input-bar button[type="submit"]:active,
-.input-bar .send-btn:active { opacity: 0.7 !important; }
+.input-bar .send-btn:active { opacity: 0.8 !important; transform: scale(0.95) !important; }
 .input-bar button[type="submit"]:disabled,
 .input-bar .send-btn:disabled { opacity: 0.3 !important; background: #6e6e73 !important; animation: none !important; }
 
 /* ═══ LOGIN PAGE ═══ */
 .login-container { background: #000 !important; }
 .login-card {
-  background: #1c1c1e !important;
-  border: none !important;
+  background: rgba(28,28,30,0.92) !important;
+  border: 0.5px solid rgba(255,255,255,0.1) !important;
   border-radius: var(--radius-xl) !important;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.5) !important;
+  box-shadow:
+    0 0 0 0.5px rgba(255,255,255,0.05),
+    0 8px 32px rgba(0,0,0,0.3),
+    0 32px 64px rgba(0,0,0,0.2) !important;
+  backdrop-filter: blur(40px) saturate(180%) !important;
+  -webkit-backdrop-filter: blur(40px) saturate(180%) !important;
   position: relative; overflow: hidden;
 }
 .login-card::before { display: none !important; }
-.login-card h1 { color: var(--text-primary) !important; -webkit-text-fill-color: unset !important; background: none !important; font-weight: 600 !important; }
+.login-card h1 { color: var(--text-primary) !important; -webkit-text-fill-color: unset !important; background: none !important; font-weight: 600 !important; letter-spacing: -0.02em !important; }
 .login-card input {
-  background: rgba(0,0,0,0.3) !important;
-  border: 0.5px solid rgba(255,255,255,0.1) !important;
+  background: rgba(0,0,0,0.35) !important;
+  border: 1px solid rgba(255,255,255,0.08) !important;
   color: var(--text-primary) !important;
-  border-radius: var(--radius-sm) !important;
+  border-radius: 12px !important;
+  transition: border-color 0.25s ease, background 0.2s ease, box-shadow 0.25s ease !important;
 }
 .login-card input:focus {
-  border-color: #007AFF !important;
-  box-shadow: none !important;
+  border-color: rgba(0,122,255,0.6) !important;
+  box-shadow: 0 0 0 3.5px rgba(0,122,255,0.12) !important;
+  outline: none !important;
 }
 .login-card button[type="submit"],
 .login-card .login-btn {
-  background: #007AFF !important;
+  background: linear-gradient(180deg, #339dff 0%, #0066d6 100%) !important;
   color: #fff !important;
-  box-shadow: none !important;
-  border-radius: var(--radius-sm) !important;
-  font-weight: 500 !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2), 0 4px 16px rgba(0,102,214,0.3) !important;
+  border-radius: 12px !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.01em !important;
+  transition: all 0.2s ease !important;
 }
 .login-card button[type="submit"]:hover,
-.login-card .login-btn:hover { opacity: 0.9 !important; filter: none !important; }
+.login-card .login-btn:hover { 
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2), 0 8px 24px rgba(0,102,214,0.4) !important;
+}
+.login-card button[type="submit"]:active,
+.login-card .login-btn:active { transform: scale(0.98) !important; }
 
 /* ═══ STATUS BADGES ═══ */
 .header-bar [class*="bg-green"] { background: rgba(48,209,88,0.15) !important; border: none !important; box-shadow: none !important; }
@@ -146,10 +163,15 @@
 /* ═══ ONBOARDING ═══ */
 /* Only style the card — overlay must keep position:fixed from onboarding.css */
 .onboarding-card {
-  background: #1c1c1e !important;
-  border: none !important;
+  background: rgba(28,28,30,0.95) !important;
+  border: 0.5px solid rgba(255,255,255,0.1) !important;
   border-radius: var(--radius-xl) !important;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.5) !important;
+  box-shadow:
+    0 0 0 0.5px rgba(255,255,255,0.06),
+    0 8px 32px rgba(0,0,0,0.4),
+    0 32px 64px rgba(0,0,0,0.3) !important;
+  backdrop-filter: blur(40px) saturate(180%) !important;
+  -webkit-backdrop-filter: blur(40px) saturate(180%) !important;
   overflow: hidden;
 }
 .onboarding-card::before { display: none !important; }
@@ -220,15 +242,25 @@
   border-color: rgba(0,0,0,0.06) !important;
 }
 /* Login */
-[data-theme="light"] .login-container { background: #f5f5f7 !important; }
+[data-theme="light"] .login-container { background: linear-gradient(135deg, #dfe6f0 0%, #f2f2f7 50%, #e8e8f0 100%) !important; }
 [data-theme="light"] .login-card {
-  background: #ffffff !important;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.1) !important;
+  background: rgba(255,255,255,0.82) !important;
+  border: 0.5px solid rgba(0,0,0,0.06) !important;
+  box-shadow:
+    0 0 0 0.5px rgba(0,0,0,0.03),
+    0 8px 32px rgba(0,0,0,0.06),
+    0 32px 64px rgba(0,0,0,0.04) !important;
+  backdrop-filter: blur(40px) saturate(180%) !important;
+  -webkit-backdrop-filter: blur(40px) saturate(180%) !important;
 }
 [data-theme="light"] .login-card input {
   background: rgba(0,0,0,0.03) !important;
   border-color: rgba(0,0,0,0.1) !important;
   color: var(--text-primary) !important;
+}
+[data-theme="light"] .login-card button[type="submit"] {
+  background: linear-gradient(180deg, #339dff 0%, #0066d6 100%) !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1), 0 4px 16px rgba(0,102,214,0.25) !important;
 }
 /* Status badges */
 [data-theme="light"] .header-bar [class*="bg-green"] { background: rgba(48,209,88,0.12) !important; }
@@ -252,9 +284,14 @@
 [data-theme="light"] ::-webkit-scrollbar-thumb:hover { background: rgba(0,0,0,0.2) !important; }
 /* Onboarding — only style the card, keep overlay fixed */
 [data-theme="light"] .onboarding-card {
-  background: rgba(255,255,255,0.95) !important;
-  border-color: rgba(0,0,0,0.08) !important;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.1) !important;
+  background: rgba(255,255,255,0.85) !important;
+  border: 0.5px solid rgba(0,0,0,0.08) !important;
+  box-shadow:
+    0 0 0 0.5px rgba(0,0,0,0.03),
+    0 8px 32px rgba(0,0,0,0.06),
+    0 32px 64px rgba(0,0,0,0.04) !important;
+  backdrop-filter: blur(40px) saturate(180%) !important;
+  -webkit-backdrop-filter: blur(40px) saturate(180%) !important;
 }
 [data-theme="light"] .onboarding-step-title { color: #1d1d1f !important; }
 [data-theme="light"] .onboarding-step-desc { color: #86868b !important; }


### PR DESCRIPTION
## Summary

Add a pre-processing pipeline that converts LaTeX math expressions (`$...$` and `$$...$$`) in assistant messages to Unicode/plain-text representations for terminal display. Follows the same pattern as the existing mermaid diagram renderer.

## Changes

### `channel/math.go` — LaTeX → Unicode renderer (new file)
- **Block math** (`$$...$$`): rendered as code blocks with Unicode math symbols
- **Inline math** (`$...$`): rendered inline with Unicode symbols
- **Greek letters**: α β γ δ ε ζ η θ λ μ π σ φ ψ ω (both cases, uppercase/lowercase)
- **Operators**: ∑ ∏ ∫ ∂ ∇ ∞ ± × ÷ · ≈ ≠ ≤ ≥ ∈ ∉ ⊂ ⊃ ∪ ∩ ∅ ∀ ∃ ¬ → ⇒ etc.
- **Superscripts/subscripts**: x² v₀ aᵢⱼ via Unicode (digits, +, -, =, letters)
- **Fractions**: `\frac{a}{b}` → `a/b`
- **Square roots**: `\sqrt{x}` → `√x`, `\sqrt[3]{x}` → `3√x`
- **Currency detection**: `$10 and $20` are NOT treated as math (heuristic: content must contain `\`, `^`, `_`, or `{}`)
- **Width-aware truncation**: long formulas truncated to terminal width

### `channel/math_test.go` — 19 test cases
- Greek letters, operators, arrows, fractions, roots, superscripts, subscripts
- Complex expressions (Einstein, quadratic formula, Euler identity)
- Edge cases: empty blocks, no-match currency, mixed content

### `channel/cli_message.go` — Pipeline integration
- Added `renderMathBlocks()` call after `renderMermaidBlocks()` in the assistant message rendering path

## Design Rationale

**Pre-processing approach** (like mermaid): The renderer converts LaTeX to Unicode *before* Glamour processes the markdown. This avoids modifying Glamour internals and requires zero new dependencies.

**Longest-first replacement**: Operator map is sorted by key length descending to prevent `\int` from matching `\in` first (a real bug caught in testing).

## Test Plan
- [x] `go test ./channel/` — 19 new tests, all pass
- [x] `go build ./...` — compiles clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] Pre-commit hooks pass (gofmt → lint → build → test)

## Rendering Examples

| LaTeX Input | Terminal Output |
|---|---|
| `E = mc^{2}` | `E = mc²` |
| `\frac{-b \pm \sqrt{b^2-4ac}}{2a}` | `-b ± √b²-4ac/2a` |
| `\sum_{i=1}^{n} i = \frac{n(n+1)}{2}` | `∑ᵢ₌₁ⁿ i = n(n+1)/2` |
| `\int_0^1 f(x) dx` | `∫₀¹ f(x) dx` |
| `\alpha + \beta = \gamma` | `α + β = γ` |
| `\forall x \in \mathbb{R}` | `∀x ∈ R` |