### PR TITLE
feat: support project-local skills/agents discovery

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2326,8 +2326,14 @@ func (a *Agent) buildPrompt(ctx context.Context, msg bus.InboundMessage, tenantS
 		mc.CWD = promptWorkDir
 	}
 
-	mc.SetExtra(ExtraKeySkillsCatalog, a.skills.GetSkillsCatalog(ctx, msg.SenderID))
-	mc.SetExtra(ExtraKeyAgentsCatalog, a.agents.GetAgentsCatalog(ctx, msg.SenderID))
+	// Determine projectDir for project-local skill/agent scanning
+	projectDir := cwd // use session CWD as project root
+	if projectDir == "" {
+		projectDir = promptWorkDir
+	}
+
+	mc.SetExtra(ExtraKeySkillsCatalog, a.skills.GetSkillsCatalog(ctx, msg.SenderID, projectDir))
+	mc.SetExtra(ExtraKeyAgentsCatalog, a.agents.GetAgentsCatalog(ctx, msg.SenderID, projectDir))
 	mc.SetExtra(ExtraKeyMemoryProvider, tenantSession.Memory())
 	permUsers := a.settingsSvc.GetPermUsers(msg.Channel, msg.SenderID)
 	mc.SetExtra(ExtraKeyPermUsers, permUsers)

