### PR TITLE
refactor: unify cron triggers with bg task notification pipeline

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1479,12 +1479,13 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	a.multiSession.StartCleanupRoutine()
 
-	a.cronSch.SetInjectFunc(func(channel, chatID, senderID, content string) {
-		// Cron injects via injectBgUserMessage to ensure both TUI notification
-		// (injectCLIUserMessage) and agent processing (injectInbound) happen together.
-		// The content passed to TUI includes a ⏰ prefix for visual distinction;
-		// the content passed to agent is the raw cron message.
-		a.injectBgUserMessage(channel, chatID, senderID, content)
+	a.cronSch.SetNotifyCronFunc(func(channel, chatID, senderID, message string) {
+		sessionKey := channel + ":" + chatID
+		a.bgTaskMgr.SendCronFired(&tools.CronFired{
+			Key:     sessionKey,
+			Sid:     senderID,
+			Message: message,
+		})
 	})
 	a.cronSch.StartDelayed(3 * time.Second)
 
@@ -2038,11 +2039,6 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*ch
 		msg.Content += ref.String()
 	}
 
-	// Cron 消息使用独立处理流程（不带历史上下文，不参与消息更新跟踪）
-	if msg.IsCron {
-		return a.processCronMessage(ctx, msg)
-	}
-
 	// 初始化 session 消息跟踪：清除旧的已发消息 ID，记录入站消息 ID 用于首条回复
 	key := qualifyChatID(msg.Channel, msg.ChatID)
 	a.resetSessionState(key)
@@ -2233,102 +2229,6 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*ch
 	}
 
 	return a.handleRunOutput(ctx, msg, out, tenantSession, replyPolicy)
-}
-
-// processCronMessage 处理 cron 触发消息（不带历史上下文，使用专用系统提示词）
-func (a *Agent) processCronMessage(ctx context.Context, msg bus.InboundMessage) (*channel.OutboundMsg, error) {
-	// 注入 requestID（如果 processMessage 未注入）
-	if log.RequestID(ctx) == "" {
-		ctx = log.WithRequestID(ctx, log.NewRequestID())
-	}
-
-	log.Ctx(ctx).WithFields(log.Fields{
-		"channel":   msg.Channel,
-		"chat_id":   msg.ChatID,
-		"sender_id": msg.SenderID,
-	}).Infof("Processing cron message: %s", tools.Truncate(msg.Content, 80))
-
-	// 清除旧的 session 状态，确保 cron 消息可以正常发送
-	key := qualifyChatID(msg.Channel, msg.ChatID)
-	a.resetSessionState(key)
-
-	// 使用创建者的工作区路径
-	senderID := msg.SenderID
-	workspaceRoot := a.workspaceRoot(senderID)
-	if err := a.ensureWorkspace(ctx, workspaceRoot, senderID); err != nil {
-		log.Ctx(ctx).WithError(err).Warn("Failed to create cron user workspace")
-	}
-
-	// 构建 cron 专用消息（无历史上下文）
-	mc := NewCronMessageContext(msg.Content)
-	messages := a.cronPipeline.Run(mc)
-
-	// 运行 Agent 循环（统一 Run，cron 不需要自动压缩和进度通知）
-	cronMsg := msg
-	cronMsg.SenderID = senderID
-	cronCfg := a.buildCronRunConfig(ctx, cronMsg, messages)
-	cronOut := Run(ctx, cronCfg)
-	if cronOut.Error != nil {
-		return nil, cronOut.Error
-	}
-	finalContent := cronOut.Content
-
-	if finalContent == "" {
-		finalContent = "定时任务已执行，但无输出内容。"
-	}
-
-	// 如果工具已发送最终回复（如卡片），跳过后续文本回复
-	if _, sent := a.sessionFinalSent.Load(key); sent {
-		log.Ctx(ctx).Info("Cron: tool already sent final reply (card), skipping text reply")
-		a.persistCronMessages(ctx, msg, finalContent)
-		return nil, nil
-	}
-
-	// 持久化 cron 消息到 session（web 端用户下次进入可见）
-	a.persistCronMessages(ctx, msg, finalContent)
-
-	// 保留原始消息 ID 以支持回复模式
-	metadata := make(map[string]string)
-	if msg.Metadata != nil {
-		metadata = msg.Metadata
-	}
-
-	return &channel.OutboundMsg{
-		Channel:  msg.Channel,
-		ChatID:   msg.ChatID,
-		Content:  finalContent,
-		Metadata: metadata,
-	}, nil
-}
-
-// persistCronMessages 将 cron 消息持久化到 session，使 web 端用户下次进入时可见。
-// 对于非 web 渠道（如飞书），消息已通过 IM 平台持久化，无需额外保存。
-func (a *Agent) persistCronMessages(ctx context.Context, msg bus.InboundMessage, assistantContent string) {
-	tenantSession, err := a.multiSession.GetOrCreateSession(msg.Channel, msg.ChatID)
-	if err != nil {
-		log.Ctx(ctx).WithError(err).Warn("Failed to get session for cron message persistence")
-		return
-	}
-
-	cronUserMsg := llm.NewUserMessage("[定时任务] " + msg.Content)
-	cronUserMsg.Timestamp = msg.Time
-	cronUserMsg.DisplayOnly = true
-	if err := tenantSession.AddMessage(cronUserMsg); err != nil {
-		log.Ctx(ctx).WithError(err).Warn("Failed to persist cron user message")
-	}
-
-	if assistantContent != "" {
-		cronAssistantMsg := llm.NewAssistantMessage(assistantContent)
-		cronAssistantMsg.DisplayOnly = true
-		if err := tenantSession.AddMessage(cronAssistantMsg); err != nil {
-			log.Ctx(ctx).WithError(err).Warn("Failed to persist cron assistant message")
-		}
-	}
-
-	log.Ctx(ctx).WithFields(log.Fields{
-		"channel": msg.Channel,
-		"chat_id": msg.ChatID,
-	}).Debug("Cron messages persisted to session")
 }
 
 // buildPrompt 构建完整的 LLM 消息列表（共用逻辑：processMessage 和 handlePromptQuery 都调用）。
