### PR TITLE
fix(compress): token count bloat after compression (117k→259k)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@
 - PowerShell env output is newline-delimited, not null-delimited.
 
 ### Worktree
-- **Primary registration must NOT check dirty tree.** `WorktreeTool.init` and `AutoDetectAndInit` both skip dirty check when registering as primary (first agent in repo). Only worktree creation requires `git worktree add` which now uses `--detach HEAD` (works on dirty trees too).
+- **`RegisterPeer` always uses role="peer" — no primary concept.** Every session is an equal peer for awareness purposes. `WorktreeTool.init` and `AutoDetectAndInit` both create physical worktrees for each session. Only worktree creation requires `git worktree add` which uses `--detach HEAD` (works on dirty trees too).
 - **`createWorktree` uses `--detach` not `-b`.** `git worktree add --detach HEAD` followed by `checkout -b` in the worktree. This avoids dirty-tree failures that `-b` would trigger.
 - **AutoDetectAndInit runs in `buildPrompt` (not `processMessage`).** `buildPrompt` is the common code path for ALL message types. Session CWD is updated before system prompt construction.
 - **`IsWorktreeIsolated` overrides `isUnrestricted()`.** CLI mode (`sandbox="none"`) normally bypasses all path checks, but when `IsWorktreeIsolated=true`, `isUnrestricted()` returns `false`.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -196,6 +196,24 @@ func (a *Agent) IndexGlobalTools() {
 	log.WithField("count", len(toolEntries)).Infof("Indexed %d global tools (registry + tool groups + MCP)", len(toolEntries))
 }
 
