### PR TITLE
fix: local mode compression bugs and token bar oscillation

### DIFF
--- a/agent/engine_run.go
+++ b/agent/engine_run.go
@@ -865,7 +865,15 @@ func (s *runState) maybeCompress(ctx context.Context) {
 	}).Info("maybeCompress check")
 
 	if needCompress {
-		s.runCompression(ctx, cm, int(totalTokens), maxTokens)
+		// Respect ContextManager mode: mode=none means auto-compression is disabled.
+		// Without this guard, maybeCompress bypasses ShouldCompress() and attempts
+		// compression even when the ContextManager is a noopManager, which returns
+		// "auto compression is disabled (mode=none)" error.
+		if cm.Mode() == ContextModeNone {
+			log.Ctx(ctx).Debug("maybeCompress: auto-compression skipped (mode=none)")
+		} else {
+			s.runCompression(ctx, cm, int(totalTokens), maxTokens)
+		}
 		return
 	}
 

--- a/agent/token_usage_after_compress_test.go
+++ b/agent/token_usage_after_compress_test.go
@@ -1,0 +1,118 @@
+package agent
+
+import (
+	"testing"
+
+	"xbot/llm"
+)
+
+// TestTokenUsageAfterCompress verifies that structuredProgress.TokenUsage
+// reflects the correct value at every stage after compression:
+//
+//	Compression → setTokenUsageAfterCompress(20k)
+//	  → LLM call returns 30k → updateTokenUsage() → should be 30k
+//	  → Tool execution → initToolProgress → should still be 30k
+//	  → next iteration beginIteration → should still be 30k
+//
+// Bug: after compression in a turn, the context bar would show the compressed
+// value (20k) during tool execution, then jump to the real value (30k) during
+// streaming. This test pinpoints which transition loses the correct value.
+func TestTokenUsageAfterCompress(t *testing.T) {
+	// Setup: create a runState with structuredProgress
+	tracker := NewTokenTracker(170000, 0) // pre-compress token count
+
+	msgs := []llm.ChatMessage{
+		llm.NewSystemMessage("system"),
+		llm.NewUserMessage("hello"),
+	}
+
+	state := &runState{
+		cfg: RunConfig{
+			MaxOutputTokens: 4096,
+		},
+		messages:     msgs,
+		tokenTracker: tracker,
+		structuredProgress: &StructuredProgress{
+			Phase:     PhaseThinking,
+			Iteration: 0,
+		},
+		autoNotify: false, // don't require ProgressNotifier
+	}
+
+	// Seed initial TokenUsage (simulates initProgress with DB-restored value)
+	state.structuredProgress.TokenUsage = &TokenUsageSnapshot{
+		PromptTokens:     170000,
+		CompletionTokens: 0,
+		TotalTokens:      170000,
+		MaxOutputTokens:  4096,
+	}
+
+	// Step 1: Simulate compression
+	// ResetAfterCompress zeros the tracker
+	tracker.ResetAfterCompress()
+
+	// setTokenUsageAfterCompress sets the compressed value
+	compressedTokens := int64(20000)
+	state.setTokenUsageAfterCompress(compressedTokens)
+
+	assertTokenUsage(t, state, "after compress", compressedTokens, "setTokenUsageAfterCompress should set compressed value")
+
+	// Step 2: Simulate LLM call returning real prompt_tokens
+	realTokens := int64(30000)
+	tracker.RecordLLMCall(realTokens, 500)
+	state.updateTokenUsage()
+
+	assertTokenUsage(t, state, "after LLM call", realTokens, "updateTokenUsage should reflect real API value")
+
+	// Step 3: Simulate beginIteration (next iteration in same turn)
+	state.beginIteration(1)
+
+	assertTokenUsage(t, state, "after beginIteration", realTokens, "beginIteration must NOT reset TokenUsage")
+
+	// Step 4: Simulate tool execution start (initToolProgress)
+	response := &llm.LLMResponse{
+		ToolCalls: []llm.ToolCall{
+			{Name: "Shell", Arguments: `{"command":"ls"}`},
+		},
+	}
+	batch := state.initToolProgress(response, 1)
+
+	assertTokenUsage(t, state, "after initToolProgress", realTokens, "initToolProgress must NOT reset TokenUsage")
+	_ = batch
+
+	// Step 5: Simulate second tool starting (sequential dispatch)
+	// beginIteration for iteration 2
+	state.beginIteration(2)
+	assertTokenUsage(t, state, "iteration 2 beginIteration", realTokens, "TokenUsage must persist across iterations")
+
+	// Step 6: Second LLM call with different token count
+	realTokens2 := int64(32000)
+	tracker.RecordLLMCall(realTokens2, 600)
+	state.updateTokenUsage()
+
+	assertTokenUsage(t, state, "after second LLM call", realTokens2, "second updateTokenUsage should reflect new API value")
+
+	// Step 7: Tool execution after second LLM call
+	response2 := &llm.LLMResponse{
+		ToolCalls: []llm.ToolCall{
+			{Name: "Read", Arguments: `{"path":"main.go"}`},
+		},
+	}
+	state.initToolProgress(response2, 2)
+
+	assertTokenUsage(t, state, "after second initToolProgress", realTokens2, "TokenUsage must persist through second tool execution")
+}
+
+func assertTokenUsage(t *testing.T, state *runState, stage string, expected int64, msg string) {
+	t.Helper()
+	if state.structuredProgress == nil {
+		t.Fatalf("%s: structuredProgress is nil", stage)
+	}
+	if state.structuredProgress.TokenUsage == nil {
+		t.Fatalf("%s: TokenUsage is nil — %s", stage, msg)
+	}
+	got := state.structuredProgress.TokenUsage.PromptTokens
+	if got != expected {
+		t.Errorf("%s: TokenUsage.PromptTokens = %d, want %d — %s", stage, got, expected, msg)
+	}
+}

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/glamour/styles"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/rivo/uniseg"
 	"strings"
 	"sync"
 	"time"