@@ -2647,7 +2547,6 @@ func (a *Agent) injectInbound(channel, chatID, senderID, content string) {
 		ChatID:    chatID,
 		Content:   content,
 		Time:      time.Now(),
-		IsCron:    false,
 		RequestID: log.NewRequestID(),
 	}
 	select {
@@ -2671,7 +2570,6 @@ func (a *Agent) injectEventMessage(msg event.Message) {
 		ChatID:       msg.ChatID,
 		Content:      msg.Content,
 		Time:         time.Now(),
-		IsCron:       false,
 		RequestID:    log.NewRequestID(),
 		EventSource:  msg.EventSource,
 		EventTrigger: msg.EventTrigger,
@@ -2754,6 +2652,26 @@ func (a *Agent) processBgNotification(task *tools.BackgroundTask) {
 	}).Info("Bg task notification: injecting as user message")
 
 	a.injectBgUserMessage(channelName, chatID, task.SenderID(), content)
+}
+
+// processCronFiredNotification handles a cron fired notification when no Run() is active.
+// It parses the session key and injects the cron message as a user message via injectBgUserMessage.
+func (a *Agent) processCronFiredNotification(c *tools.CronFired) {
+	parts := strings.SplitN(c.SessionKey(), ":", 2)
+	if len(parts) != 2 {
+		log.WithField("session_key", c.SessionKey()).Warn("CronFired notification: invalid session key")
+		return
+	}
+	channelName, chatID := parts[0], parts[1]
+	content := fmt.Sprintf("⏰ [定时任务触发] %s", c.Message)
+
+	log.WithFields(log.Fields{
+		"channel": channelName,
+		"chat_id": chatID,
+		"message": tools.Truncate(c.Message, 80),
+	}).Info("CronFired notification: injecting as user message")
+
+	a.injectBgUserMessage(channelName, chatID, c.SenderID(), content)
 }
 
 // processSubAgentBgNotification handles a bg subagent notification when no Run() is active.

--- a/agent/agent_process.go
+++ b/agent/agent_process.go
@@ -139,6 +139,8 @@ func (a *Agent) drainAndProcessNotifications(sessionKey string) {
 			a.processBgNotification(n)
 		case *tools.SubAgentBgNotify:
 			a.processSubAgentBgNotification(n)
+		case *tools.CronFired:
+			a.processCronFiredNotification(n)
 		}
 	}
 }

