### PR TITLE
fix(db): enable foreign keys, clean orphaned data, add periodic cleanup

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -322,6 +322,9 @@ type Agent struct {
 	// maskStore manages observation masking storage
 	maskStore *ObservationMaskStore
 
+	// cleanupStopCh signals the periodic cleanup goroutine to stop
+	cleanupStopCh chan struct{}
+
 	// contextEditor 管理上下文编辑（Context Editing 工具）
 	contextEditor *ContextEditor
 
@@ -871,7 +874,6 @@ func initServices(a *Agent, cfg Config, multiSession *session.MultiTenantSession
 		MaxResultBytes:  10240,
 		CleanupAgeDays:  7,
 	})
-	go a.offloadStore.CleanStale()
 
 	// Inject sandbox into OffloadStore for remote mode file hash computation
 	if a.sandbox != nil {
@@ -888,7 +890,11 @@ func initServices(a *Agent, cfg Config, multiSession *session.MultiTenantSession
 	}
 	a.maskStore = NewObservationMaskStore(200)
 	a.maskStore.SetBaseDir(maskDir)
-	go a.maskStore.CleanStale(7)
+
+	// Start periodic cleanup for offload and mask data.
+	// Runs immediately at startup, then every 6 hours.
+	a.cleanupStopCh = make(chan struct{})
+	go a.periodicCleanup()
 
 	// 注册 offload_recall 工具（需要 OffloadStore 依赖注入）
 	if a.offloadStore != nil {
@@ -1382,6 +1388,11 @@ func (a *Agent) Close() error {
 	// Cancel agent-level context to stop background subagents
 	if a.agentCancel != nil {
 		a.agentCancel()
+	}
+	// Stop periodic cleanup goroutine
+	if a.cleanupStopCh != nil {
+		close(a.cleanupStopCh)
+		a.cleanupStopCh = nil
 	}
 	// Deactivate all plugins before shutting down subsystems
 	if a.pluginMgr != nil {
@@ -2825,6 +2836,44 @@ func (a *Agent) ProcessDirect(ctx context.Context, content string) (string, erro
 		return "", nil
 	}
 	return resp.Content, nil
+}
+
+// CleanupSessionFiles removes offload data for a session identified by (channel, chatID).
+// Called from delete_chat RPC handler and CLI session deletion to ensure disk-stored
+// offload data is cleaned when a session is removed from DB.
+// Mask data cleanup relies on the periodic CleanStale timer which removes dirs
+// older than 7 days (mask dirs are keyed by numeric tenant ID, not session key).
+func (a *Agent) CleanupSessionFiles(channel, chatID string) {
+	sessionKey := qualifyChatID(channel, chatID)
+	if a.offloadStore != nil {
+		a.offloadStore.CleanSession(sessionKey)
+	}
+}
+
+// periodicCleanup runs offload and mask stale cleanup on a 6-hour ticker.
+// Runs once immediately at startup, then periodically until cleanupStopCh is closed.
+func (a *Agent) periodicCleanup() {
+	a.doCleanup()
+	ticker := time.NewTicker(6 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-a.cleanupStopCh:
+			return
+		case <-ticker.C:
+			a.doCleanup()
+		}
+	}
+}
+
+// doCleanup runs stale cleanup for offload and mask stores.
+func (a *Agent) doCleanup() {
+	if a.offloadStore != nil {
+		a.offloadStore.CleanStale()
+	}
+	if a.maskStore != nil {
+		a.maskStore.CleanStale(7)
+	}
 }
 
 // formatToolProgress generates a human-readable one-line summary of a tool call for progress display.

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -265,7 +265,8 @@ func (a *Agent) wireSubAgentCLIProgress(key, originChatID string, cfg *RunConfig
 }
 
 // destroyInteractiveSession removes all resources for an interactive SubAgent session:
-// interactiveSubAgents entry, progress snapshot/iteration history, and tenant session (DB).
+// interactiveSubAgents entry, progress snapshot/iteration history, tenant session (DB),
+// offload data, and mask data on disk.
 // This ensures the next SubAgent with the same role/instance starts with a clean slate.
 func (a *Agent) destroyInteractiveSession(key string) {
 	// Auto-cleanup group membership: remove this agent from its group,
@@ -283,6 +284,15 @@ func (a *Agent) destroyInteractiveSession(key string) {
 	agentProgressKey := "agent:" + key
 	a.lastProgressSnapshot.Delete(agentProgressKey)
 	a.iterationHistories.Delete(agentProgressKey)
+
+	// Clean up offload data for this agent session.
+	// The session key format matches qualifyChatID("agent", key) = "agent:key".
+	offloadKey := qualifyChatID("agent", key)
+	if a.offloadStore != nil {
+		a.offloadStore.CleanSession(offloadKey)
+	}
+	// Note: mask cleanup is handled by CleanStale periodic timer — mask dirs are keyed by
+	// numeric tenant ID which is not available here. CleanStale removes dirs older than 7 days.
 
 	// Destroy tenant session (cache + DB with CASCADE to messages)
 	if a.multiSession != nil {

--- a/serverapp/rpc_table.go
+++ b/serverapp/rpc_table.go
@@ -741,6 +741,8 @@ func registerSessionHandlers(t RPCTable, h *RPCContext) {
 		} else {
 			return nil, fmt.Errorf("database not available")
 		}
+		// Clean up offload files for the deleted session.
+		h.Ag.CleanupSessionFiles(p.Channel, p.ChatID)
 		log.WithFields(log.Fields{"channel": p.Channel, "chat_id": p.ChatID}).Info("RPC delete_chat")
 		return map[string]string{"status": "ok"}, nil
 	})

--- a/storage/sqlite/core_memory_test.go
+++ b/storage/sqlite/core_memory_test.go
@@ -5,6 +5,22 @@ import (
 	"testing"
 )
 
+// ensureTenants inserts tenant rows for the given IDs so foreign key constraints are satisfied.
+// Only needed in tests that use synthetic tenant IDs.
+func ensureTenants(t *testing.T, db *DB, tenantIDs ...int64) {
+	t.Helper()
+	conn := db.Conn()
+	for _, id := range tenantIDs {
+		_, err := conn.Exec(
+			"INSERT OR IGNORE INTO tenants (id, channel, chat_id, created_at, last_active_at) VALUES (?, 'test', ?, datetime('now'), datetime('now'))",
+			id, id,
+		)
+		if err != nil {
+			t.Fatalf("Failed to create tenant %d: %v", id, err)
+		}
+	}
+}
+
 // TestCoreMemoryService_PersonaPerTenant tests that persona is per-tenant isolated.
 // Each tenant/Agent/SubAgent has its own independent persona block.
 func TestCoreMemoryService_PersonaPerTenant(t *testing.T) {
@@ -19,6 +35,7 @@ func TestCoreMemoryService_PersonaPerTenant(t *testing.T) {
 
 	tenantID1 := int64(100)
 	tenantID2 := int64(200)
+	ensureTenants(t, db, 0, tenantID1, tenantID2)
 
 	// Initialize both tenants
 	if err := svc.InitBlocks(tenantID1, ""); err != nil {
@@ -81,6 +98,7 @@ func TestCoreMemoryService_HumanCrossTenant(t *testing.T) {
 	tenantID1 := int64(100)
 	tenantID2 := int64(200)
 	userID := "ou_123"
+	ensureTenants(t, db, 0, tenantID1, tenantID2)
 
 	// Initialize both tenants
 	if err := svc.InitBlocks(tenantID1, userID); err != nil {
@@ -131,6 +149,7 @@ func TestCoreMemoryService_WorkingContextPerTenant(t *testing.T) {
 
 	tenantID1 := int64(100)
 	tenantID2 := int64(200)
+	ensureTenants(t, db, 0, tenantID1, tenantID2)
 
 	// Initialize both tenants
 	if err := svc.InitBlocks(tenantID1, ""); err != nil {
@@ -189,6 +208,7 @@ func TestCoreMemoryService_ReadWriteConsistency(t *testing.T) {
 
 	tenantID := int64(100)
 	userID := "ou_123"
+	ensureTenants(t, db, 0, tenantID)
 
 	if err := svc.InitBlocks(tenantID, userID); err != nil {
 		t.Fatalf("InitBlocks failed: %v", err)
@@ -248,6 +268,7 @@ func TestCoreMemoryService_DefaultBlocks(t *testing.T) {
 
 	tenantID := int64(100)
 	userID := "ou_123"
+	ensureTenants(t, db, 0, tenantID)
 
 	if err := svc.InitBlocks(tenantID, userID); err != nil {
 		t.Fatalf("InitBlocks failed: %v", err)
@@ -291,6 +312,7 @@ func TestCoreMemoryService_CharLimit(t *testing.T) {
 	svc := NewCoreMemoryService(db)
 
 	tenantID := int64(100)
+	ensureTenants(t, db, 0, tenantID)
 
 	if err := svc.InitBlocks(tenantID, ""); err != nil {
 		t.Fatalf("InitBlocks failed: %v", err)
@@ -322,6 +344,7 @@ func TestCoreMemoryService_DifferentUsersDifferentHuman(t *testing.T) {
 	tenantID := int64(100)
 	userID1 := "ou_123"
 	userID2 := "ou_456"
+	ensureTenants(t, db, 0, tenantID)
 
 	// Initialize for both users
 	if err := svc.InitBlocks(tenantID, userID1); err != nil {
@@ -371,6 +394,9 @@ func TestCoreMemoryService_MigrationKeepsLongestHuman(t *testing.T) {
 	defer db.Close()
 
 	conn := db.Conn()
+
+	// Create parent tenants for foreign key constraints
+	ensureTenants(t, db, 0, 1, 2, 100)
 
 	// Create table manually (simulating old schema)
 	_, err = conn.Exec(`
@@ -490,6 +516,9 @@ func TestCoreMemoryService_PersonaFallbackFromTenant0(t *testing.T) {
 	defer db.Close()
 
 	conn := db.Conn()
+
+	// Create parent tenants for foreign key constraints (0 = shared, 200 = per-tenant)
+	ensureTenants(t, db, 0, 5, 200)
 
 	// Manually create table and insert persona at tenantID=0 (simulates legacy v1 state)
 	_, err = conn.Exec(`

--- a/storage/sqlite/db.go
+++ b/storage/sqlite/db.go
@@ -22,7 +22,7 @@ type DB struct {
 	mu   sync.RWMutex
 }
 
-const schemaVersion = 32
+const schemaVersion = 33
 
 // Open opens or creates a SQLite database at the given path
 // If the database doesn't exist, it will be created with the required schema
@@ -53,6 +53,13 @@ func Open(path string) (*DB, error) {
 	if _, err := conn.Exec("PRAGMA busy_timeout=5000"); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("set busy_timeout: %w", err)
+	}
+	// 启用外键约束：确保 ON DELETE CASCADE 生效。
+	// SQLite 默认关闭外键约束，导致 DeleteTenant 时关联数据不被级联删除，
+	// 造成 session_messages 等表大量孤儿数据膨胀。
+	if _, err := conn.Exec("PRAGMA foreign_keys=ON"); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("enable foreign keys: %w", err)
 	}
 
 	db := &DB{

--- a/storage/sqlite/migrations.go
+++ b/storage/sqlite/migrations.go
@@ -138,6 +138,15 @@ func (db *DB) migrateSchema(from int) error {
 		}
 	}
 
+	// v33: clean orphaned rows from tables with foreign keys to tenants.
+	// Before this version, PRAGMA foreign_keys was OFF, so ON DELETE CASCADE never fired.
+	// This migration removes all orphaned data and then VACUUMs to reclaim disk space.
+	if from < 33 {
+		if err := migrateV32ToV33(db.Conn()); err != nil {
+			return fmt.Errorf("migrate to v33: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -1044,5 +1053,79 @@ func migrateV31ToV32(conn *sql.DB) error {
 		return fmt.Errorf("update schema version: %w", err)
 	}
 	log.Info("Database migrated to v32: added per_model_configs to user_llm_subscriptions")
+	return nil
+}
+
+// orphanTables lists all tables that have a tenant_id foreign key to tenants(id).
+// Used by migrateV32ToV33 to clean up orphaned rows left by disabled foreign keys.
+var orphanTables = []string{
+	"session_messages",
+	"tenant_state",
+	"core_memory_blocks",
+	"long_term_memory",
+	"event_history",
+	"archival_memory",
+}
+
+// migrateV32ToV33 cleans orphaned rows from all tables with foreign keys to tenants.
+// Before v33, PRAGMA foreign_keys was OFF, so ON DELETE CASCADE never fired when tenants
+// were deleted. This left behind orphaned rows (tenant_id pointing to non-existent tenants)
+// that accumulated over time, sometimes comprising 77%+ of total rows in session_messages.
+//
+// The migration:
+//  1. Deletes all orphaned rows from FK-linked tables.
+//  2. Runs VACUUM to reclaim the freed disk space back to the OS.
+//  3. Enables foreign_keys pragma for the current connection (also set in Open() for future).
+func migrateV32ToV33(conn *sql.DB) error {
+	// Enable foreign keys so CASCADE works for future deletes.
+	if _, err := conn.Exec("PRAGMA foreign_keys=ON"); err != nil {
+		return fmt.Errorf("enable foreign keys: %w", err)
+	}
+
+	// Ensure the shared tenant (id=0) exists for core_memory human blocks.
+	// Human blocks are stored at tenant_id=0 as shared cross-tenant data.
+	// Without this row, FK constraints on core_memory_blocks would block
+	// any InitBlocks call that creates human blocks.
+	conn.Exec("INSERT OR IGNORE INTO tenants (id, channel, chat_id, created_at, last_active_at) VALUES (0, '_shared', '_shared', datetime('now'), datetime('now'))")
+
+	// Clean orphaned rows from each FK-linked table.
+	totalOrphans := 0
+	for _, table := range orphanTables {
+		result, err := conn.Exec(
+			fmt.Sprintf("DELETE FROM %s WHERE tenant_id NOT IN (SELECT id FROM tenants)", table),
+		)
+		if err != nil {
+			// Table might not exist in older DBs; skip silently.
+			log.WithError(err).WithField("table", table).Debug("Skipping orphan cleanup for table")
+			continue
+		}
+		rows, _ := result.RowsAffected()
+		if rows > 0 {
+			totalOrphans += int(rows)
+			log.WithFields(log.Fields{
+				"table":  table,
+				"orphan": rows,
+			}).Info("Cleaned orphaned rows from table")
+		}
+	}
+
+	// Also clean orphaned event_history_fts (virtual table matching event_history).
+	// FTS tables don't have FK constraints, but their rows mirror event_history orphans.
+	if _, err := conn.Exec("DELETE FROM event_history_fts WHERE rowid NOT IN (SELECT id FROM event_history)"); err != nil {
+		log.WithError(err).Debug("Skipping orphan cleanup for event_history_fts")
+	}
+
+	if totalOrphans > 0 {
+		log.WithField("total_orphans", totalOrphans).Info("Running VACUUM to reclaim disk space after orphan cleanup")
+		if _, err := conn.Exec("VACUUM"); err != nil {
+			// VACUUM failure is non-fatal: data is cleaned, just space not reclaimed.
+			log.WithError(err).Warn("VACUUM failed after orphan cleanup (space not reclaimed)")
+		}
+	}
+
+	if _, err := conn.Exec("UPDATE schema_version SET version = 33"); err != nil {
+		return fmt.Errorf("update schema version: %w", err)
+	}
+	log.WithField("orphan_rows_cleaned", totalOrphans).Info("Database migrated to v33: cleaned orphaned data, enabled foreign keys")
 	return nil
 }

--- a/storage/sqlite/tenant.go
+++ b/storage/sqlite/tenant.go
@@ -118,6 +118,7 @@ func (s *TenantService) ListTenants() ([]TenantInfo, error) {
 		`SELECT t.id, t.channel, t.chat_id, COALESCE(c.label, '') as label, t.created_at, t.last_active_at
 		FROM tenants t
 		LEFT JOIN user_chats c ON c.channel = t.channel AND c.chat_id = t.chat_id
+		WHERE t.channel != '_shared'
 		ORDER BY t.last_active_at DESC`,
 	)
 	if err != nil {


### PR DESCRIPTION
## Problem

`~/.xbot/xbot.db` had grown to **240 MB** with **77% orphaned data** (84,662 rows, 95 MB of `session_messages` pointing to deleted tenants). The root cause: `PRAGMA foreign_keys` was never enabled, making all `ON DELETE CASCADE` constraints a no-op.

### Audit findings

| Area | Size | Issue |
|------|------|-------|
| **xbot.db** | 240 MB | 84,662 orphaned session_messages (77% of total) |
| **offload_store/** | 275 MB | 39 orphaned dirs from deleted sessions |
| **logs/** | 457 MB | Normal (7-day rotation works) |
| **mask/** | 20 MB | 40 orphaned dirs |

## Changes

### P0: Enable `PRAGMA foreign_keys = ON`
- `storage/sqlite/db.go`: Added `PRAGMA foreign_keys=ON` to `Open()`
- Future `DeleteTenant` calls will cascade to `session_messages`, `tenant_state`, `core_memory_blocks`, etc.

### v33 Migration: Clean orphaned data
- `storage/sqlite/migrations.go`: New `migrateV32ToV33` deletes orphaned rows from 6 tables
- Runs `VACUUM` after cleanup to reclaim disk space (240 MB → ~30 MB expected)
- Creates shared tenant (id=0) for core_memory human blocks (FK requirement)

### Session deletion: clean offload files
- `agent/interactive.go`: `destroyInteractiveSession` now calls `offloadStore.CleanSession`
- `serverapp/rpc_table.go`: `delete_chat` RPC calls `Agent.CleanupSessionFiles`
- Mask cleanup handled by periodic CleanStale timer (dirs keyed by numeric tenant ID)

### Periodic cleanup (was one-shot at startup)
- `agent/agent.go`: Replaced `go offloadStore.CleanStale()` + `go maskStore.CleanStale(7)` with `periodicCleanup` ticker (6h interval)
- Graceful shutdown via `cleanupStopCh` closed in `Agent.Close()`

### Test fixes
- Added `ensureTenants` helper to create parent tenant rows (required by FK enforcement)
- Updated all core_memory tests to create tenant rows before InitBlocks
- `ListTenants` excludes internal `_shared` tenant from results

## Verification

```
go build ./...          # pass
golangci-lint run ./... # 0 issues
go test ./...           # all 24 packages pass
```

## Files changed (7 files, +185 / -4)

| File | Change |
|------|--------|
| `storage/sqlite/db.go` | +`PRAGMA foreign_keys=ON` |
| `storage/sqlite/migrations.go` | +v33 migration (orphan cleanup + VACUUM + shared tenant) |
| `storage/sqlite/tenant.go` | Exclude `_shared` from `ListTenants` |
| `storage/sqlite/core_memory_test.go` | +`ensureTenants` helper, fix all tests for FK |
| `agent/agent.go` | +`periodicCleanup`, +`CleanupSessionFiles`, +`cleanupStopCh` |
| `agent/interactive.go` | +offload cleanup in `destroyInteractiveSession` |
| `serverapp/rpc_table.go` | +offload cleanup in `delete_chat` handler |