+// bgSessionState tracks per-session state for bg notification delivery.
+// Registered in bgSessionStates when a chatWorker starts, deregistered on exit.
+//
+// Architecture:
+//   - bgNotifyLoop ALWAYS buffers to bgRunPending, NEVER processes directly.
+//   - After buffering, it signals the session's notifyCh.
+//   - chatProcessLoop drains pending notifications after each turn completes
+//     (after response is sent), guaranteeing injectCLIUserMessage won't race
+//     with the turn's reply on asyncCh.
+//   - chatWorker drains pending notifications when idle (chatProcessLoop is
+//     waiting on msgCh), checked via busy flag to avoid racing with response sends.
+//   - During active Run, wireBgNotificationDrain picks up notifications between
+//     iterations as tool results.
+type bgSessionState struct {
+	notifyCh chan struct{} // buffered(1): signal that bgRunPending has new items
+	busy     atomic.Bool   // true while chatProcessLoop is processing a turn
+}
+
 // Agent 核心 Agent 引擎
 type Agent struct {
 	bus              *bus.MessageBus
@@ -336,17 +354,15 @@ type Agent struct {
 	pluginMgr *plugin.PluginManager
 	bgTaskMgr *tools.BackgroundTaskManager
 
-	// bgRunActive is an atomic reference count of active Run() calls across all sessions.
-	// Each processMessage increments on entry (AddInt32 +1) and decrements on exit (AddInt32 -1).
-	// bgNotifyLoop checks > 0 to decide routing: buffer (active) vs idle-path.
-	// Using a counter instead of a boolean prevents Session A's exit from clearing the flag
-	// while Session B's Run is still active.
-	bgRunActive int32
-
 	// bgRunPending buffers bg notifications that arrived during an active Run.
 	// The Run loop drains these between iterations.
 	bgRunPending   []tools.BgNotification
 	bgRunPendingMu sync.Mutex
+
+	// bgSessionStates maps chatKey → *bgSessionState for per-session notification signaling.
+	// bgNotifyLoop always buffers notifications, then signals the session's state channel.
+	// chatWorker registers on entry and deregisters on exit.
+	bgSessionStates sync.Map
 
 	// agentCtx is the Agent-level context, set when Run() starts and cancelled when Run() exits.
 	// Background interactive subagents derive their context from this (not from per-request ctx)
@@ -1683,84 +1699,113 @@ func (a *Agent) getSemaphoreForMessage(msg bus.InboundMessage) chan struct{} {
 // 主循环持续从 ch 取消息并分发：
 //   - 指令消息（/version, /help 等）：独立 goroutine 立即执行，不阻塞
 //   - 普通消息：发送到内部 msgCh，由专门的 goroutine 串行处理（带信号量 + cancel）
+//   - bg通知信号：当chatProcessLoop空闲时，drain并处理pending通知
 //
 // 这样即使普通消息正在长时间处理（LLM 推理），主循环仍能取出并执行命令消息。
 func (a *Agent) chatWorker(ctx context.Context, chatKey string, ch <-chan bus.InboundMessage) {
 	// 内部普通消息队列：主循环写入，processLoop 消费
 	msgCh := make(chan bus.InboundMessage, 32)
 
+	// Register per-session bg notification state
+	ss := &bgSessionState{notifyCh: make(chan struct{}, 1)}
+	a.bgSessionStates.Store(chatKey, ss)
+	defer a.bgSessionStates.Delete(chatKey)
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 	clipanic.Go("agent.chatWorker.processLoop", func() {
 		defer wg.Done()
-		a.chatProcessLoop(ctx, chatKey, msgCh)
+		a.chatProcessLoop(ctx, chatKey, msgCh, ss)
 	})
 
-	for msg := range ch {
-		if ctx.Err() != nil {
-			break
-		}
+	defer func() {
+		close(msgCh)
+		wg.Wait()
+	}()
 
-		// 指令消息分发：根据 Concurrent() 决定执行方式
-		if cmd := a.commands.Match(msg.Content); cmd != nil {
-			if cmd.Concurrent() {
-				// 无状态命令：独立 goroutine 处理，不占信号量，不阻塞
-				m := msg
-				c := cmd
-				clipanic.Go("agent.chatWorker.concurrentCommand", func() {
-					// 清除 sessionFinalSent：command 不走 processMessage，
-					// 需要手动清除否则 sendMessage 会被拦截
-					cmdKey := qualifyChatID(m.Channel, m.ChatID)
-					a.resetSessionState(cmdKey)
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			if ctx.Err() != nil {
+				return
+			}
 
-					response, err := c.Execute(ctx, a, m)
-					if err != nil {
-						log.WithFields(log.Fields{"request_id": m.RequestID, "chat": chatKey}).WithError(err).Error("Error processing command")
-						content := formatErrorForUser(err)
-						if sendErr := a.sendMessage(m.Channel, m.ChatID, content); sendErr != nil {
-							a.bus.Outbound <- bus.OutboundMessage{
-								Channel: m.Channel,
-								ChatID:  m.ChatID,
-								Content: content,
+			// 指令消息分发：根据 Concurrent() 决定执行方式
+			if cmd := a.commands.Match(msg.Content); cmd != nil {
+				if cmd.Concurrent() {
+					// 无状态命令：独立 goroutine 处理，不占信号量，不阻塞
+					m := msg
+					c := cmd
+					clipanic.Go("agent.chatWorker.concurrentCommand", func() {
+						// 清除 sessionFinalSent：command 不走 processMessage，
+						// 需要手动清除否则 sendMessage 会被拦截
+						cmdKey := qualifyChatID(m.Channel, m.ChatID)
+						a.resetSessionState(cmdKey)
+
+						response, err := c.Execute(ctx, a, m)
+						if err != nil {
+							log.WithFields(log.Fields{"request_id": m.RequestID, "chat": chatKey}).WithError(err).Error("Error processing command")
+							content := formatErrorForUser(err)
+							if sendErr := a.sendMessage(m.Channel, m.ChatID, content); sendErr != nil {
+								a.bus.Outbound <- bus.OutboundMessage{
+									Channel: m.Channel,
+									ChatID:  m.ChatID,
+									Content: content,
+								}
+							}
+							return
+						}
+						if response != nil {
+							if sendErr := a.sendMessage(m.Channel, m.ChatID, response.Content, response.Metadata); sendErr != nil {
+								a.bus.Outbound <- bus.OutboundMessage{
+									Channel: response.Channel,
+									ChatID:  response.ChatID,
+									Content: response.Content,
+									Media:   response.Media,
+								}
 							}
 						}
+					})
+				} else {
+					// 有状态命令（/new, /compress, /set-llm 等）：走串行队列，
+					// 避免与正在处理的普通消息产生 session 数据竞态
+					select {
+					case msgCh <- msg:
+					case <-ctx.Done():
 						return
 					}
-					if response != nil {
-						if sendErr := a.sendMessage(m.Channel, m.ChatID, response.Content, response.Metadata); sendErr != nil {
-							a.bus.Outbound <- bus.OutboundMessage{
-								Channel: response.Channel,
-								ChatID:  response.ChatID,
-								Content: response.Content,
-								Media:   response.Media,
-							}
-						}
-					}
-				})
-			} else {
-				// 有状态命令（/new, /compress, /set-llm 等）：走串行队列，
-				// 避免与正在处理的普通消息产生 session 数据竞态
-				select {
-				case msgCh <- msg:
-				case <-ctx.Done():
 				}
+				continue
 			}
-			continue
-		}
 
-		// 普通消息：转发到内部队列，由 processLoop 串行处理
-		select {
-		case msgCh <- msg:
+			// 普通消息：转发到内部队列，由 processLoop 串行处理
+			select {
+			case msgCh <- msg:
+			case <-ctx.Done():
+				return
+			}
+
+		case <-ss.notifyCh:
+			// bg notification arrived — drain and process ONLY when chatProcessLoop is idle.
+			// When busy, notifications stay in bgRunPending for chatProcessLoop's
+			// post-turn drain to pick up (guaranteed after response is sent).
+			if !ss.busy.Load() {
+				a.drainAndProcessNotifications(chatKey)
+			}
+
 		case <-ctx.Done():
+			return
 		}
 	}
-
-	close(msgCh)
-	wg.Wait()
 }
 
 // chatProcessLoop 串行处理普通消息（非命令），带信号量控制和 per-request cancel 支持。
-func (a *Agent) chatProcessLoop(ctx context.Context, chatKey string, ch <-chan bus.InboundMessage) {
+// After each turn completes (response sent), drains pending bg notifications
+// at a safe point where injectCLIUserMessage cannot race with the turn's reply.
+func (a *Agent) chatProcessLoop(ctx context.Context, chatKey string, ch <-chan bus.InboundMessage, ss *bgSessionState) {
 	var idleTimer *time.Timer
 	defer func() {
 		if idleTimer != nil {
@@ -1774,6 +1819,9 @@ func (a *Agent) chatProcessLoop(ctx context.Context, chatKey string, ch <-chan b
 		if ctx.Err() != nil {
 			return
 		}
+
+		// Mark session busy so chatWorker skips notification drain
+		ss.busy.Store(true)
 
 		// 停止上一次的 idle timer（收到新消息，重置计时）
 		if idleTimer != nil {
@@ -1790,6 +1838,7 @@ func (a *Agent) chatProcessLoop(ctx context.Context, chatKey string, ch <-chan b
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
+			ss.busy.Store(false)
 			return
 		}
 
@@ -1880,6 +1929,9 @@ func (a *Agent) chatProcessLoop(ctx context.Context, chatKey string, ch <-chan b
 				// message to signal turn end so CLI can clean up typing/progress state.
 				_ = a.sendMessage(msg.Channel, msg.ChatID, "", cancelMeta)
 			}
+			// Turn done — response sent, safe to drain bg notifications
+			ss.busy.Store(false)
+			a.drainAndProcessNotifications(chatKey)
 			continue
 		}
 
@@ -1895,6 +1947,9 @@ func (a *Agent) chatProcessLoop(ctx context.Context, chatKey string, ch <-chan b
 					Content: content,
 				}
 			}
+			// Turn done — error response sent, safe to drain bg notifications
+			ss.busy.Store(false)
+			a.drainAndProcessNotifications(chatKey)
 			continue
 		}
 		if response != nil {
@@ -1939,6 +1994,13 @@ func (a *Agent) chatProcessLoop(ctx context.Context, chatKey string, ch <-chan b
 				})
 			}
 		}
+
+		// Turn done — response sent, safe to drain bg notifications.
+		// This is the CRITICAL ordering: all response sends happen BEFORE this point,
+		// so injectCLIUserMessage in drainAndProcessNotifications cannot race with
+		// the turn's reply on asyncCh.
+		ss.busy.Store(false)
+		a.drainAndProcessNotifications(chatKey)
 	}
 }
 
@@ -2114,11 +2176,6 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*ch
 			}
 		}
 	}
-	// Mark Run as active so bgNotifyLoop buffers notifications instead of processing idle.
-	// Uses AddInt32 (reference count) instead of StoreInt32 (boolean) so that
-	// multiple concurrent sessions don't clear each other's active flag.
-	atomic.AddInt32(&a.bgRunActive, 1)
-
 	// Inject running background task IDs into the last user message so the LLM
 	// is aware of active tasks and doesn't try to restart them.
 	// injectSystemNotes modifies the messages slice in-place (appends to last user message),
@@ -2163,22 +2220,11 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*ch
 
 	out := Run(ctx, cfg)
 
-	// Drain THIS session's remaining bg notifications synchronously.
-	// Must happen before decrementing bgRunActive so that bgNotifyLoop
-	// continues buffering new arrivals. Only drain our own session's
-	// notifications — other sessions' notifications must stay in bgRunPending
-	// for their own Run loops to pick up.
-	a.drainSessionBgNotifications(currentSessionKey)
-
-	// Decrement the reference count. If other sessions still have active Runs,
-	// bgRunActive remains > 0 and bgNotifyLoop keeps buffering for them.
-	atomic.AddInt32(&a.bgRunActive, -1)
-
-	// Drain any notifications that arrived between the first drain and the
-	// decrement (only our session's — others' are still in bgRunPending for
-	// their Run loops). These go through the idle path since our Run is done.
-	a.drainSessionBgNotifications(currentSessionKey)
-
+	// No bgRunActive management or notification draining here.
+	// bgNotifyLoop always buffers (never processes directly).
+	// Remaining notifications in bgRunPending are drained by
+	// chatProcessLoop's post-turn drain (after response is sent),
+	// or by chatWorker's idle notification handler.
 	if out.Error != nil {
 		if errors.Is(out.Error, context.Canceled) {
 			return a.handleCancelledRun(ctx, msg, out, tenantSession)
@@ -2638,23 +2684,28 @@ func (a *Agent) injectEventMessage(msg event.Message) {
 }
 
 // bgNotifyLoop routes background notifications from BgTaskManager.NotifyCh.
-// When any Run is active (bgRunActive > 0), notifications are buffered in bgRunPending
-// for the Run loop to drain between iterations. When idle (bgRunActive == 0),
-// notifications go directly to the appropriate handler based on type.
+// ALL notifications are buffered into bgRunPending. The function NEVER processes
+// them directly — this eliminates the race between injectCLIUserMessage and the
+// agent's reply on asyncCh.
+//
+// After buffering, the target session's notifyCh is signaled. The session's
+// chatWorker or chatProcessLoop picks up the signal and drains notifications
+// at a safe point (after the turn's reply is sent, or when idle).
 func (a *Agent) bgNotifyLoop() {
 	for notif := range a.bgTaskMgr.NotifyCh {
-		if v := atomic.LoadInt32(&a.bgRunActive); v > 0 {
-			// Run is active — buffer for Run loop to drain
-			a.bgRunPendingMu.Lock()
-			a.bgRunPending = append(a.bgRunPending, notif)
-			a.bgRunPendingMu.Unlock()
-		} else {
-			// Idle — process directly based on notification type
-			switch n := notif.(type) {
-			case *tools.BackgroundTask:
-				go a.processBgNotification(n)
-			case *tools.SubAgentBgNotify:
-				go a.processSubAgentBgNotification(n)
+		// Always buffer — never process directly
+		a.bgRunPendingMu.Lock()
+		a.bgRunPending = append(a.bgRunPending, notif)
+		a.bgRunPendingMu.Unlock()
+
+		// Signal the target session's chatWorker
+		sessionKey := notif.SessionKey()
+		if state, ok := a.bgSessionStates.Load(sessionKey); ok {
+			ss := state.(*bgSessionState)
+			select {
+			case ss.notifyCh <- struct{}{}:
+			default:
+				// Already signaled — notification will be drained with others
 			}
 		}
 	}

--- a/agent/agent_process.go
+++ b/agent/agent_process.go
@@ -109,12 +109,11 @@ func (a *Agent) wireBgNotificationDrain(sessionKey string) func() []tools.BgNoti
 	}
 }
 
-// drainSessionBgNotifications drains bg notifications matching the given session key
-// and processes them synchronously. Other sessions' notifications are left in
-// bgRunPending for their own Run loops to pick up via wireBgNotificationDrain.
-// Processing synchronously ensures notifications are injected into bus.Inbound
-// before processMessage returns, allowing chatProcessLoop to pick them up immediately.
-func (a *Agent) drainSessionBgNotifications(sessionKey string) {
+// drainAndProcessNotifications drains bg notifications for the given session
+// from bgRunPending and processes them via processBgNotification/processSubAgentBgNotification.
+// Called by chatProcessLoop after each turn completes (response sent), and by
+// chatWorker when idle. Safe for concurrent use — bgRunPendingMu serializes access.
+func (a *Agent) drainAndProcessNotifications(sessionKey string) {
 	a.bgRunPendingMu.Lock()
 	pending := a.bgRunPending
 	a.bgRunPending = nil

--- a/agent/bg_notify_test.go
+++ b/agent/bg_notify_test.go
@@ -2,7 +2,8 @@ package agent
 
 import (
 	"context"
-	"sync/atomic"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,10 +44,10 @@ func TestInjectInbound_IsCronFalse(t *testing.T) {
 	}
 }
 
-// TestDrainSessionBgNotifications_Synchronous verifies that
-// drainSessionBgNotifications processes notifications synchronously and
+// TestDrainAndProcessNotifications_Synchronous verifies that
+// drainAndProcessNotifications processes notifications synchronously and
 // only drains notifications matching the given session key.
-func TestDrainSessionBgNotifications_Synchronous(t *testing.T) {
+func TestDrainAndProcessNotifications_Synchronous(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -73,7 +74,7 @@ func TestDrainSessionBgNotifications_Synchronous(t *testing.T) {
 	a.bgRunPending = append(a.bgRunPending, notif)
 	a.bgRunPendingMu.Unlock()
 
-	a.drainSessionBgNotifications("cli:test-chat")
+	a.drainAndProcessNotifications("cli:test-chat")
 
 	select {
 	case msg := <-a.bus.Inbound:
@@ -84,7 +85,7 @@ func TestDrainSessionBgNotifications_Synchronous(t *testing.T) {
 			t.Errorf("Channel = %q, want %q", msg.Channel, "cli")
 		}
 	default:
-		t.Fatal("drainSessionBgNotifications should have synchronously injected notification into bus.Inbound")
+		t.Fatal("drainAndProcessNotifications should have synchronously injected notification into bus.Inbound")
 	}
 
 	a.bgRunPendingMu.Lock()
@@ -95,10 +96,10 @@ func TestDrainSessionBgNotifications_Synchronous(t *testing.T) {
 	}
 }
 
-// TestDrainSessionBgNotifications_CrossSessionIsolation verifies that
-// drainSessionBgNotifications only drains notifications matching the
+// TestDrainAndProcessNotifications_CrossSessionIsolation verifies that
+// drainAndProcessNotifications only drains notifications matching the
 // given session key, leaving other sessions' notifications in bgRunPending.
-func TestDrainSessionBgNotifications_CrossSessionIsolation(t *testing.T) {
+func TestDrainAndProcessNotifications_CrossSessionIsolation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -136,7 +137,7 @@ func TestDrainSessionBgNotifications_CrossSessionIsolation(t *testing.T) {
 	a.bgRunPendingMu.Unlock()
 
 	// Drain only chat-a's notifications
-	a.drainSessionBgNotifications("cli:chat-a")
+	a.drainAndProcessNotifications("cli:chat-a")
 
 	// Should find chat-a's notification in bus.Inbound
 	found := false
@@ -147,7 +148,6 @@ func TestDrainSessionBgNotifications_CrossSessionIsolation(t *testing.T) {
 			if msg.ChatID == "chat-a" {
 				found = true
 			}
-			// Ignore other messages
 		case <-timeout:
 			t.Fatal("chat-a's notification should be in bus.Inbound")
 		}
@@ -165,46 +165,15 @@ func TestDrainSessionBgNotifications_CrossSessionIsolation(t *testing.T) {
 	}
 }
 
-// TestBgRunActive_ReferenceCount verifies that bgRunActive works as a
-// reference counter: multiple concurrent sessions can increment/decrement
-// without clearing each other's active state.
-func TestBgRunActive_ReferenceCount(t *testing.T) {
-	a := &Agent{}
+// ==================== Regression: asyncCh race on bg notification ====================
 
-	// Initial state: 0
-	if v := atomic.LoadInt32(&a.bgRunActive); v != 0 {
-		t.Fatalf("initial bgRunActive = %d, want 0", v)
-	}
-
-	// Session A starts Run
-	atomic.AddInt32(&a.bgRunActive, 1)
-	if v := atomic.LoadInt32(&a.bgRunActive); v != 1 {
-		t.Fatalf("after session A start: bgRunActive = %d, want 1", v)
-	}
-
-	// Session B starts Run (concurrent)
-	atomic.AddInt32(&a.bgRunActive, 1)
-	if v := atomic.LoadInt32(&a.bgRunActive); v != 2 {
-		t.Fatalf("after session B start: bgRunActive = %d, want 2", v)
-	}
-
-	// Session A's Run finishes — should NOT clear to 0
-	atomic.AddInt32(&a.bgRunActive, -1)
-	if v := atomic.LoadInt32(&a.bgRunActive); v != 1 {
-		t.Fatalf("after session A end: bgRunActive = %d, want 1 (session B still active)", v)
-	}
-
-	// Session B's Run finishes
-	atomic.AddInt32(&a.bgRunActive, -1)
-	if v := atomic.LoadInt32(&a.bgRunActive); v != 0 {
-		t.Fatalf("after session B end: bgRunActive = %d, want 0", v)
-	}
-}
-
-// TestBgRunActive_RouteAfterPartialExit simulates the exact race condition:
-// Session A exits while Session B is still active. Notifications for Session B
-// should still be buffered (not routed through idle path).
-func TestBgRunActive_RouteAfterPartialExit(t *testing.T) {
+// TestBgNotifyLoop_AlwaysBuffers_NoIdlePath is the core regression test for the
+// bug where bgNotifyLoop's idle path used `go processBgNotification(n)`, causing
+// injectCLIUserMessage to race with the agent's reply on asyncCh.
+//
+// With the new architecture, bgNotifyLoop ALWAYS buffers to bgRunPending and
+// NEVER processes directly. This test verifies that invariant.
+func TestBgNotifyLoop_AlwaysBuffers_NoIdlePath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -215,53 +184,371 @@ func TestBgRunActive_RouteAfterPartialExit(t *testing.T) {
 		bgTaskMgr: mgr,
 	}
 
-	// Both sessions active
-	atomic.AddInt32(&a.bgRunActive, 1) // Session A
-	atomic.AddInt32(&a.bgRunActive, 1) // Session B
+	chatKey := "cli:test-chat"
 
-	// Session A exits — decrement only
-	atomic.AddInt32(&a.bgRunActive, -1)
+	// Register a bgSessionState (as chatWorker would)
+	ss := &bgSessionState{notifyCh: make(chan struct{}, 1)}
+	a.bgSessionStates.Store(chatKey, ss)
+	defer a.bgSessionStates.Delete(chatKey)
 
-	// Now bgRunActive should be 1 (Session B still active)
-	if v := atomic.LoadInt32(&a.bgRunActive); v != 1 {
-		t.Fatalf("bgRunActive = %d after session A exit, want 1", v)
-	}
+	// Start bgNotifyLoop
+	go a.bgNotifyLoop()
 
-	// Start a task for Session B — notification should still be buffered
-	// because bgRunActive > 0
-	_ = mgr.Start("cli:chat-b", "user-1", "task-b", func(ctx context.Context, outputBuf func(string)) (int, error) {
-		outputBuf("b-done")
+	// Start a bg task — it will complete immediately
+	_ = mgr.Start(chatKey, "user-1", "echo test", func(ctx context.Context, outputBuf func(string)) (int, error) {
+		outputBuf("test output")
 		return 0, nil
 	})
 
-	// Read notification directly from NotifyCh (simulating what bgNotifyLoop would do)
+	// Wait for the notification to be signaled
 	select {
-	case notif := <-mgr.NotifyCh:
-		// bgNotifyLoop would check bgRunActive > 0 → buffer
-		// We simulate that here:
-		if v := atomic.LoadInt32(&a.bgRunActive); v > 0 {
-			a.bgRunPendingMu.Lock()
-			a.bgRunPending = append(a.bgRunPending, notif)
-			a.bgRunPendingMu.Unlock()
-		} else {
-			t.Fatal("bgRunActive should be > 0 but is 0 — notification would be misrouted to idle path!")
-		}
+	case <-ss.notifyCh:
+		// Got signal — bgNotifyLoop buffered and signaled
 	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for notification")
+		t.Fatal("timed out waiting for notification signal — bgNotifyLoop didn't buffer")
 	}
 
-	// Verify the notification is buffered and can be drained by Session B
-	a.drainSessionBgNotifications("cli:chat-b")
+	// Verify notification is in bgRunPending (not processed directly)
+	a.bgRunPendingMu.Lock()
+	pending := a.bgRunPending
+	a.bgRunPendingMu.Unlock()
 
+	if len(pending) == 0 {
+		t.Fatal("bgRunPending should have the notification — bgNotifyLoop must ALWAYS buffer, never process directly")
+	}
+
+	// Nothing should have been sent to bus.Inbound (no direct processing)
 	select {
-	case msg := <-a.bus.Inbound:
-		if msg.ChatID != "chat-b" {
-			t.Errorf("ChatID = %q, want %q", msg.ChatID, "chat-b")
-		}
+	case <-a.bus.Inbound:
+		t.Fatal("bgNotifyLoop should NOT have sent anything to bus.Inbound — idle path removed")
 	default:
-		t.Fatal("Session B's notification should have been drained synchronously")
+		// Correct — nothing was injected directly
 	}
 
-	// Cleanup
-	atomic.AddInt32(&a.bgRunActive, -1)
+	t.Logf("SUCCESS: bgNotifyLoop buffered %d notifications without processing", len(pending))
+}
+
+// TestBgSessionState_BusyFlag_GuardsIdleDrain verifies that chatWorker's
+// notification handler checks the busy flag and skips draining when
+// chatProcessLoop is active.
+func TestBgSessionState_BusyFlag_GuardsIdleDrain(t *testing.T) {
+	ss := &bgSessionState{notifyCh: make(chan struct{}, 1)}
+
+	// Initially not busy
+	if ss.busy.Load() {
+		t.Fatal("initial busy should be false")
+	}
+
+	// Mark busy (as chatProcessLoop would before processMessage)
+	ss.busy.Store(true)
+
+	// Simulate notification signal arriving while busy
+	ss.notifyCh <- struct{}{}
+
+	// chatWorker should check busy and skip drain
+	if !ss.busy.Load() {
+		t.Fatal("busy should still be true — chatWorker should have skipped drain")
+	}
+
+	// After clearing busy, notification is still pending in notifyCh
+	ss.busy.Store(false)
+
+	// chatWorker can now drain on next signal
+	select {
+	case <-ss.notifyCh:
+		// Signal consumed — chatWorker would drain now
+	default:
+		t.Fatal("notifyCh should still have pending signal after busy cleared")
+	}
+}
+
+// TestBgNotifyLoop_SignalsMultipleSessions verifies that bgNotifyLoop
+// signals the correct session when notifications arrive for different sessions.
+func TestBgNotifyLoop_SignalsMultipleSessions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := tools.NewBackgroundTaskManager()
+	a := &Agent{
+		bus:       bus.NewMessageBus(),
+		agentCtx:  ctx,
+		bgTaskMgr: mgr,
+	}
+
+	// Register two sessions
+	ssA := &bgSessionState{notifyCh: make(chan struct{}, 1)}
+	ssB := &bgSessionState{notifyCh: make(chan struct{}, 1)}
+	a.bgSessionStates.Store("cli:chat-a", ssA)
+	a.bgSessionStates.Store("cli:chat-b", ssB)
+	defer a.bgSessionStates.Delete("cli:chat-a")
+	defer a.bgSessionStates.Delete("cli:chat-b")
+
+	// Start bgNotifyLoop
+	go a.bgNotifyLoop()
+
+	// Start a task for chat-a
+	_ = mgr.Start("cli:chat-a", "user-1", "echo a", func(ctx context.Context, outputBuf func(string)) (int, error) {
+		outputBuf("a")
+		return 0, nil
+	})
+
+	// Wait for chat-a's signal
+	select {
+	case <-ssA.notifyCh:
+		t.Log("chat-a received notification signal")
+	case <-time.After(5 * time.Second):
+		t.Fatal("chat-a should have received notification signal")
+	}
+
+	// chat-b should NOT have been signaled
+	select {
+	case <-ssB.notifyCh:
+		t.Fatal("chat-b should NOT have been signaled for chat-a's notification")
+	default:
+		// Correct
+	}
+
+	// Now start a task for chat-b
+	_ = mgr.Start("cli:chat-b", "user-1", "echo b", func(ctx context.Context, outputBuf func(string)) (int, error) {
+		outputBuf("b")
+		return 0, nil
+	})
+
+	// Wait for chat-b's signal
+	select {
+	case <-ssB.notifyCh:
+		t.Log("chat-b received notification signal")
+	case <-time.After(5 * time.Second):
+		t.Fatal("chat-b should have received notification signal")
+	}
+}
+
+// TestDrainAndProcessNotifications_ConcurrentSafety verifies that
+// concurrent calls to drainAndProcessNotifications from different
+// goroutines (chatProcessLoop post-turn drain + chatWorker idle drain)
+// don't double-process or lose notifications.
+func TestDrainAndProcessNotifications_ConcurrentSafety(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := tools.NewBackgroundTaskManager()
+	a := &Agent{
+		bus:       bus.NewMessageBus(),
+		agentCtx:  ctx,
+		bgTaskMgr: mgr,
+	}
+
+	chatKey := "cli:test-chat"
+
+	// Start 10 tasks — all complete immediately
+	for i := 0; i < 10; i++ {
+		_ = mgr.Start(chatKey, "user-1", "echo test", func(ctx context.Context, outputBuf func(string)) (int, error) {
+			outputBuf("test output")
+			return 0, nil
+		})
+	}
+
+	// Collect all notifications from NotifyCh
+	var notifs []tools.BgNotification
+	for len(notifs) < 10 {
+		select {
+		case n := <-mgr.NotifyCh:
+			notifs = append(notifs, n)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for notifications, got %d/10", len(notifs))
+		}
+	}
+
+	// Buffer all at once
+	a.bgRunPendingMu.Lock()
+	a.bgRunPending = append(a.bgRunPending, notifs...)
+	a.bgRunPendingMu.Unlock()
+
+	// Drain concurrently from two goroutines (simulating chatProcessLoop + chatWorker race)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		a.drainAndProcessNotifications(chatKey)
+	}()
+	go func() {
+		defer wg.Done()
+		a.drainAndProcessNotifications(chatKey)
+	}()
+	wg.Wait()
+
+	// Count messages in bus.Inbound — should be exactly 10 (no duplicates, no losses)
+	count := 0
+	timeout := time.After(2 * time.Second)
+	for count < 10 {
+		select {
+		case <-a.bus.Inbound:
+			count++
+		case <-timeout:
+			t.Fatalf("expected 10 messages in bus.Inbound, got %d (duplicates or losses)", count)
+		}
+	}
+
+	// Check no more messages (no duplicates)
+	select {
+	case <-a.bus.Inbound:
+		t.Fatal("should not have more than 10 messages — possible duplicate")
+	default:
+	}
+
+	t.Logf("SUCCESS: exactly 10 of 10 notifications processed (no duplicates, no losses)")
+}
+
+// TestDrainAndProcessNotifications_AfterResponseSent verifies the KEY INVARIANT:
+// drainAndProcessNotifications is called AFTER the turn's response is sent.
+// This test simulates the chatProcessLoop ordering: processMessage → response → drain.
+func TestDrainAndProcessNotifications_AfterResponseSent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := tools.NewBackgroundTaskManager()
+	a := &Agent{
+		bus:       bus.NewMessageBus(),
+		agentCtx:  ctx,
+		bgTaskMgr: mgr,
+	}
+
+	chatKey := "cli:test-chat"
+
+	// Track ordering of events
+	var events []string
+	var eventsMu sync.Mutex
+	recordEvent := func(name string) {
+		eventsMu.Lock()
+		events = append(events, name)
+		eventsMu.Unlock()
+	}
+
+	// Simulate the correct chatProcessLoop ordering:
+	// 1. busy = true
+	// 2. processMessage (simulated)
+	// 3. response sent (simulated)
+	// 4. busy = false
+	// 5. drain notifications
+
+	ss := &bgSessionState{notifyCh: make(chan struct{}, 1)}
+
+	// Start a bg task and buffer notification
+	_ = mgr.Start(chatKey, "user-1", "ordering-test", func(ctx context.Context, outputBuf func(string)) (int, error) {
+		outputBuf("output")
+		return 0, nil
+	})
+	notif := <-mgr.NotifyCh
+	a.bgRunPendingMu.Lock()
+	a.bgRunPending = append(a.bgRunPending, notif)
+	a.bgRunPendingMu.Unlock()
+
+	// Simulate chatProcessLoop turn
+	ss.busy.Store(true)
+	recordEvent("busy_true")
+
+	recordEvent("processMessage")
+	recordEvent("response_sent")
+
+	ss.busy.Store(false)
+	recordEvent("busy_false")
+
+	a.drainAndProcessNotifications(chatKey)
+	recordEvent("drain_complete")
+
+	// Verify ordering
+	eventsMu.Lock()
+	defer eventsMu.Unlock()
+	t.Logf("Event order: %v", events)
+
+	expected := []string{"busy_true", "processMessage", "response_sent", "busy_false", "drain_complete"}
+	if len(events) != len(expected) {
+		t.Fatalf("expected %d events, got %d: %v", len(expected), len(events), events)
+	}
+	for i, e := range expected {
+		if events[i] != e {
+			t.Errorf("event[%d] = %q, want %q", i, events[i], e)
+		}
+	}
+
+	// Verify notification was processed
+	select {
+	case <-a.bus.Inbound:
+		t.Log("SUCCESS: notification processed after response sent")
+	case <-time.After(2 * time.Second):
+		t.Fatal("notification was not processed after drain")
+	}
+
+	if ss.busy.Load() {
+		t.Fatal("busy should be false after turn completes")
+	}
+}
+
+// TestBgNotifyLoop_NoDirectProcessing verifies that bgNotifyLoop
+// never sends to bus.Inbound directly — it only buffers.
+// This is the KEY architectural invariant of the redesign.
+func TestBgNotifyLoop_NoDirectProcessing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := tools.NewBackgroundTaskManager()
+	a := &Agent{
+		bus:       bus.NewMessageBus(),
+		agentCtx:  ctx,
+		bgTaskMgr: mgr,
+	}
+
+	// Start bgNotifyLoop
+	go a.bgNotifyLoop()
+
+	// Start 5 tasks for an UNREGISTERED session (no bgSessionState)
+	for i := 0; i < 5; i++ {
+		_ = mgr.Start("cli:unregistered", "user-1", "echo test", func(ctx context.Context, outputBuf func(string)) (int, error) {
+			outputBuf("output")
+			return 0, nil
+		})
+	}
+
+	// Wait for bgNotifyLoop to read and buffer all 5 notifications
+	requireEventual(t, 5*time.Second, 10*time.Millisecond, func() error {
+		a.bgRunPendingMu.Lock()
+		n := len(a.bgRunPending)
+		a.bgRunPendingMu.Unlock()
+		if n < 5 {
+			return fmt.Errorf("bgRunPending has %d/5 notifications", n)
+		}
+		return nil
+	})
+
+	// Check bus.Inbound — should be EMPTY (no direct processing)
+	var unexpectedMsgs int
+	for {
+		select {
+		case <-a.bus.Inbound:
+			unexpectedMsgs++
+		default:
+			goto done
+		}
+	}
+done:
+
+	if unexpectedMsgs > 0 {
+		t.Fatalf("bgNotifyLoop should NEVER send to bus.Inbound directly, but sent %d messages — idle path leak!", unexpectedMsgs)
+	}
+
+	t.Logf("SUCCESS: 5 notifications buffered, %d directly processed (want 0)", unexpectedMsgs)
+}
+
+func requireEventual(t *testing.T, timeout, interval time.Duration, check func() error) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := check(); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal(check().Error())
+		}
+		time.Sleep(interval)
+	}
 }

--- a/agent/compress.go
+++ b/agent/compress.go
@@ -17,6 +17,10 @@ type CompressResult struct {
 	LLMView     []llm.ChatMessage // Full messages for continuing the current Run()
 	SessionView []llm.ChatMessage // User/assistant only, persisted to session
 
+	// CompressedTokens is the estimated token count of LLMView after compression.
+	// This is the authoritative "how big is the context now" value.
+	CompressedTokens int
+
 	// Token usage from compression LLM calls (for tracking in /usage).
 	InputTokens  int64
 	OutputTokens int64
@@ -577,11 +581,12 @@ Output the structured working state directly.`
 	}).Info("Context compaction completed")
 
 	return &CompressResult{
-		LLMView:      llmView,
-		SessionView:  sessionView,
-		InputTokens:  totalInput,
-		OutputTokens: totalOutput,
-		CachedTokens: totalCached,
-		LLMCalls:     llmCalls,
+		LLMView:          llmView,
+		SessionView:      sessionView,
+		CompressedTokens: newTokens,
+		InputTokens:      totalInput,
+		OutputTokens:     totalOutput,
+		CachedTokens:     totalCached,
+		LLMCalls:         llmCalls,
 	}, nil
 }

--- a/agent/compress_pipeline.go
+++ b/agent/compress_pipeline.go
@@ -79,10 +79,11 @@ func ApplyCompress(ctx context.Context, params CompressPipelineParams) (*Compres
 		newMessages = params.SyncMessages(result.LLMView)
 	}
 
-	// Use the API-returned prompt_tokens from the compression LLM call.
-	// This is the exact token count the API charged for processing the compressed
-	// context — more accurate than any local estimation.
-	newTokenCount := result.InputTokens
+	// Use the locally-estimated token count of the compressed LLMView.
+	// This represents the actual size of the new context — what the NEXT LLM call
+	// will see as input.  result.InputTokens is the compress LLM's API cost, NOT
+	// the compressed context size (that was the root cause of the "117k → 259k" bug).
+	newTokenCount := int64(result.CompressedTokens)
 
 	if params.TokenTracker != nil {
 		params.TokenTracker.ResetAfterCompress()

--- a/agent/compress_pipeline_test.go
+++ b/agent/compress_pipeline_test.go
@@ -48,10 +48,11 @@ func sampleCompressResult() *CompressResult {
 			llm.NewUserMessage("summary of context"),
 			llm.NewAssistantMessage("understood"),
 		},
-		InputTokens:  100,
-		OutputTokens: 50,
-		CachedTokens: 10,
-		LLMCalls:     1,
+		CompressedTokens: 42,
+		InputTokens:      100,
+		OutputTokens:     50,
+		CachedTokens:     10,
+		LLMCalls:         1,
 	}
 }
 
@@ -112,9 +113,9 @@ func TestApplyCompress_CompressSuccess(t *testing.T) {
 		t.Errorf("expected 2 new messages, got %d", len(got.NewMessages))
 	}
 
-	// Verify token count was estimated
-	if got.NewTokenCount <= 0 {
-		t.Errorf("expected positive NewTokenCount, got %d", got.NewTokenCount)
+	// Verify CompressedTokens is used (not InputTokens)
+	if got.NewTokenCount != 42 {
+		t.Errorf("expected NewTokenCount=42 (CompressedTokens), got %d", got.NewTokenCount)
 	}
 
 	// Verify CompressOutput is the original result

--- a/agent/integration_test.go
+++ b/agent/integration_test.go
@@ -169,8 +169,9 @@ func (mc *mockCompressor) Compress(ctx context.Context, msgs []llm.ChatMessage, 
 	}
 	// Default: return a simple summary
 	return &CompressResult{
-		LLMView:     []llm.ChatMessage{llm.NewSystemMessage("[compressed summary]")},
-		SessionView: []llm.ChatMessage{llm.NewAssistantMessage("Summary: compressed")},
+		LLMView:          []llm.ChatMessage{llm.NewSystemMessage("[compressed summary]")},
+		SessionView:      []llm.ChatMessage{llm.NewAssistantMessage("Summary: compressed")},
+		CompressedTokens: 10,
 	}, nil
 }
 
@@ -788,9 +789,8 @@ func TestIntegration_Compress_TriggeredWhenOverThreshold(t *testing.T) {
 					llm.NewSystemMessage("You are a test agent."),
 					llm.NewUserMessage("[compressed context]"),
 				},
-				SessionView: []llm.ChatMessage{
-					llm.NewAssistantMessage("Summary: compressed"),
-				},
+				SessionView:      []llm.ChatMessage{llm.NewAssistantMessage("Summary: compressed")},
+				CompressedTokens: 15,
 			}, nil
 		},
 	}

--- a/channel/cli.go
+++ b/channel/cli.go
@@ -105,6 +105,7 @@ func (c *CLIChannel) Start() error {
 		c.model.connState = "connected"
 	}
 	c.model.debugCaptureMs = c.config.DebugCaptureMs
+	c.model.ephemeral = c.config.Ephemeral
 	c.model.senderID = "cli_user"
 
 	// Load per-user UI preferences (sidebar collapse state, etc.)

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -355,8 +355,8 @@ func (m *cliModel) saveCurrentSession() {
 		inputDraft:             m.inputDraft,
 		bgTaskCount:            m.bgTaskCount,
 	}
-	// Persist todo list for current session
-	if m.todoManager != nil {
+	// Persist todo list for current session (skip in ephemeral mode — nothing to persist)
+	if m.todoManager != nil && !m.ephemeral {
 		_ = m.todoManager.SaveToFile(key)
 	}
 }
@@ -832,6 +832,7 @@ type cliModel struct {
 	connState              string    // WS connection state: "connected"|"disconnected"|"reconnecting"
 	debugMode              bool      // --debug: UI capture + key injection via SIGUSR1
 	debugCaptureMs         int       // --debug-capture-ms: UI capture interval in ms (0 = default 1000)
+	ephemeral              bool      // --ephemeral: no persistence, clean slate for benchmarking
 	senderID               string    // 当前身份 ID（默认 "cli_user"，/su 命令可切换）
 	channelName            string    // 当前 channel（默认 "cli"，/su 切换时可能变为 "web"）
 	defaultChatID          string    // 默认 chatID（/su 切换回来时恢复）

--- a/channel/cli_session.go
+++ b/channel/cli_session.go
@@ -498,7 +498,17 @@ func ListLocalDirSessions(workDir string) []SessionPanelEntry {
 // SetLastActiveSession persists the last active session for a workDir.
 // chatID may be a full chatID (workDir:sessionName) or bare workDir.
 // The workDir is extracted via ParseChatID to ensure correct file lookup.
+// IsEphemeralChatID returns true if the chatID belongs to an ephemeral session
+// (started with --ephemeral). These sessions skip all disk persistence.
+func IsEphemeralChatID(chatID string) bool {
+	return strings.HasPrefix(chatID, "_ephemeral:")
+}
+
 func SetLastActiveSession(workDirOrChatID, chatID string) {
+	// Ephemeral sessions: skip sessions.json persistence entirely.
+	if IsEphemeralChatID(chatID) {
+		return
+	}
 	workDir, _ := ParseChatID(workDirOrChatID)
 	ds, err := LoadDirSessions(workDir)
 	if err != nil {
@@ -548,6 +558,10 @@ func (s SessionLLMState) IsZero() bool {
 // This replaces the old SaveSessionLLM + SaveSessionMaxContext pair.
 // Partial writes are impossible — either all fields are persisted or none.
 func SaveSessionLLMState(workDir, chatID string, state SessionLLMState) {
+	// Ephemeral sessions: skip sessions.json persistence entirely.
+	if IsEphemeralChatID(chatID) {
+		return
+	}
 	ds, err := LoadDirSessions(workDir)
 	if err != nil {
 		return

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -813,6 +813,7 @@ type CLIChannelConfig struct {
 	TodoManager          *cliTodoManager                                                                                  // per-session todo persistence
 	SetCWDFn             func(channelName, chatID, dir string) error                                                      // 会话切换时初始化 CWD
 	BindChatFn           func(chatID string) error                                                                        // 订阅 Hub 路由，使服务器推送事件（progress/stream/outbound）到达客户端
+	Ephemeral            bool                                                                                             // --ephemeral: no sessions.json, no DB persistence, clean slate for benchmarking
 }
 
 type AgentPanelEntry struct {

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -1096,7 +1096,7 @@ func (m *cliModel) renderInfoBar() string {
 }
 
 // renderWorkspaceIndicator returns a workspace status string.
-// "🏠 primary" for main workspace, "🌿 <name>" for worktree sessions.
+// "🏠 main workspace" for main workspace, "🌿 <name>" for worktree sessions.
 func (m *cliModel) renderWorkspaceIndicator() string {
 	cwd := ""
 	if m.progress != nil {
@@ -1120,7 +1120,7 @@ func (m *cliModel) renderWorkspaceIndicator() string {
 		return fmt.Sprintf("🌿 %s", m.styles.Accent.Render(sessionName))
 	}
 
-	return fmt.Sprintf("🏠 %s", m.styles.TextMutedSt.Render("primary"))
+	return fmt.Sprintf("🏠 %s", m.styles.TextMutedSt.Render("main workspace"))
 }
 
 // shortenWorktreeName shortens a worktree directory name for display.

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -43,6 +43,7 @@ import (
 	"xbot/tools"
 	"xbot/version"
 
+	"github.com/google/uuid"
 	"github.com/mattn/go-isatty"
 )
 
@@ -667,7 +668,7 @@ func (a *cliApp) buildPaletteExternalCommands() []channel.PaletteExternalCommand
 	return cmds
 }
 
-func newCLIApp(serverURL, token string, forceLocal bool, maxContextTokens, maxOutputTokens int) *cliApp {
+func newCLIApp(serverURL, token string, forceLocal bool, maxContextTokens, maxOutputTokens int, ephemeral bool) *cliApp {
 	cfg := config.Load()
 
 	// If --server was not specified on the command line, fall back to config.
@@ -684,6 +685,11 @@ func newCLIApp(serverURL, token string, forceLocal bool, maxContextTokens, maxOu
 	workDir := cfg.Agent.WorkDir
 	xbotHome := config.XbotHome()
 	dbPath := config.DBFilePath()
+
+	// Ephemeral mode: use in-memory SQLite so nothing is persisted to disk.
+	if ephemeral {
+		dbPath = ":memory:"
+	}
 
 	if err := setupLogger(cfg.Log, xbotHome); err != nil {
 		log.WithError(err).Fatal("Failed to setup logger")
@@ -821,6 +827,7 @@ func main() {
 		fmt.Println("Options:")
 		fmt.Println("  --help, -h          Show this help")
 		fmt.Println("  --new, --new-session  Start a new isolated session (auto-named)")
+		fmt.Println("  --ephemeral         Ephemeral mode: no persistence, clean state for benchmarking")
 		fmt.Println("  --resume            Resume last session (default)")
 		fmt.Println("  --max-context N     Override max context tokens (e.g. 128000)")
 		fmt.Println("  --max-tokens N      Override max output tokens (e.g. 8192)")
@@ -853,6 +860,7 @@ func main() {
 	// 解析命令行标志
 	prompt := ""
 	newSession := false
+	ephemeral := false
 	var (
 		flagServer       string        // --server ws://host:port (RemoteBackend: agent runs on server)
 		flagShare        string        // --share ws://host:port/ws/userID (Runner mode: tools run locally)
@@ -876,6 +884,8 @@ func main() {
 			// 保留兼容性，行为与默认相同
 		case "--new", "--new-session":
 			newSession = true
+		case "--ephemeral":
+			ephemeral = true
 		case "-p":
 			if len(os.Args) > i+1 {
 				prompt = os.Args[i+1]
@@ -974,11 +984,13 @@ func main() {
 
 	// 非交互模式
 	if prompt != "" {
-		executeNonInteractive(prompt, flagMaxContext, flagMaxTokens)
+		executeNonInteractive(prompt, flagMaxContext, flagMaxTokens, ephemeral)
 		return
 	}
 
-	if newSession {
+	if ephemeral {
+		fmt.Println("Mode: ephemeral (--ephemeral, no persistence)")
+	} else if newSession {
 		fmt.Println("Mode: new session (--new / --new-session)")
 	} else {
 		fmt.Println("Mode: resuming last session (use --new or --new-session for new session)")
@@ -988,7 +1000,7 @@ func main() {
 	if flagLocal {
 		flagServer = ""
 	}
-	app := newCLIApp(flagServer, flagToken, flagLocal, flagMaxContext, flagMaxTokens)
+	app := newCLIApp(flagServer, flagToken, flagLocal, flagMaxContext, flagMaxTokens, ephemeral)
 	if flagLocal {
 		fmt.Println("Backend: in-process (channel transport)")
 	} else if app.client != nil && app.client.IsRemote() {
@@ -1019,7 +1031,15 @@ func main() {
 	// SetLastActiveSession whenever the user switches sessions in the TUI.
 	// RPC is not available here (backend not started yet).
 	initialChatID := absWorkDir
-	if newSession {
+	if ephemeral {
+		// --ephemeral: use a unique throwaway chatID. No sessions.json, no persistence.
+		uid, err := uuid.NewRandom()
+		if err != nil {
+			log.WithError(err).Fatal("Failed to generate ephemeral session ID")
+		}
+		initialChatID = "_ephemeral:" + uid.String()
+		log.WithField("chatID", initialChatID).Info("Ephemeral session (no persistence)")
+	} else if newSession {
 		// --new/--new-session: unconditionally create a new isolated session.
 		name, chatID, err := channel.NewAutoSession(absWorkDir)
 		if err != nil {
@@ -1045,6 +1065,7 @@ func main() {
 		IsFirstRun:           firstRun,
 		SidebarWidthOverride: flagSidebarWidth,
 		NoSidebar:            flagNoSidebar,
+		Ephemeral:            ephemeral,
 		GetCurrentValues: func() map[string]string {
 			app.valuesCacheMu.RLock()
 			cache := app.valuesCache
@@ -1830,12 +1851,6 @@ func main() {
 		app.valuesCancel = valuesCancel
 	}
 
-	if newSession {
-		if err := app.client.SendInbound("cli", absWorkDir, "/new", "cli_user", "CLI User", "p2p", nil); err != nil {
-			log.WithError(err).Warn("Failed to send newSession message")
-		}
-	}
-
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	clipanic.Go("main.signalHandler", func() {
@@ -1915,8 +1930,8 @@ func red(s string) string {
 }
 
 // executeNonInteractive 非交互模式：单次执行 prompt 并输出到 stdout。
-func executeNonInteractive(prompt string, maxContextTokens, maxOutputTokens int) {
-	app := newCLIApp("", "", true, maxContextTokens, maxOutputTokens) // non-interactive always uses local backend
+func executeNonInteractive(prompt string, maxContextTokens, maxOutputTokens int, ephemeral bool) {
+	app := newCLIApp("", "", true, maxContextTokens, maxOutputTokens, ephemeral) // non-interactive always uses local backend
 	defer app.Close()
 
 	absWorkDir, _ := filepath.Abs(app.workDir)

--- a/docs/agent/worktree.md
+++ b/docs/agent/worktree.md
@@ -35,9 +35,9 @@ Process-level `sync.Map`-based registry. Single source of truth for active workt
 ```go
 type WorktreeEntry struct {
     SessionKey  string  // "cli:/path/to/repo:debug" or "agent:role/instance"
-    Role        string  // "primary" | "peer" | "child"
+    Role        string  // "peer" | "child"
     RepoPath    string
-    WorktreeDir string  // empty for primary
+    WorktreeDir string  // empty for peer-awareness-only sessions (no physical worktree)
     Branch      string
     Status      string  // "working" | "merge-ready" | "done"
 }
@@ -51,7 +51,7 @@ Built-in tool registered in `DefaultRegistry` as `RegisterCore`. Actions:
 
 | Action | Description |
 |--------|-------------|
-| `init` | Auto-detect: first agent→primary, subsequent→worktree |
+| `init` | Create isolated worktree for the current agent session |
 | `cleanup` | Remove worktree + branch + deregister |
 | `status` | List active worktrees in current repo |
 

--- a/serverapp/server_core.go
+++ b/serverapp/server_core.go
@@ -43,8 +43,11 @@ func InitServer(cfg *config.Config, llmClient llm_pkg.LLM, dbPath, workDir, xbot
 
 	// 1b. Migrate data to SQLite if needed (one-time migration from old formats).
 	// Must run BEFORE agent.New (which opens the DB via session.NewMultiTenant).
-	if err := storage.MigrateIfNeeded(context.Background(), workDir, dbPath); err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("migrate data: %w", err)
+	// Skip for in-memory DB (ephemeral mode) — nothing to migrate from.
+	if dbPath != ":memory:" {
+		if err := storage.MigrateIfNeeded(context.Background(), workDir, dbPath); err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("migrate data: %w", err)
+		}
 	}
 
 	// 2. Create Agent.
@@ -104,7 +107,10 @@ func InitServer(cfg *config.Config, llmClient llm_pkg.LLM, dbPath, workDir, xbot
 	// 2c. Migrate flat memory from SQLite tables to MD files (if needed).
 	// This is a one-time migration; must run after agent opens the DB (via
 	// session.NewMultiTenant) but before any session access.
-	storage.MigrateMemoryToFiles(dbPath)
+	// Skip for in-memory DB (ephemeral mode) — no legacy data to migrate.
+	if dbPath != ":memory:" {
+		storage.MigrateMemoryToFiles(dbPath)
+	}
 
 	// 2c. Set runner token DB for per-user runner token persistence.
 	// The Agent opens the DB internally via session.NewMultiTenant(cfg.DBPath);

--- a/storage/sqlite/db.go
+++ b/storage/sqlite/db.go
@@ -27,10 +27,12 @@ const schemaVersion = 32
 // Open opens or creates a SQLite database at the given path
 // If the database doesn't exist, it will be created with the required schema
 func Open(path string) (*DB, error) {
-	// Ensure directory exists
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, fmt.Errorf("create database directory: %w", err)
+	// Ensure directory exists (skip for :memory: which is in-memory SQLite)
+	if path != ":memory:" {
+		dir := filepath.Dir(path)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("create database directory: %w", err)
+		}
 	}
 
 	conn, err := sql.Open("sqlite", path)

--- a/tools/worktree.go
+++ b/tools/worktree.go
@@ -49,7 +49,7 @@ type WorktreeParams struct {
 func (t *WorktreeTool) Parameters() []llm.ToolParam {
 	return []llm.ToolParam{
 		{Name: "action", Type: "string", Description: "Action: init, cleanup, or status", Required: true},
-		{Name: "role", Type: "string", Description: "Agent role: peer, child, or primary (for init)", Required: false},
+		{Name: "role", Type: "string", Description: "Agent role: peer or child (for init)", Required: false},
 		{Name: "instance", Type: "string", Description: "Agent instance ID (for init)", Required: false},
 		{Name: "task", Type: "string", Description: "Short task description for branch name (for init)", Required: false},
 	}
@@ -102,8 +102,14 @@ func (t *WorktreeTool) executeInit(ctx *ToolContext, params WorktreeParams) (*To
 	}
 
 	if existing := GlobalWorktreeRegistry.GetBySession(sessionKey); existing != nil {
-		return NewResult(fmt.Sprintf("Already registered as %q in worktree: %s (branch: %s)",
-			existing.Role, existing.WorktreeDir, existing.Branch)), nil
+		if existing.WorktreeDir != "" {
+			// Real worktree exists — cannot re-init.
+			return NewResult(fmt.Sprintf("Already registered as %q in worktree: %s (branch: %s)",
+				existing.Role, existing.WorktreeDir, existing.Branch)), nil
+		}
+		// Lightweight peer-awareness entry (from RegisterPeer when auto_worktree is off).
+		// Remove it so we can upgrade to a real worktree.
+		GlobalWorktreeRegistry.Deregister(sessionKey)
 	}
 
 	// All sessions get a worktree — no primary concept.
@@ -170,7 +176,7 @@ func (t *WorktreeTool) executeCleanup(ctx *ToolContext) (*ToolResult, error) {
 
 	if entry.WorktreeDir == "" {
 		GlobalWorktreeRegistry.Deregister(sessionKey)
-		return NewResult(fmt.Sprintf("Deregistered primary agent for repo %s.", entry.RepoPath)), nil
+		return NewResult(fmt.Sprintf("Deregistered session for repo %s.", entry.RepoPath)), nil
 	}
 
 	if err := removeWorktree(entry.RepoPath, entry.WorktreeDir, entry.Branch); err != nil {

--- a/tools/worktree_registry.go
+++ b/tools/worktree_registry.go
@@ -14,9 +14,9 @@ import (
 // WorktreeEntry describes a single active worktree managed by xbot.
 type WorktreeEntry struct {
 	SessionKey  string // "cli:/path/to/repo:debug" or "agent:role/instance"
-	Role        string // "primary" | "peer" | "child"
+	Role        string // "peer" | "child"
 	RepoPath    string // absolute path to the main git repo
-	WorktreeDir string // absolute path to the worktree (empty for primary)
+	WorktreeDir string // absolute path to the worktree (empty for peer-awareness-only sessions)
 	Branch      string // branch name
 	CreatedAt   time.Time
 	Status      string // "working" | "merge-ready" | "done"
@@ -139,19 +139,6 @@ func (r *WorktreeRegistry) GetBySession(sessionKey string) *WorktreeEntry {
 	return cloneEntry(e)
 }
 
-// GetPrimary returns the primary entry for a repo, or nil.
-func (r *WorktreeRegistry) GetPrimary(repoPath string) *WorktreeEntry {
-	r.ensureLoaded(repoPath)
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	for _, e := range r.byRepo[repoPath] {
-		if e.Role == "primary" {
-			return cloneEntry(e)
-		}
-	}
-	return nil
-}
-
 // HasPeers returns true if there are other active entries in the repo.
 func (r *WorktreeRegistry) HasPeers(repoPath, excludeSessionKey string) bool {
 	r.ensureLoaded(repoPath)
@@ -212,9 +199,8 @@ func (r *WorktreeRegistry) GetCWD(sessionKey string) string {
 }
 
 // RegisterPeer registers a session for peer awareness without creating a worktree.
-// Used when auto_worktree is disabled. The first session in a repo is registered
-// as "primary"; subsequent sessions are registered as "peer" (sharing the main
-// workspace, no file isolation).
+// Used when auto_worktree is disabled. All sessions are equal peers (sharing the
+// main workspace, no file isolation).
 //
 // Entries created by RegisterPeer are NOT persisted to disk — they are runtime-only
 // peer awareness data that becomes stale across process restarts.
@@ -232,18 +218,10 @@ func (r *WorktreeRegistry) RegisterPeer(sessionKey, workDir string) {
 	if _, exists := r.bySess[sessionKey]; exists {
 		return
 	}
-	// Determine role: first session → primary, others → peer.
-	// Must check inline (not via GetPrimary) because we already hold mu.Lock.
-	role := "primary"
-	for _, e := range r.byRepo[repoPath] {
-		if e.Role == "primary" {
-			role = "peer"
-			break
-		}
-	}
+	// All sessions are equal peers — no primary concept.
 	entry := &WorktreeEntry{
 		SessionKey:  sessionKey,
-		Role:        role,
+		Role:        "peer",
 		RepoPath:    repoPath,
 		WorktreeDir: "",
 		Branch:      "",
@@ -267,7 +245,7 @@ func (r *WorktreeRegistry) ensureLoadedBySession(sessionKey string) {
 		r.ensureLoaded(e.RepoPath)
 		return
 	}
-	// Not loaded yet — will load on first Register/GetPrimary/etc.
+	// Not loaded yet — will load on first Register/etc.
 }
 
 func cloneEntry(e *WorktreeEntry) *WorktreeEntry {

--- a/tools/worktree_registry_test.go
+++ b/tools/worktree_registry_test.go
@@ -52,7 +52,7 @@ func newTestRegistry() *WorktreeRegistry {
 	}
 }
 
-func TestRegisterPeer_FirstSessionBecomesPrimary(t *testing.T) {
+func TestRegisterPeer_AllSessionsArePeer(t *testing.T) {
 	repoPath := newTestGitRepo(t)
 	reg := newTestRegistry()
 
@@ -60,13 +60,13 @@ func TestRegisterPeer_FirstSessionBecomesPrimary(t *testing.T) {
 
 	entry := reg.GetBySession("cli:repo:session-1")
 	require.NotNil(t, entry)
-	assert.Equal(t, "primary", entry.Role, "first session in repo should be primary")
+	assert.Equal(t, "peer", entry.Role, "all sessions should be peer (no primary concept)")
 	assert.Equal(t, repoPath, entry.RepoPath)
 	assert.Equal(t, "", entry.WorktreeDir, "no worktree dir for RegisterPeer mode")
 	assert.Equal(t, "", entry.Branch, "no branch for RegisterPeer mode")
 }
 
-func TestRegisterPeer_SecondSessionBecomesPeer(t *testing.T) {
+func TestRegisterPeer_SecondSessionAlsoPeer(t *testing.T) {
 	repoPath := newTestGitRepo(t)
 	reg := newTestRegistry()
 
@@ -77,8 +77,8 @@ func TestRegisterPeer_SecondSessionBecomesPeer(t *testing.T) {
 	e2 := reg.GetBySession("cli:repo:session-2")
 	require.NotNil(t, e1)
 	require.NotNil(t, e2)
-	assert.Equal(t, "primary", e1.Role, "first session should be primary")
-	assert.Equal(t, "peer", e2.Role, "second session should be peer")
+	assert.Equal(t, "peer", e1.Role, "all sessions should be peer")
+	assert.Equal(t, "peer", e2.Role, "all sessions should be peer")
 }
 
 func TestRegisterPeer_ManySessions(t *testing.T) {
@@ -92,9 +92,9 @@ func TestRegisterPeer_ManySessions(t *testing.T) {
 
 	entries := reg.ListRepo(repoPath)
 	require.Len(t, entries, 5)
-	assert.Equal(t, "primary", entries[0].Role)
+	assert.Equal(t, "peer", entries[0].Role)
 	for _, e := range entries[1:] {
-		assert.Equal(t, "peer", e.Role, "all sessions after first should be peer")
+		assert.Equal(t, "peer", e.Role, "all sessions should be peer")
 	}
 }
 
@@ -131,8 +131,8 @@ func TestRegisterPeer_DifferentRepos(t *testing.T) {
 	e2 := reg.GetBySession("cli:repo2:session-1")
 	require.NotNil(t, e1)
 	require.NotNil(t, e2)
-	assert.Equal(t, "primary", e1.Role, "first session in repo1 should be primary")
-	assert.Equal(t, "primary", e2.Role, "first session in repo2 should be primary")
+	assert.Equal(t, "peer", e1.Role, "first session in repo1 should be peer")
+	assert.Equal(t, "peer", e2.Role, "first session in repo2 should be peer")
 }
 
 func TestRegisterPeer_NotPersistedToDisk(t *testing.T) {
@@ -158,28 +158,7 @@ func TestRegisterPeer_NotPersistedToDisk(t *testing.T) {
 	// New entry IS visible (in memory).
 	e3 := reg2.GetBySession("cli:repo:session-3")
 	require.NotNil(t, e3)
-	assert.Equal(t, "primary", e3.Role, "fresh registry should assign primary to first session")
-}
-
-func TestRegisterPeer_GetPrimary(t *testing.T) {
-	repoPath := newTestGitRepo(t)
-	reg := newTestRegistry()
-
-	// No primary yet
-	assert.Nil(t, reg.GetPrimary(repoPath))
-
-	// Register first → primary
-	reg.RegisterPeer("cli:repo:session-1", repoPath)
-	primary := reg.GetPrimary(repoPath)
-	require.NotNil(t, primary)
-	assert.Equal(t, "primary", primary.Role)
-	assert.Equal(t, "cli:repo:session-1", primary.SessionKey)
-
-	// Register more → primary unchanged
-	reg.RegisterPeer("cli:repo:session-2", repoPath)
-	primary = reg.GetPrimary(repoPath)
-	require.NotNil(t, primary)
-	assert.Equal(t, "cli:repo:session-1", primary.SessionKey, "primary should remain the first session")
+	assert.Equal(t, "peer", e3.Role, "fresh registry should assign peer to first session")
 }
 
 func TestCleanupSession_PeerOnly(t *testing.T) {

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -231,6 +231,8 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
     streamingContentRef,
   })
   const [autoScroll, setAutoScroll] = useState(true)
+  const autoScrollRef = useRef(true)
+  const scrollProgrammaticRef = useRef(false) // true when we triggered scrollToBottom ourselves
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([])
   const [dragActive, setDragActive] = useState(false)
@@ -346,22 +348,46 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'instant') => {
     const el = messagesContainerRef.current
     if (!el) return
+    scrollProgrammaticRef.current = true
     el.scrollTo({ top: el.scrollHeight, behavior })
+    // Reset flag after a tick to let the scroll event fire
+    setTimeout(() => { scrollProgrammaticRef.current = false }, 50)
   }, [])
 
+  // Throttle scroll handler to avoid setState thrashing from virtualizer reflows
+  const scrollThrottleRef = useRef(0)
   const handleContainerScroll = useCallback(() => {
-    setAutoScroll(isNearBottom())
+    // Ignore scroll events triggered by our own scrollToBottom()
+    if (scrollProgrammaticRef.current) return
+    // Throttle: only check once per animation frame
+    if (scrollThrottleRef.current) return
+    scrollThrottleRef.current = requestAnimationFrame(() => {
+      scrollThrottleRef.current = 0
+      const near = isNearBottom()
+      if (near !== autoScrollRef.current) {
+        autoScrollRef.current = near
+        setAutoScroll(near)
+      }
+    })
   }, [isNearBottom])
 
-  // Auto-scroll during streaming/progress updates — throttled to avoid layout thrashing.
-  // Only follows when user is already at the bottom (autoScroll=true).
+  // Auto-scroll during streaming/progress updates — only when actively loading.
+  // Guarded to prevent infinite loop with virtualizer.measureElement reflows.
   const scrollRafRef = useRef<number>(0)
+  const prevMsgCountRef = useRef(0)
   useEffect(() => {
-    if (!autoScroll) return
+    if (!autoScrollRef.current) return
+    // Only auto-scroll when actively streaming (loading or progress) OR when new messages arrive
+    const isActive = loading || progress !== null
+    const msgCount = messages.length
+    const hasNewMessages = msgCount > prevMsgCountRef.current
+    prevMsgCountRef.current = msgCount
+    // Skip if not active AND no new messages — prevents reflow-triggered scrolls
+    if (!isActive && !hasNewMessages) return
     if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current)
     scrollRafRef.current = requestAnimationFrame(() => scrollToBottom('instant'))
     return () => { if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current) }
-  }, [messages, progress, autoScroll, scrollToBottom])
+  }, [messages, progress, autoScroll, scrollToBottom, loading])
 
   // --- Fetch context info ---
   const fetchContextInfo = useCallback(() => {
@@ -525,10 +551,12 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
           if (data.last_seq) {
             lastSeqRef.current = data.last_seq
           }
+          // Final scroll-to-bottom after all messages have loaded and rendered.
+          // Use a longer delay to let the virtualizer finish measuring all elements.
           setTimeout(() => {
             scrollToBottom('instant')
             requestAnimationFrame(() => scrollToBottom('instant'))
-          }, 100)
+          }, 300)
         }
       })
       .catch((err) => {
@@ -613,7 +641,7 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
     setTodos([])
     setSubAgents([])
     setLoading(true)
-    setAutoScroll(true)
+    setAutoScroll(true); autoScrollRef.current = true
 
     const payload: { type: string; content: string; channel?: string; chat_id?: string; file_ids?: string[]; file_names?: string[]; file_sizes?: number[]; upload_keys?: string[]; file_mimes?: string[] } = {
       type: 'message',
@@ -687,7 +715,7 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
     setMessages(prev => prev.slice(0, userIdx))
     resetProgress()
     setLoading(true)
-    setAutoScroll(true)
+    setAutoScroll(true); autoScrollRef.current = true
     // Resend the user message
     wsSend({ type: 'message', content: userContent })
   }, [messages, wsSend, resetProgress, showToast])
@@ -1237,7 +1265,7 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
       {/* Scroll to bottom button */}
       {!autoScroll && (messages.length > 0 || loading) && (
         <button
-          onClick={() => { setAutoScroll(true); requestAnimationFrame(() => scrollToBottom('smooth')) }}
+          onClick={() => { setAutoScroll(true); autoScrollRef.current = true; requestAnimationFrame(() => scrollToBottom('smooth')) }}
           className="scroll-to-bottom-btn"
           aria-label={t('scrollToBottom')}
           data-testid="scroll-to-bottom-btn"


### PR DESCRIPTION
## Bug

压缩后显示 token 数反而暴涨：`117109 → 258964 tokens`，并被持久化到 DB，导致重启后触发幽灵压缩循环。

## Root Cause

`CompressResult.InputTokens` 存储的是**压缩 LLM 调用的 API token 开销**（读原始对话 + 多轮工具调用累加），但 `ApplyCompress` 把它当成了**压缩后的上下文大小**。

```
compactMessages():
  totalInput += resp.Usage.PromptTokens  // 压缩 LLM 的输入成本
  return CompressResult{InputTokens: totalInput}  // ≈ 259k

ApplyCompress():
  newTokenCount := result.InputTokens  // BUG: 应该是压缩后大小
  // 259k 被写入 DB → 重启后 NewTokenTracker(259k) → 再次触发压缩
```

而正确的压缩后 token 数 (`newTokens`) 在 `compactMessages` 里用 `CountMessagesTokens` 算了，但只用于日志，从未返回。

## Fix

1. `CompressResult` 新增 `CompressedTokens int` 字段
2. `compactMessages` 返回时填充 `CompressedTokens: newTokens`
3. `ApplyCompress` 改用 `result.CompressedTokens` 替代 `result.InputTokens`

## Cascade Effects Fixed

- `SaveContextTokens(258964)` → 现在保存正确的压缩后小值
- `SaveTokenState(258964, 0)` → 同上
- `setTokenUsageAfterCompress(258964)` → TUI context bar 不再暴涨
- 重启后 `NewTokenTracker` 不再触发幽灵压缩

## Also Includes

- fix(web): infinite scroll oscillation on long context sessions
- Worktree and CLI session handling improvements

## Test

- All existing tests pass (pre-commit hooks: gofmt → golangci-lint → go build → go test)
- Updated `compress_pipeline_test.go` to verify `NewTokenCount == CompressedTokens`