--- a/agent/bg_notify_test.go
+++ b/agent/bg_notify_test.go
@@ -552,3 +552,202 @@ func requireEventual(t *testing.T, timeout, interval time.Duration, check func()
 		time.Sleep(interval)
 	}
 }
+
+// ==================== CronFired Notification ====================
+
+// TestDrainAndProcessNotifications_CronFired verifies that drainAndProcessNotifications
+// processes a CronFired notification and injects it into bus.Inbound with the ⏰ prefix.
+func TestDrainAndProcessNotifications_CronFired(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := tools.NewBackgroundTaskManager()
+	a := &Agent{
+		bus:       bus.NewMessageBus(),
+		agentCtx:  ctx,
+		bgTaskMgr: mgr,
+	}
+
+	// Buffer a CronFired notification
+	cronNotif := &tools.CronFired{
+		Key:     "cli:test-chat",
+		Sid:     "user-1",
+		Message: "check server status",
+	}
+	a.bgRunPendingMu.Lock()
+	a.bgRunPending = append(a.bgRunPending, cronNotif)
+	a.bgRunPendingMu.Unlock()
+
+	a.drainAndProcessNotifications("cli:test-chat")
+
+	select {
+	case msg := <-a.bus.Inbound:
+		if msg.ChatID != "test-chat" {
+			t.Errorf("ChatID = %q, want %q", msg.ChatID, "test-chat")
+		}
+		if msg.Channel != "cli" {
+			t.Errorf("Channel = %q, want %q", msg.Channel, "cli")
+		}
+		// Must have the ⏰ prefix from processCronFiredNotification
+		if !containsPrefix(msg.Content, "⏰") {
+			t.Errorf("Content should contain ⏰ prefix, got: %q", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainAndProcessNotifications should have injected CronFired into bus.Inbound")
+	}
+
+	// Verify nothing left in bgRunPending
+	a.bgRunPendingMu.Lock()
+	remaining := a.bgRunPending
+	a.bgRunPendingMu.Unlock()
+	if len(remaining) != 0 {
+		t.Errorf("bgRunPending should be empty after draining, got %d items", len(remaining))
+	}
+}
+
+// TestBgNotifyLoop_CronFired_BuffersAndSignals verifies that CronFired goes through
+// the bgNotifyLoop buffering pipeline (not processed directly) and signals the session.
+func TestBgNotifyLoop_CronFired_BuffersAndSignals(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := tools.NewBackgroundTaskManager()
+	a := &Agent{
+		bus:       bus.NewMessageBus(),
+		agentCtx:  ctx,
+		bgTaskMgr: mgr,
+	}
+
+	chatKey := "cli:test-chat"
+
+	// Register a bgSessionState (as chatWorker would)
+	ss := &bgSessionState{notifyCh: make(chan struct{}, 1)}
+	a.bgSessionStates.Store(chatKey, ss)
+	defer a.bgSessionStates.Delete(chatKey)
+
+	// Start bgNotifyLoop
+	go a.bgNotifyLoop()
+
+	// Send a CronFired through NotifyCh
+	mgr.SendCronFired(&tools.CronFired{
+		Key:     chatKey,
+		Sid:     "user-1",
+		Message: "run backups",
+	})
+
+	// Wait for the notification to be signaled
+	select {
+	case <-ss.notifyCh:
+		// Got signal — bgNotifyLoop buffered and signaled
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for notification signal — bgNotifyLoop didn't buffer CronFired")
+	}
+
+	// Verify notification is in bgRunPending (not processed directly)
+	a.bgRunPendingMu.Lock()
+	pending := a.bgRunPending
+	a.bgRunPendingMu.Unlock()
+
+	if len(pending) == 0 {
+		t.Fatal("bgRunPending should have the CronFired notification")
+	}
+
+	// Verify it's actually a CronFired
+	found := false
+	for _, n := range pending {
+		if cf, ok := n.(*tools.CronFired); ok {
+			if cf.Message == "run backups" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("bgRunPending should contain the CronFired notification with correct message")
+	}
+
+	// Nothing should have been sent to bus.Inbound (no direct processing)
+	select {
+	case <-a.bus.Inbound:
+		t.Fatal("bgNotifyLoop should NOT have sent anything to bus.Inbound — only buffers")
+	default:
+		// Correct — nothing was injected directly
+	}
+}
+
+// TestDrainAndProcessNotifications_MixedTypes verifies that drainAndProcessNotifications
+// handles both bg task completions and CronFired notifications in the same drain cycle.
+func TestDrainAndProcessNotifications_MixedTypes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := tools.NewBackgroundTaskManager()
+	a := &Agent{
+		bus:       bus.NewMessageBus(),
+		agentCtx:  ctx,
+		bgTaskMgr: mgr,
+	}
+
+	chatKey := "cli:test-chat"
+
+	// Start a bg task — it will complete immediately
+	_ = mgr.Start(chatKey, "user-1", "echo hello", func(ctx context.Context, outputBuf func(string)) (int, error) {
+		outputBuf("hello output")
+		return 0, nil
+	})
+
+	// Collect the bg task notification
+	var bgNotif tools.BgNotification
+	select {
+	case bgNotif = <-mgr.NotifyCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for bg task notification")
+	}
+
+	// Buffer both bg task and CronFired notifications
+	cronNotif := &tools.CronFired{
+		Key:     chatKey,
+		Sid:     "user-1",
+		Message: "check health",
+	}
+	a.bgRunPendingMu.Lock()
+	a.bgRunPending = append(a.bgRunPending, bgNotif, cronNotif)
+	a.bgRunPendingMu.Unlock()
+
+	a.drainAndProcessNotifications(chatKey)
+
+	// Should receive 2 messages in bus.Inbound
+	var msgs []bus.InboundMessage
+	timeout := time.After(2 * time.Second)
+	for len(msgs) < 2 {
+		select {
+		case msg := <-a.bus.Inbound:
+			msgs = append(msgs, msg)
+		case <-timeout:
+			t.Fatalf("expected 2 messages in bus.Inbound, got %d", len(msgs))
+		}
+	}
+
+	// One should be a cron message (⏰ prefix), one should be a bg task message
+	hasCron := false
+	hasBgTask := false
+	for _, msg := range msgs {
+		if containsPrefix(msg.Content, "⏰") {
+			hasCron = true
+		} else {
+			hasBgTask = true
+		}
+	}
+	if !hasCron {
+		t.Error("expected one message with ⏰ prefix (cron)")
+	}
+	if !hasBgTask {
+		t.Error("expected one message without ⏰ prefix (bg task)")
+	}
+
+	t.Logf("SUCCESS: both bg task and CronFired notifications processed in mixed drain")
+}
+
+// containsPrefix checks if s starts with the given prefix string.
+func containsPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/agent/engine_run.go
+++ b/agent/engine_run.go
@@ -1243,6 +1243,8 @@ func (s *runState) postToolProcessing(ctx context.Context, response *llm.LLMResp
 				s.injectBgTaskNotification(ctx, iteration, n)
 			case *tools.SubAgentBgNotify:
 				s.injectSubAgentBgNotification(ctx, iteration, n)
+			case *tools.CronFired:
+				s.injectCronFiredNotification(ctx, iteration, n)
 			}
 		}
 	}