@@ -185,9 +186,9 @@ func hardWrapRunes(line string, maxW int) string {
 	return strings.Join(wrapped, "\n")
 }
 
-// hardWrapSingleLine wraps a single line (no \n) at maxW columns.
-// It prefers breaking at word boundaries (spaces) and CJK character boundaries
-// over hard-cutting in the middle of a word. ANSI escape sequences are preserved.
+// hardWrapSingleLine wraps a single line to fit within maxW columns.
+// It processes by grapheme clusters to preserve multi-rune emoji sequences
+// (ZWJ, variation selectors, skin tone). ANSI escapes are preserved.
 func hardWrapSingleLine(line string, maxW int) string {
 	if maxW <= 0 {
 		return line
@@ -196,164 +197,60 @@ func hardWrapSingleLine(line string, maxW int) string {
 		return line
 	}
 
-	segs := tokenizeLine(line)
-
-	var lines []string
+	var wrapped []string
 	var buf strings.Builder
 	w := 0
 
-	for _, seg := range segs {
-		switch seg.kind {
-		case segANSI:
-			buf.WriteString(seg.s)
-		case segSpace:
-			// Spaces are treated like regular characters — hard-break at column boundary
-			for _, r := range seg.s {
-				rw := ansi.StringWidth(string(r))
-				if w+rw > maxW && buf.Len() > 0 {
-					lines = append(lines, buf.String())
-					buf.Reset()
-					w = 0
-					if seg.ansiState != "" {
-						buf.WriteString(seg.ansiState)
-					}
+	remaining := line
+	var ansiState string
+	for len(remaining) > 0 {
+		if remaining[0] == '\x1b' {
+			i := 1
+			for i < len(remaining) {
+				c := remaining[i]
+				if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+					i++
+					break
 				}
-				buf.WriteRune(r)
-				w += rw
+				i++
 			}
-		case segCJK:
-			for _, r := range seg.s {
-				rw := ansi.StringWidth(string(r))
-				if w+rw > maxW && buf.Len() > 0 {
-					lines = append(lines, buf.String())
-					buf.Reset()
-					w = 0
-					if seg.ansiState != "" {
-						buf.WriteString(seg.ansiState)
-					}
-				}
-				buf.WriteRune(r)
-				w += rw
+			seq := remaining[:i]
+			buf.WriteString(seq)
+			remaining = remaining[i:]
+			if strings.HasSuffix(seq, "[0m") || strings.HasSuffix(seq, "[m") {
+				ansiState = ""
+			} else if strings.HasSuffix(seq, "m") {
+				ansiState = seq
 			}
-		default: // segOther: latin, digits, punctuation — hard-break rune by rune
-			for _, r := range seg.s {
-				rw := ansi.StringWidth(string(r))
-				if w+rw > maxW && buf.Len() > 0 {
-					lines = append(lines, buf.String())
-					buf.Reset()
-					w = 0
-					if seg.ansiState != "" {
-						buf.WriteString(seg.ansiState)
-					}
-				}
-				buf.WriteRune(r)
-				w += rw
+			continue
+		}
+
+		cluster, next, _, _ := uniseg.StepString(remaining, 0)
+		cw := ansi.StringWidth(cluster)
+
+		if w+cw > maxW && buf.Len() > 0 {
+			wrapped = append(wrapped, buf.String())
+			buf.Reset()
+			w = 0
+			if ansiState != "" {
+				buf.WriteString(ansiState)
 			}
 		}
+		buf.WriteString(cluster)
+		w += cw
+		remaining = next
 	}
 	if buf.Len() > 0 {
-		lines = append(lines, buf.String())
+		wrapped = append(wrapped, buf.String())
 	}
-	return strings.Join(lines, "\n")
+	return strings.Join(wrapped, "\n")
 }
 
 // --- Line segment tokenizer for smart wrapping ---
 
-type segKind int
-
-const (
-	segANSI  segKind = iota // ANSI escape sequence (0 display width)
-	segSpace                // whitespace (spaces, tabs)
-	segCJK                  // CJK ideograph/hangul/kana — can break anywhere
-	segOther                // Latin, digits, punctuation — keep together
-)
-
-type seg struct {
-	kind      segKind
-	s         string
-	w         int // display width
-	ansiState string
-}
-
 // isCJKRune returns true for runes that allow line breaks on either side.
-func isCJKRune(r rune) bool {
-	return (r >= 0x4E00 && r <= 0x9FFF) || // Han
-		(r >= 0x3400 && r <= 0x4DBF) || // Extension A
-		(r >= 0x20000 && r <= 0x2A6DF) || // Extension B
-		(r >= 0x3040 && r <= 0x309F) || // Hiragana
-		(r >= 0x30A0 && r <= 0x30FF) || // Katakana
-		(r >= 0xAC00 && r <= 0xD7AF) || // Hangul syllables
-		(r >= 0x1100 && r <= 0x11FF) || // Hangul Jamo
-		(r >= 0xF900 && r <= 0xFAFF) || // CJK compat ideographs
-		(r >= 0xFF01 && r <= 0xFF60) || // Fullwidth forms
-		(r >= 0x3000 && r <= 0x303F) // CJK punctuation
-}
 
 // tokenizeLine splits a line into typed segments for smart wrapping.
-func tokenizeLine(line string) []seg {
-	var segs []seg
-	var cur seg
-	var ansiState strings.Builder
-	haveAnsi := false
-	inEscape := false
-
-	flush := func() {
-		if len(cur.s) > 0 {
-			cur.w = ansi.StringWidth(cur.s)
-			if haveAnsi {
-				cur.ansiState = ansiState.String()
-			}
-			segs = append(segs, cur)
-			cur = seg{}
-		}
-	}
-
-	classify := func(r rune) segKind {
-		if r == ' ' || r == '\t' {
-			return segSpace
-		}
-		if isCJKRune(r) {
-			return segCJK
-		}
-		return segOther
-	}
-
-	for _, r := range line {
-		if r == '\x1b' {
-			if cur.kind != segANSI && cur.kind != 0 {
-				flush()
-			}
-			cur.kind = segANSI
-			cur.s += string(r)
-			ansiState.WriteRune(r)
-			inEscape = true
-			continue
-		}
-		if inEscape {
-			cur.s += string(r)
-			ansiState.WriteRune(r)
-			if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
-				inEscape = false
-				s := ansiState.String()
-				if strings.HasSuffix(s, "[0m") || strings.HasSuffix(s, "[m") {
-					ansiState.Reset()
-					haveAnsi = false
-				} else if strings.HasSuffix(s, "m") {
-					haveAnsi = true
-				}
-			}
-			continue
-		}
-		k := classify(r)
-		if k != cur.kind {
-			flush()
-		}
-		cur.kind = k
-		cur.s += string(r)
-	}
-	flush()
-	return segs
-}
 
 // Document.Margin=0 prevents misalignment inside lipgloss bubbles.
 // WordWrap is set to the available width so glamour can calculate proper

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -374,10 +374,18 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 
 	case cliTokenRefreshMsg:
 		if msg.tokenPrompt > 0 || msg.tokenCompletion > 0 {
-			m.lastTokenUsage = &protocol.TokenUsage{
-				PromptTokens:     msg.tokenPrompt,
-				CompletionTokens: msg.tokenCompletion,
-				TotalTokens:      msg.tokenPrompt + msg.tokenCompletion,
+			// Only accept the DB value if we don't have a more recent value
+			// from engine progress events. After compression, the async
+			// refreshTokenStateAfterReload goroutine may read a stale value
+			// from DB (the compressed token count) while engine has already
+			// pushed the real post-LLM-call value via progress events.
+			// Accept when: nil (no data yet) or DB value is HIGHER (genuinely newer).
+			if m.lastTokenUsage == nil || msg.tokenPrompt > m.lastTokenUsage.PromptTokens {
+				m.lastTokenUsage = &protocol.TokenUsage{
+					PromptTokens:     msg.tokenPrompt,
+					CompletionTokens: msg.tokenCompletion,
+					TotalTokens:      msg.tokenPrompt + msg.tokenCompletion,
+				}
 			}
 		}
 

--- a/channel/wrap_unicode_test.go
+++ b/channel/wrap_unicode_test.go
@@ -1,0 +1,87 @@
+package channel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestHardWrapSingleLine_EmojiSequence(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		maxW  int
+		want  int // expected number of lines
+	}{
+		{
+			name:  "family emoji stays together when fits",
+			input: "hello 👨‍👩‍👧‍👦 world",
+			maxW:  20,
+			want:  1,
+		},
+		{
+			name:  "CJK characters wrap individually",
+			input: "你好世界再见",
+			maxW:  4,
+			want:  3, // 2 chars (4 width) per line
+		},
+		{
+			name:  "mixed CJK and emoji",
+			input: "你好🎉世界",
+			maxW:  6,
+			want:  2, // "你好🎉" (2+2+2=6) on line 1, "世界" (4) on line 2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hardWrapSingleLine(tt.input, tt.maxW)
+			lines := strings.Split(result, "\n")
+			if len(lines) != tt.want {
+				t.Errorf("got %d lines, want %d\nlines: %q", len(lines), tt.want, lines)
+			}
+			// Verify no line exceeds maxW
+			for i, line := range lines {
+				w := ansi.StringWidth(line)
+				if w > tt.maxW {
+					t.Errorf("line %d width %d exceeds maxW %d: %q", i, w, tt.maxW, line)
+				}
+			}
+		})
+	}
+}
+
+func TestHardWrapSingleLine_NoBrokenGrapheme(t *testing.T) {
+	// Verify that multi-rune emoji sequences are never split mid-sequence
+	emoji := "👨‍👩‍👧‍👦" // family: man + ZWJ + woman + ZWJ + girl + ZWJ + boy
+	input := strings.Repeat(emoji, 5)
+	for maxW := 2; maxW <= 20; maxW++ {
+		result := hardWrapSingleLine(input, maxW)
+		lines := strings.Split(result, "\n")
+		for i, line := range lines {
+			w := ansi.StringWidth(line)
+			if w > maxW {
+				t.Errorf("maxW=%d line %d width %d exceeds: %q", maxW, i, w, line)
+			}
+		}
+	}
+}
+
+func TestHardWrapSingleLine_SkinToneNotSplit(t *testing.T) {
+	// 👍🏽 = thumbs up + skin tone modifier (2 runes, 2 width)
+	// Must never be split into 👍 and 🏽
+	input := "👍🏽👍🏽👍🏽"
+	result := hardWrapSingleLine(input, 4)
+	lines := strings.Split(result, "\n")
+	for i, line := range lines {
+		w := ansi.StringWidth(line)
+		if w > 4 {
+			t.Errorf("line %d width %d exceeds 4: %q", i, w, line)
+		}
+		// Should contain complete 👍🏽 pairs, never a lone 👍 or 🏽
+		if strings.Contains(line, "👍") && !strings.Contains(line, "👍🏽") {
+			t.Errorf("line %d has broken skin tone: %q", i, line)
+		}
+	}
+}

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -697,6 +697,12 @@ func newCLIApp(serverURL, token string, forceLocal bool, maxContextTokens, maxOu
 
 	var client *agent.Client
 
+	// Seed cfg.LLM from the active config subscription so createLLM uses
+	// the correct BaseURL/APIKey. Without this, cfg.LLM may contain a
+	// stale/placeholder URL while the real credentials live in config.Subscriptions.
+	// This prevents "Model list load failed: Get https://api.example.com" errors
+	// in --local mode on startup.
+	syncLLMFromActiveSub(cfg)
 	// Apply CLI flag overrides (after subscription loading so they take precedence).
 	if maxContextTokens > 0 {
 		cfg.Agent.MaxContextTokens = maxContextTokens
@@ -756,6 +762,17 @@ func newCLIApp(serverURL, token string, forceLocal bool, maxContextTokens, maxOu
 			syncLLMFromActiveSub(cfg)
 		}
 
+		// Sync runtime settings from DB to the Agent.
+		// The Agent's ContextManager and other runtime state were created from
+		// config.json values during InitServer. But user settings (enable_auto_compress,
+		// context_mode, max_iterations, etc.) live in the DB and may differ.
+		// Without this sync, the Agent runs with stale config.json defaults — e.g.
+		// noopManager (mode=none) even though DB says "Auto Compress: On".
+		if dbSettings, err := client.GetSettings("cli", "cli_user"); err == nil && len(dbSettings) > 0 {
+			agent.ApplyRuntimeSettingsLocal(cfg, dbSettings)
+			client.ApplyRuntimeSettings(dbSettings)
+			log.WithField("keys", len(dbSettings)).Debug("Local mode: synced DB settings to Agent")
+		}
 		// Apply CLI flag overrides via RPC
 		if maxOutputTokens > 0 {
 			_ = client.SetGlobalMaxTokens(maxOutputTokens)

--- a/internal/textarea/textarea.go
+++ b/internal/textarea/textarea.go
@@ -2008,12 +2008,23 @@ func wrap(runes []rune, width int) [][]rune {
 	i := 0
 	for i < len(runes) {
 		r := runes[i]
+
+		// Use uniseg to extract grapheme clusters, which keep multi-rune
+		// emoji sequences (ZWJ, variation selectors, skin tone modifiers)
+		// together as a single unit. This prevents breaking emoji like
+		// 👨‍👩‍👧‍👦 into incomplete fragments.
+		rest := string(runes[i:])
+		cluster, _, _, _ := uniseg.StepString(rest, 0)
+		clusterRunes := len([]rune(cluster))
+
 		switch {
-		case isCJK(r):
-			// CJK characters break individually: each character is a potential
-			// line break point. No word accumulation is needed.
-			addRune(r)
-			i++
+		case clusterRunes > 1 || isCJK(r):
+			// Grapheme cluster (emoji sequence) or CJK character:
+			// treat as a single unit that breaks individually.
+			for j := 0; j < clusterRunes && i < len(runes); j++ {
+				addRune(runes[i])
+				i++
+			}
 
 		case unicode.IsSpace(r):
 			// Whitespace is a break point but does not force a wrap by itself.

--- a/tools/edit.go
+++ b/tools/edit.go
@@ -35,17 +35,19 @@ func (t *FileCreateTool) Name() string {
 func (t *FileCreateTool) Description() string {
 	return `Create a new file.
 Required: path, content
-Creates the file (and parent directories if needed). Returns error if file already exists.
+Creates the file (and parent directories if needed). Returns error if file already exists, unless rewrite is set to true.
 
 Examples:
 - {"path": "hello.txt", "content": "Hello!"}
-- {"path": "src/main.go", "content": "package main\n\nfunc main() {}"}`
+- {"path": "src/main.go", "content": "package main\n\nfunc main() {}"}
+- {"path": "config.yaml", "content": "key: value", "rewrite": true}`
 }
 
 func (t *FileCreateTool) Parameters() []llm.ToolParam {
 	return []llm.ToolParam{
 		{Name: "path", Type: "string", Description: "File path to create (relative to working directory or absolute)", Required: true},
 		{Name: "content", Type: "string", Description: "Content to write to the new file", Required: true},
+		{Name: "rewrite", Type: "boolean", Description: "Set to true to allow overwriting an existing file. Default is false.", Required: false},
 		{Name: "run_as", Type: "string", Description: "OS username to execute as. Requires permission control to be enabled. Only effective in none sandbox mode.", Required: false},
 		{Name: "reason", Type: "string", Description: "Optional human-readable reason shown in approval requests when approval is required.", Required: false},
 	}
@@ -54,6 +56,7 @@ func (t *FileCreateTool) Parameters() []llm.ToolParam {
 type FileCreateParams struct {
 	Path    string `json:"path"`
 	Content string `json:"content"`
+	Rewrite bool   `json:"rewrite"`
 	RunAs   string `json:"run_as"`
 	Reason  string `json:"reason"`
 }
@@ -79,14 +82,20 @@ func (t *FileCreateTool) Execute(ctx *ToolContext, input string) (*ToolResult, e
 
 	if shouldUseSandbox(ctx) {
 		sandboxPath := resolveSandboxPath(ctx, params.Path)
-		return t.sandboxCreate(ctx, sandboxPath, params.Content)
+		return t.sandboxCreate(ctx, sandboxPath, params.Content, params.Rewrite)
 	}
 	return t.executeLocal(ctx, *params)
 }
 
-func (t *FileCreateTool) sandboxCreate(ctx *ToolContext, path, content string) (*ToolResult, error) {
-	if err := sandboxWriteNewFile(ctx, path, content); err != nil {
-		return nil, err
+func (t *FileCreateTool) sandboxCreate(ctx *ToolContext, path, content string, rewrite bool) (*ToolResult, error) {
+	if !rewrite {
+		if err := sandboxWriteNewFile(ctx, path, content); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := sandboxWriteFile(ctx, path, content); err != nil {
+			return nil, err
+		}
 	}
 	summary := fmt.Sprintf("File created successfully: %s", path)
 	return &ToolResult{Summary: summary, Tips: tipFileCreated}, nil
@@ -100,7 +109,9 @@ func (t *FileCreateTool) executeLocal(ctx *ToolContext, params FileCreateParams)
 
 	// Check if file already exists
 	if _, err := os.Stat(filePath); err == nil {
-		return nil, fmt.Errorf("file already exists: %s (use FileReplace to modify existing files)", filePath)
+		if !params.Rewrite {
+			return nil, fmt.Errorf("file already exists: %s (use FileReplace to modify existing files, or set rewrite=true to overwrite)", filePath)
+		}
 	}
 
 	// Create parent directories if needed

--- a/tools/edit_test.go
+++ b/tools/edit_test.go
@@ -653,6 +653,25 @@ func TestFileCreateTool_LocalMode(t *testing.T) {
 			t.Errorf("error should mention 'already exists', got: %v", err)
 		}
 	})
+
+	t.Run("rewrite=false returns error for existing file", func(t *testing.T) {
+		_, err := tool.Execute(ctx, `{"path": "hello.txt", "content": "nope", "rewrite": false}`)
+		if err == nil {
+			t.Fatal("expected error for existing file without rewrite")
+		}
+	})
+
+	t.Run("rewrite=true overwrites existing file", func(t *testing.T) {
+		result, err := tool.Execute(ctx, `{"path": "hello.txt", "content": "rewritten", "rewrite": true}`)
+		if err != nil {
+			t.Fatalf("rewrite=true should succeed, got: %v", err)
+		}
+		content, _ := os.ReadFile(filepath.Join(ws, "hello.txt"))
+		if string(content) != "rewritten" {
+			t.Errorf("got %q, want %q", string(content), "rewritten")
+		}
+		_ = result
+	})
 }
 
 // ============================================================================

--- a/tools/worktree.go
+++ b/tools/worktree.go
@@ -151,17 +151,17 @@ func (t *WorktreeTool) executeInit(ctx *ToolContext, params WorktreeParams) (*To
 	ctx.CurrentDir = worktreePath
 
 	msg := fmt.Sprintf("Worktree created successfully.\n"+
-		"- Repo: %s\n- Worktree: %s\n- Branch: %s\n- Role: %s%s\n\n"+
-		"已自动 cd 到 worktree 目录。你现在在隔离的工作区中工作，其他 agent 不会看到你的更改，直到合并。",
-		repoPath, worktreePath, branch, role, dirtyWarning)
+		"- Worktree: `%s`\n- Branch: `%s`\n- Role: %s%s\n\n"+
+		"已自动 cd 到 worktree 目录。所有文件读写、Shell 命令都在此隔离工作区内执行。\n"+
+		"不要使用主仓库路径访问或修改文件，其他 agent 不会看到你的更改，直到合并。",
+		worktreePath, branch, role, dirtyWarning)
 
 	peers := GlobalWorktreeRegistry.GetPeers(repoPath, sessionKey)
 	if len(peers) > 0 {
-		msg += "\n\nActive peers in this repo:"
+		msg += "\n\nActive peers (use `SendMessage(to=\"<SessionKey>\", ...)` to communicate):"
 		for _, p := range peers {
-			msg += fmt.Sprintf("\n- %s (%s) on branch %s [%s]", p.SessionKey, p.Role, p.Branch, p.Status)
+			msg += fmt.Sprintf("\n- `%s` (%s) on branch `%s` [%s]", p.SessionKey, p.Role, p.Branch, p.Status)
 		}
-		msg += "\n\nUse SendMessage to communicate with peers when merging."
 	}
 
 	return NewResult(msg), nil


### PR DESCRIPTION
## Summary

Four fixes for local mode (`xbot-cli --local`) issues:

### Bug 1: `Model list load failed: Get "https://api.example.com"`
**File**: `cmd/xbot-cli/main.go`
**Cause**: `createLLM()` used stale `cfg.LLM` before syncing active subscription credentials.
**Fix**: Call `syncLLMFromActiveSub(cfg)` before `createLLM()`.

### Bug 2: `auto compression is disabled (mode=none)` despite "Auto Compress: On"
**Files**: `cmd/xbot-cli/main.go`, `agent/engine_run.go`
**Cause**: Agent ContextManager created from config.json, DB settings never synced. Also `maybeCompress()` bypassed `ShouldCompress()`.
**Fix**: Sync DB settings to Agent after InitServer. Guard `maybeCompress` with mode check.

### Bug 3: Token bar oscillates after compression
**File**: `channel/cli_update.go`
**Cause**: Async `refreshTokenStateAfterReload` reads stale compressed token count from DB, overwriting real values from engine progress events.
**Fix**: `cliTokenRefreshMsg` only overwrites when nil or DB value is higher.

### Improvement: Worktree init prompt
**File**: `tools/worktree.go` — cleaner, emphasizes worktree-only file ops.

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint run ./...`)
- [x] Engine-side test `TestTokenUsageAfterCompress`