--- a/agent/agents.go
+++ b/agent/agents.go
@@ -35,11 +35,13 @@ func (s *AgentStore) userAgentsDir(senderID string) string {
 // GetAgentsCatalog returns a formatted catalog of all available agents for the system prompt.
 // Scans embedded agents first, then global agents, then user-private agents;
 // same-name agents are overridden by later sources (user > global > embedded).
-func (s *AgentStore) GetAgentsCatalog(ctx context.Context, senderID string) string {
+// projectDir is the session's workspace root; if non-empty, agents under {projectDir}/.xbot/agents/
+// are scanned as an additional layer (highest priority).
+func (s *AgentStore) GetAgentsCatalog(ctx context.Context, senderID string, projectDir ...string) string {
 	type agentInfo struct {
 		name string
 		role tools.SubAgentRole
-		dir  string // 定义文件所在目录："embed" / 全局目录 / 用户目录
+		dir  string // 定义文件所在目录："embed" / 全局目录 / 用户目录 / 项目目录
 	}
 
 	merged := make(map[string]agentInfo)
@@ -63,6 +65,16 @@ func (s *AgentStore) GetAgentsCatalog(ctx context.Context, senderID string) stri
 	sources := []string{s.globalDir}
 	if senderID != "" {
 		sources = append(sources, s.userAgentsDir(senderID))
+	}
+
+	// 3. 扫描项目本地目录（最高优先级）
+	pDir := ""
+	if len(projectDir) > 0 {
+		pDir = projectDir[0]
+	}
+	if pDir != "" {
+		projectAgentsDir := filepath.Join(pDir, ".xbot", "agents")
+		sources = append(sources, projectAgentsDir)
 	}
 
 	for i, dir := range sources {
@@ -114,6 +126,10 @@ func (s *AgentStore) GetAgentsCatalog(ctx context.Context, senderID string) stri
 	// 注入目录路径，供 agent-creator 参考新建位置
 	if s.globalDir != "" {
 		fmt.Fprintf(&sb, "**Agents 存储目录**: %s\n\n", s.globalDir)
+	}
+	// 注入项目本地目录提示
+	if pDir != "" {
+		fmt.Fprintf(&sb, "**项目 Agents 目录**: %s\n\n", filepath.Join(pDir, ".xbot", "agents"))
 	}
 
 	sb.WriteString("<available_agents>\n")

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -501,7 +501,7 @@ func (a *Agent) buildSubAgentRunConfig(
 
 	// 注入可用 agent 目录（只在 spawn_agent=true 时注入）
 	if caps.SpawnAgent {
-		if agentsCatalog := a.agents.GetAgentsCatalog(ctx, parentCtx.SenderID); agentsCatalog != "" {
+		if agentsCatalog := a.agents.GetAgentsCatalog(ctx, parentCtx.SenderID, workDir); agentsCatalog != "" {
 			sysPrompt += "\n" + agentsCatalog
 		}
 	}
@@ -511,7 +511,7 @@ func (a *Agent) buildSubAgentRunConfig(
 	if originUserID == "" {
 		originUserID = parentCtx.SenderID
 	}
-	if skillsCatalog := a.skills.GetSkillsCatalog(ctx, originUserID); skillsCatalog != "" {
+	if skillsCatalog := a.skills.GetSkillsCatalog(ctx, originUserID, workDir); skillsCatalog != "" {
 		sysPrompt += "\n" + skillsCatalog
 	}
 

--- a/agent/skills.go
+++ b/agent/skills.go
@@ -173,7 +173,9 @@ func (s *SkillStore) refreshSkills(ctx context.Context, senderID string) ([]Skil
 
 // GetSkillsCatalog returns a formatted catalog of all available skills for the system prompt.
 // The LLM uses the Read tool to load a skill's SKILL.md when the task matches its description.
-func (s *SkillStore) GetSkillsCatalog(ctx context.Context, senderID string) string {
+// projectDir is the session's workspace root; if non-empty, skills under {projectDir}/.xbot/skills/
+// are scanned as an additional layer (between global and user-private).
+func (s *SkillStore) GetSkillsCatalog(ctx context.Context, senderID string, projectDir ...string) string {
 	skills, err := s.ListSkills(ctx, senderID)
 	if err != nil {
 		log.WithError(err).Warn("Failed to list skills for catalog")
@@ -181,6 +183,16 @@ func (s *SkillStore) GetSkillsCatalog(ctx context.Context, senderID string) stri
 	}
 	if len(skills) == 0 {
 		return ""
+	}
+
+	// Scan project-local skills if projectDir is provided
+	var projectSkills []SkillInfo
+	pDir := ""
+	if len(projectDir) > 0 {
+		pDir = projectDir[0]
+	}
+	if pDir != "" {
+		projectSkills = s.scanProjectSkills(pDir, skills)
 	}
 
 	var sb strings.Builder
@@ -192,13 +204,68 @@ func (s *SkillStore) GetSkillsCatalog(ctx context.Context, senderID string) stri
 	if len(s.globalDirs) > 0 {
 		fmt.Fprintf(&sb, "**Skills 存储目录**: %s\n\n", s.globalDirs[0])
 	}
+	// 注入项目本地目录提示
+	if pDir != "" {
+		fmt.Fprintf(&sb, "**项目 Skills 目录**: %s\n\n", filepath.Join(pDir, ".xbot", "skills"))
+	}
 
 	sb.WriteString("<available_skills>\n")
 	for _, sk := range skills {
 		fmt.Fprintf(&sb, "  <skill>\n    <name>%s</name>\n    <description>%s</description>\n    <dir>%s</dir>\n  </skill>\n", sk.Name, sk.Description, sk.Path)
 	}
+	// Append project-local skills (not yet in the merged list)
+	for _, sk := range projectSkills {
+		fmt.Fprintf(&sb, "  <skill>\n    <name>%s</name>\n    <description>%s</description>\n    <dir>%s</dir>\n  </skill>\n", sk.Name, sk.Description, sk.Path)
+	}
 	sb.WriteString("</available_skills>\n")
 	return sb.String()
+}
+
+// scanProjectSkills scans {projectDir}/.xbot/skills/ for project-local skills.
+// Returns skills that are NOT already present in the existing list (avoids duplicates).
+func (s *SkillStore) scanProjectSkills(projectDir string, existing []SkillInfo) []SkillInfo {
+	projectSkillsDir := filepath.Join(projectDir, ".xbot", "skills")
+	entries, err := os.ReadDir(projectSkillsDir)
+	if err != nil {
+		return nil // directory doesn't exist — not an error
+	}
+
+	// Build set of existing names for dedup
+	existingNames := make(map[string]bool, len(existing))
+	for _, sk := range existing {
+		existingNames[sk.Name] = true
+	}
+
+	var result []SkillInfo
+	for _, e := range entries {
+		skillDir := filepath.Join(projectSkillsDir, e.Name())
+		info, err := os.Stat(skillDir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		skillFile := filepath.Join(skillDir, "SKILL.md")
+		if _, err := os.Stat(skillFile); err != nil {
+			continue
+		}
+		data, err := os.ReadFile(skillFile)
+		if err != nil {
+			continue
+		}
+		name, description := parseSkillFrontmatter(data)
+		if name == "" {
+			name = e.Name()
+		}
+		// Skip if already present from global/embedded/user
+		if existingNames[name] {
+			continue
+		}
+		result = append(result, SkillInfo{
+			Name:        name,
+			Description: description,
+			Path:        skillDir,
+		})
+	}
+	return result
 }
 
 // InvalidateCache clears the skill cache for all users, forcing a rescan on the next ListSkills call.

--- a/agent/skills_test.go
+++ b/agent/skills_test.go
@@ -80,3 +80,64 @@ func TestSkillStore_EmbeddedDebugSkillPresent(t *testing.T) {
 		t.Fatalf("expected debug skill description in catalog, got: %s", catalog)
 	}
 }
+
+func TestSkillStore_ProjectLocalSkills(t *testing.T) {
+	workDir := t.TempDir()
+	globalDir := filepath.Join(workDir, ".claude", "skills")
+	projectDir := t.TempDir()
+
+	// Create global skill
+	writeSkill(t, globalDir, "global-tool", "global-tool", "global skill")
+	// Create project-local skill
+	writeSkill(t, filepath.Join(projectDir, ".xbot", "skills"), "project-tool", "project-tool", "project skill")
+
+	store := NewSkillStore(workDir, []string{globalDir}, nil)
+	catalog := store.GetSkillsCatalog(context.Background(), "user-1", projectDir)
+
+	if !strings.Contains(catalog, "<name>global-tool</name>") {
+		t.Fatalf("expected global skill in catalog, got: %s", catalog)
+	}
+	if !strings.Contains(catalog, "<name>project-tool</name>") {
+		t.Fatalf("expected project-local skill in catalog, got: %s", catalog)
+	}
+	if !strings.Contains(catalog, "project skill") {
+		t.Fatalf("expected project skill description in catalog, got: %s", catalog)
+	}
+	// Verify project Skills directory hint is present
+	if !strings.Contains(catalog, "项目 Skills 目录") {
+		t.Fatalf("expected project Skills directory hint, got: %s", catalog)
+	}
+}
+
+func TestSkillStore_ProjectLocalNoDuplicate(t *testing.T) {
+	workDir := t.TempDir()
+	globalDir := filepath.Join(workDir, ".claude", "skills")
+	projectDir := t.TempDir()
+
+	// Create same-named skill in both global and project
+	writeSkill(t, globalDir, "dup", "dup", "global dup")
+	writeSkill(t, filepath.Join(projectDir, ".xbot", "skills"), "dup", "dup", "project dup")
+
+	store := NewSkillStore(workDir, []string{globalDir}, nil)
+	catalog := store.GetSkillsCatalog(context.Background(), "user-1", projectDir)
+
+	// Global should win since it's scanned first; project-local deduplicates against existing
+	if strings.Count(catalog, "<name>dup</name>") != 1 {
+		t.Fatalf("expected deduped skill entry, got: %s", catalog)
+	}
+}
+
+func TestSkillStore_ProjectLocalNoDir(t *testing.T) {
+	workDir := t.TempDir()
+	globalDir := filepath.Join(workDir, ".claude", "skills")
+	projectDir := t.TempDir() // empty — no .xbot/skills
+
+	writeSkill(t, globalDir, "global-tool", "global-tool", "global skill")
+
+	store := NewSkillStore(workDir, []string{globalDir}, nil)
+	catalog := store.GetSkillsCatalog(context.Background(), "user-1", projectDir)
+
+	if !strings.Contains(catalog, "<name>global-tool</name>") {
+		t.Fatalf("expected global skill in catalog, got: %s", catalog)
+	}
+}

--- a/tools/embed_skills/agent-creator/SKILL.md
+++ b/tools/embed_skills/agent-creator/SKILL.md
@@ -18,7 +18,19 @@ Ask the user:
 
 ### Step 2: Create Agent File
 
-**IMPORTANT**: Create agent files in the correct agents directory, NOT in the current working directory. Use the system prompt's **"Agents 存储目录"** path (each agent's `<dir>` field also shows its definition location; `embed` means built-in). For example, if Agents 存储目录 is `/opt/xbot/.xbot/agents`, create files as `/opt/xbot/.xbot/agents/{agent-name}.md`.
+**IMPORTANT**: Agents can be created in two locations:
+
+1. **Global agents** — Create in the system prompt's **"Agents 存储目录"** path (e.g. `~/.xbot/agents/{agent-name}.md`). These are available in ALL projects and sessions. This is the default choice for general-purpose agents.
+
+2. **Project-local agents** — Create in the current project's `.xbot/agents/` directory (e.g. `<project-root>/.xbot/agents/{agent-name}.md`). These are ONLY available when working inside that project. This is ideal for project-specific roles, domain-specialized agents, or team-shared agents that live alongside the code.
+
+   To determine the project root, check the system prompt's **"📂 默认工作目录"** or the **"项目 Agents 目录"** line if present.
+
+   **When to use project-local**: the agent is specific to this codebase, understands project conventions, works with project-specific tools/workflows, or should be version-controlled with the project (commit the `.xbot/agents/` directory).
+
+The system prompt also shows a **"项目 Agents 目录"** line when project-local agents are detected — use this path when creating project-local agents.
+
+Each agent's `<dir>` field in the system prompt also shows its definition location; `embed` means built-in.
 
 Agent definition uses YAML frontmatter + Markdown body:
 
@@ -111,7 +123,8 @@ Follow `code-reviewer.md` quality standard:
 
 List available agents to confirm:
 ```bash
-ls -la agents/
+ls -la ~/.xbot/agents/           # global agents
+ls -la .xbot/agents/             # project-local agents (if applicable)
 ```
 
 ## Agent Naming Convention

--- a/tools/embed_skills/skill-creator/SKILL.md
+++ b/tools/embed_skills/skill-creator/SKILL.md
@@ -16,11 +16,19 @@ skills/{skill-name}/
 └── assets/               # Optional: templates, config files
 ```
 
-**IMPORTANT**: Create skills under the directory shown in the system prompt's **"Skills 存储目录"** line (e.g. `/opt/xbot/.xbot/skills/`). Do NOT use the current working directory or project root — the running xbot instance only scans its configured skills directory.
+**IMPORTANT**: Skills can be created in two locations:
 
-To find the correct path, look at the system prompt section `# Available Skills` → `**Skills 存储目录**`.
+1. **Global skills** — Create under the directory shown in the system prompt's **"Skills 存储目录"** line (e.g. `~/.xbot/skills/`). These are available in ALL projects and sessions. This is the default choice for general-purpose skills.
 
-Alternatively, use `Skill(name=skill-creator, action=list_files)` to get this skill's own directory, then derive the parent as the skills root.
+2. **Project-local skills** — Create under the current project's `.xbot/skills/` directory (e.g. `<project-root>/.xbot/skills/{skill-name}/`). These are ONLY available when working inside that project. This is ideal for project-specific workflows, domain-specific skills, or team-shared skills that live alongside the code.
+
+   To determine the project root, check the system prompt's **"📂 默认工作目录"** or the **"项目 Skills 目录"** line if present.
+
+   **When to use project-local**: the skill is specific to this codebase, uses project conventions, references project files, or should be version-controlled with the project (commit the `.xbot/skills/` directory).
+
+The system prompt also shows a **"项目 Skills 目录"** line when project-local skills are detected — use this path when creating project-local skills.
+
+To find the correct path, look at the system prompt section `# Available Skills` → `**Skills 存储目录**` (global) and `**项目 Skills 目录**` (project-local).
 
 ## Lifecycle
 


### PR DESCRIPTION
## Summary

Skill-creator and agent-creator now guide users to create **project-local** skills/agents alongside the existing global location.

## What Changed

### Backend — Project-local scanning
- `SkillStore.GetSkillsCatalog()` accepts optional `projectDir` param, scans `{projectDir}/.xbot/skills/` for project-local skills (deduped against global/embedded)
- `AgentStore.GetAgentsCatalog()` accepts optional `projectDir` param, scans `{projectDir}/.xbot/agents/` as highest-priority source
- All callers (`agent.go`, `engine_wire.go`) pass session CWD as projectDir
- System prompt shows `**项目 Skills/Agents 目录**` hint when project-local skills/agents are detected

### SKILL.md — Updated guidance
- **skill-creator SKILL.md**: now documents both global (`~/.xbot/skills/`) and project-local (`<project>/.xbot/skills/`) locations, with guidance on when to use which
- **agent-creator SKILL.md**: now documents both global and project-local locations

### Priority chain (for agents): embedded → global → user-private → project-local
### Priority chain (for skills): embedded → global → user-private (project-local deduped separately)

## Files Changed (7 files, +183/-12)
| File | Change |
|------|--------|
| `agent/skills.go` | +69 lines: project-local scanning + `scanProjectSkills()` |
| `agent/agents.go` | +20 lines: project-local source in scan chain |
| `agent/agent.go` | +6 lines: pass `projectDir` to catalog calls |
| `agent/engine_wire.go` | +2 lines: pass `workDir` for SubAgent catalog |
| `agent/skills_test.go` | +61 lines: 3 new tests for project-local |
| `tools/embed_skills/skill-creator/SKILL.md` | Updated guidance |
| `tools/embed_skills/agent-creator/SKILL.md` | Updated guidance |

## Test
```
go test ./agent/ -run TestSkillStore -v  # 6/6 pass (3 new)
go build ./...                            # clean
golangci-lint run ./...                   # 0 issues
```

## How to Use

Users can now create project-specific skills:
```
<project-root>/.xbot/skills/my-project-skill/SKILL.md
```

And project-specific agents:
```
<project-root>/.xbot/agents/my-project-agent.md
```

These are automatically discovered when working inside that project, and can be version-controlled alongside the code.