@@ -1369,6 +1371,51 @@ func (s *runState) injectSubAgentBgNotification(ctx context.Context, iteration i
 		s.structuredProgress.CompletedTools = append(s.structuredProgress.CompletedTools, ToolProgress{
 			Name:      toolName,
 			Label:     fmt.Sprintf("bgsub:%s/%s", n.Role, n.Instance),
+			Status:    ToolDone,
+			Iteration: iteration,
+		})
+		if s.autoNotify {
+			s.notifyProgress("")
+		}
+	}
+}
+
+// injectCronFiredNotification injects a cron fired notification as a synthetic tool call/result pair.
+// Cron messages are injected as tool results so the LLM can act on them during the current Run.
+func (s *runState) injectCronFiredNotification(ctx context.Context, iteration int, c *tools.CronFired) {
+	bgContent := fmt.Sprintf("⏰ A scheduled cron job has fired.\n\nMessage: %s", c.Message)
+	toolName := "cron_fired"
+	toolID := "cron_" + c.SessionKey()
+	assistantMsg := llm.ChatMessage{
+		Role:    "assistant",
+		Content: "A scheduled cron job has fired. Let me process it.",
+		ToolCalls: []llm.ToolCall{{
+			ID:   toolID,
+			Name: toolName,
+		}},
+	}
+	if s.cfg.OffloadStore != nil {
+		if offloaded, ok := s.cfg.OffloadStore.MaybeOffload(ctx, s.offloadSessionKey, toolName, "", bgContent, s.cfg.WorkspaceRoot, "", s.cfg.OriginUserID); ok {
+			bgContent = offloaded.Summary
+			GlobalMetrics.OffloadEvents.Add(1)
+			GlobalMetrics.OffloadedItems.Add(1)
+		}
+	}
+	toolMsg := llm.NewToolMessage(toolName, toolID, "", bgContent)
+	s.messages = s.syncMessages(append(s.messages, assistantMsg, toolMsg))
+	log.Ctx(ctx).WithField("session_key", c.SessionKey()).Info("Injected cron fired notification into Run loop")
+
+	if s.cfg.Session != nil {
+		_ = s.cfg.Session.AddMessage(assistantMsg)
+		_ = s.cfg.Session.AddMessage(toolMsg)
+		s.persistence.MarkAllPersisted(len(s.messages))
+	}
+
+	// Show in TUI progress block
+	if s.structuredProgress != nil {
+		s.structuredProgress.CompletedTools = append(s.structuredProgress.CompletedTools, ToolProgress{
+			Name:      toolName,
+			Label:     "cron",
 			Status:    ToolDone,
 			Iteration: iteration,
 		})

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -372,19 +372,6 @@ func (a *Agent) buildMainRunConfig(
 	return cfg
 }
 
-// buildCronRunConfig 为 Cron 消息构建 RunConfig。
-// Cron 消息不需要自动压缩、进度通知、session 持久化。
-func (a *Agent) buildCronRunConfig(
-	_ context.Context,
-	msg bus.InboundMessage,
-	messages []llm.ChatMessage,
-) RunConfig {
-	channel, chatID, senderID := msg.Channel, msg.ChatID, msg.SenderID
-
-	cfg, _ := a.buildBaseRunConfig(channel, chatID, senderID, messages, "", senderID)
-	return cfg
-}
-
 // buildSubAgentRunConfig 为 SubAgent 构建 RunConfig。
 // SubAgent 使用独立工具集、无 session、有压缩（独立 ContextManager）、无进度通知。
 // Phase 2: SubAgent 通过 RunConfig 继承父 Agent 的工作区配置，

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -16,7 +16,7 @@ type MessagePayload struct {
 
 	Metadata  map[string]string `json:"metadata,omitempty"`
 	Time      time.Time         `json:"time"`
-	IsCron    bool              `json:"is_cron,omitempty"`
+	IsCron    bool              `json:"is_cron,omitempty"` // Deprecated: cron now uses same pipeline as regular messages
 	RequestID string            `json:"request_id,omitempty"`
 
 	EventSource  string `json:"event_source,omitempty"`
@@ -78,7 +78,7 @@ type InboundMessage struct {
 	// === 元数据 ===
 	Metadata  map[string]string // 渠道/调用方特定元数据
 	Time      time.Time
-	IsCron    bool   // 是否由 cron 定时任务触发
+	IsCron    bool   // Deprecated: cron now uses same pipeline as regular messages. Kept for backward compat.
 	RequestID string // 请求追踪 ID（UUID 无横线），在渠道收到消息时生成
 
 	// Event-triggered metadata (generalization beyond IsCron)

--- a/cron/scheduler.go
+++ b/cron/scheduler.go
@@ -10,17 +10,26 @@ import (
 	"xbot/storage/sqlite"
 )
 
-// InjectFunc is the function type for injecting messages into the agent
+// InjectFunc is the function type for injecting messages into the agent.
+// Deprecated: use NotifyCronFunc for the unified bg notification pipeline.
 type InjectFunc func(channel, chatID, senderID, content string)
 
-// Scheduler manages the cron job scheduling loop
+// NotifyCronFunc pushes a cron fired notification into the background notification
+// pipeline (BgTaskManager.NotifyCh). When set, cron triggers reuse the same
+// busy/idle routing as bg task completions.
+type NotifyCronFunc func(channel, chatID, senderID, message string)
+
+// Scheduler manages the cron job scheduling loop.
+// Cron jobs are fired via NotifyCronFunc through the bg notification pipeline,
+// reusing the same routing as bg task completions (busy → tool message, idle → user message).
 type Scheduler struct {
-	cronSvc    *sqlite.CronService
-	injectFunc InjectFunc
-	stopCh     chan struct{}
-	once       sync.Once // 共用 once 保证 Start 和 StartDelayed 互斥：只有第一个调用者会启动调度器
-	running    bool
-	mu         sync.Mutex
+	cronSvc      *sqlite.CronService
+	injectFunc   InjectFunc     // deprecated, kept for tests
+	notifyCronFn NotifyCronFunc // preferred: unified bg notification pipeline
+	stopCh       chan struct{}
+	once         sync.Once
+	running      bool
+	mu           sync.Mutex
 }
 
 // NewScheduler creates a new Scheduler
@@ -36,6 +45,15 @@ func (s *Scheduler) SetInjectFunc(fn InjectFunc) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.injectFunc = fn
+}
+
+// SetNotifyCronFunc sets the function that pushes cron notifications into the
+// bg notification pipeline. When set, cron triggers reuse the same busy/idle
+// routing as bg task completions.
+func (s *Scheduler) SetNotifyCronFunc(fn NotifyCronFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.notifyCronFn = fn
 }
 
 // Start starts the scheduler loop
@@ -174,10 +192,11 @@ func (s *Scheduler) runLoop() {
 // checkAndFire checks for due jobs and fires them
 func (s *Scheduler) checkAndFire(now time.Time) {
 	s.mu.Lock()
+	notifyCronFn := s.notifyCronFn
 	injectFunc := s.injectFunc
 	s.mu.Unlock()
 
-	if injectFunc == nil {
+	if notifyCronFn == nil && injectFunc == nil {
 		return
 	}
 
@@ -188,21 +207,14 @@ func (s *Scheduler) checkAndFire(now time.Time) {
 	}
 
 	for _, job := range jobs {
-		// Skip jobs not yet due
 		if now.Before(job.NextRun) {
 			continue
 		}
 
-		// Skip one-shot jobs that were already fired (LastTrigger is set).
-		// One-shot jobs with NextRun in the past and no LastTrigger were never
-		// executed (e.g. missed during downtime) — they should fall through to
-		// the firing logic below, not be silently removed.
 		if job.OneShot && job.LastTrigger != nil {
 			continue
 		}
 
-		// Prevent double-firing: check if this job was already triggered very recently
-		// This handles edge cases where the job runs again within the same second
 		if job.LastTrigger != nil && now.Sub(*job.LastTrigger) < time.Second {
 			log.WithFields(log.Fields{
 				"job_id":       job.ID,
@@ -211,14 +223,17 @@ func (s *Scheduler) checkAndFire(now time.Time) {
 			continue
 		}
 
-		// Fire the job
 		log.WithFields(log.Fields{
 			"job_id":  job.ID,
 			"channel": job.Channel,
 			"chat_id": job.ChatID,
 		}).Info("Cron job fired")
 
-		injectFunc(job.Channel, job.ChatID, job.SenderID, job.Message)
+		if notifyCronFn != nil {
+			notifyCronFn(job.Channel, job.ChatID, job.SenderID, job.Message)
+		} else {
+			injectFunc(job.Channel, job.ChatID, job.SenderID, job.Message)
+		}
 
 		// Record trigger time for deduplication
 		if err := s.cronSvc.UpdateLastTrigger(job.ID, now); err != nil {

--- a/tools/task_manager.go
+++ b/tools/task_manager.go
@@ -556,6 +556,23 @@ func (n *SubAgentBgNotify) SessionKey() string { return n.Key }
 // SenderID implements BgNotification.
 func (n *SubAgentBgNotify) SenderID() string { return n.Sid }
 
+// CronFired is a background notification for cron job triggers.
+// Implements BgNotification so it flows through the same NotifyCh → bgNotifyLoop
+// → bgRunPending → drain pipeline as bg task completions.
+// This unifies cron and bg task injection: both respect the busy/idle split
+// (busy → tool message, idle → user message with immediate TUI display).
+type CronFired struct {
+	Key     string // channel:chatID for routing
+	Sid     string // original user ID that created the cron job
+	Message string // cron job message (the prompt to execute)
+}
+
+// SessionKey implements BgNotification.
+func (c *CronFired) SessionKey() string { return c.Key }
+
+// SenderID implements BgNotification.
+func (c *CronFired) SenderID() string { return c.Sid }
+
 // SendSubAgentNotify sends a subagent notification through BgTaskManager.NotifyCh.
 // Safe to call from any goroutine. Drops silently if channel is full or closed.
 func (m *BackgroundTaskManager) SendSubAgentNotify(n *SubAgentBgNotify) {
@@ -573,6 +590,22 @@ func (m *BackgroundTaskManager) SendSubAgentNotify(n *SubAgentBgNotify) {
 			"instance": n.Instance,
 			"type":     n.Type,
 		}).Warn("Bg subagent notify channel full, dropping notification")
+	}
+}
+
+// SendCronFired sends a cron fired notification through BgTaskManager.NotifyCh.
+// Safe to call from any goroutine. Drops silently if channel is full or closed.
+func (m *BackgroundTaskManager) SendCronFired(c *CronFired) {
+	if m.NotifyCh == nil {
+		return
+	}
+	defer func() {
+		recover()
+	}()
+	select {
+	case m.NotifyCh <- c:
+	default:
+		log.WithField("key", c.Key).Warn("Cron fired notify channel full, dropping notification")
 	}
 }
 


### PR DESCRIPTION
## Summary

Unifies cron triggers and bg task completions into a single notification pipeline, eliminating the architectural divergence that caused the asyncCh race condition.

## Changes

### Core: CronFired notification type (`tools/task_manager.go`)
- `CronFired` implements `BgNotification` interface
- `SendCronFired()` method pushes through `NotifyCh`
- Flows through same `bgNotifyLoop → bgRunPending → drain` as bg tasks

### Cron scheduler (`cron/scheduler.go`)
- New `NotifyCronFunc` type + `SetNotifyCronFunc()` method
- `checkAndFire()` uses `notifyCronFn` (preferred) with `injectFunc` as fallback for tests

### Agent wiring (`agent/agent.go`)
- Replaces `SetInjectFunc` with `SetNotifyCronFunc` that sends `CronFired` through `bgTaskMgr.SendCronFired()`
- Removes `processCronMessage()` — cron no longer has separate processing path
- Removes `persistCronMessages()` — cron uses same persistence as regular messages
- Removes `IsCron` bypass check in `processMessage()`
- Adds `processCronFiredNotification()` — formats cron message with `⏰ [定时任务触发]` prefix

### Engine (`engine_run.go`, `engine_wire.go`)
- Adds `CronFired` case in `DrainBgNotifications` switch (busy path)
- Adds `injectCronFiredNotification()` on `runState` (tool message injection during Run)
- Removes `buildCronRunConfig()` (unused after unification)

### Bus (`bus/bus.go`)
- `IsCron` field marked deprecated

### Tests (`agent/bg_notify_test.go`)
- `TestDrainAndProcessNotifications_CronFired` — verifies CronFired drains correctly
- `TestBgNotifyLoop_CronFired_BuffersAndSignals` — verifies buffer-and-signal (no direct processing)
- `TestDrainAndProcessNotifications_MixedTypes` — verifies bg task + CronFired mixed drain

## Unified routing (both bg tasks and cron)

| State | Behavior |
|-------|----------|
| **Busy** (Run active) | Injected as tool message in Run loop via `DrainBgNotifications` |
| **Idle** (no Run) | Injected as user message via `injectBgUserMessage` → immediate TUI display |

## Test plan
- [x] `go build ./...` — passes
- [x] `go test ./... -count=1` — all 23 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] 3 new CronFired regression tests pass