### PR TITLE
fix: CreateChat background agent TUI state, AgentChannel panic hang, and turn notification

### DIFF
--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -794,7 +794,7 @@ func (a *Agent) SendToInteractiveSession(
 	roleName string,
 	msg bus.InboundMessage,
 ) (*channelpkg.OutboundMsg, error) {
-	originChannel, originChatID, _ := resolveOriginIDs(msg)
+	originChannel, originChatID, originSender := resolveOriginIDs(msg)
 	instance := msg.Metadata["instance_id"]
 
 	key := interactiveKey(originChannel, originChatID, roleName, instance)
@@ -901,6 +901,36 @@ func (a *Agent) SendToInteractiveSession(
 	} else {
 		// Background 模式：禁用进度穿透
 		cfg.ProgressNotifier = nil
+
+		// Re-wire OnIterationSnapshot for incremental history updates
+		// (same as SpawnInteractiveSession does for the initial Run).
+		sessionKey := originChannel + ":" + originChatID
+		notifyMgr := a.bgTaskMgr
+		cfg.OnIterationSnapshot = func(snap IterationSnapshot) {
+			ia.mu.Lock()
+			ia.iterationHistory = append(ia.iterationHistory, snap)
+			ia.mu.Unlock()
+
+			if notifyMgr != nil {
+				var sb strings.Builder
+				fmt.Fprintf(&sb, "Iteration %d completed.\n", snap.Iteration)
+				for _, t := range snap.Tools {
+					fmt.Fprintf(&sb, "- %s [%s, %dms]", t.Name, t.Status, t.ElapsedMS)
+					if t.Summary != "" {
+						fmt.Fprintf(&sb, " %s", t.Summary)
+					}
+					sb.WriteString("\n")
+				}
+				notifyMgr.SendSubAgentNotify(&tools.SubAgentBgNotify{
+					Key:      sessionKey,
+					Type:     tools.SubAgentBgNotifyProgress,
+					Role:     roleName,
+					Instance: instance,
+					Content:  sb.String(),
+					Sid:      originSender,
+				})
+			}
+		}
 	}
 
 	preLen := len(cfg.Messages)
@@ -909,6 +939,87 @@ func (a *Agent) SendToInteractiveSession(
 	ia.running = true
 	ia.mu.Unlock()
 
+	if ia.background {
+		// Background agents: run asynchronously (same as initial spawn).
+		// Without this, SubAgent(action="send") blocks the caller's tool
+		// execution for the entire duration of Run() — which can be minutes.
+		// The caller gets an immediate acknowledgment, and the result is
+		// delivered via BgTaskMgr notification when Run() completes.
+		go func() {
+			startTime := time.Now()
+			defer func() {
+				if r := recover(); r != nil {
+					clipanic.Report("agent.interactive.SendBackground", fmt.Sprintf("%s:%s", roleName, instance), r)
+					ia.mu.Lock()
+					ia.running = false
+					ia.lastError = fmt.Sprintf("panic: %v", r)
+					ia.mu.Unlock()
+					if a.bgTaskMgr != nil {
+						sessionKey := originChannel + ":" + originChatID
+						a.bgTaskMgr.SendSubAgentNotify(&tools.SubAgentBgNotify{
+							Key:      sessionKey,
+							Type:     tools.SubAgentBgNotifyCompleted,
+							Role:     roleName,
+							Instance: instance,
+							Content:  fmt.Sprintf("Panic: %v", r),
+							Elapsed:  time.Since(startTime),
+							Sid:      originSender,
+						})
+					}
+				}
+			}()
+
+			out := Run(subCtx, cfg)
+
+			ia.mu.Lock()
+			ia.running = false
+			ia.mu.Unlock()
+
+			// Notify parent via BgTaskManager (same as initial spawn).
+			if a.bgTaskMgr != nil {
+				content := out.Content
+				if out.Error != nil {
+					content = fmt.Sprintf("Error: %v\n%s", out.Error, out.Content)
+				}
+				if len(content) > 2000 {
+					content = content[:2000] + "... [truncated, use inspect for details]"
+				}
+				sessionKey := originChannel + ":" + originChatID
+				a.bgTaskMgr.SendSubAgentNotify(&tools.SubAgentBgNotify{
+					Key:      sessionKey,
+					Type:     tools.SubAgentBgNotifyCompleted,
+					Role:     roleName,
+					Instance: instance,
+					Content:  content,
+					Elapsed:  time.Since(startTime),
+					Sid:      originSender,
+				})
+			}
+
+			// --- Write back results (same as 阶段 3 below, but for async path) ---
+			ia.mu.Lock()
+			defer ia.mu.Unlock()
+
+			if out.Error != nil {
+				ia.lastError = out.Error.Error()
+				ia.lastReply = out.Content
+			} else {
+				ia.lastError = ""
+				ia.lastReply = out.Content
+				// Append new messages from Run() to ia.messages
+				if preLen > 0 && len(cfg.Messages) > preLen {
+					newFromRun := cfg.Messages[preLen:]
+					ia.messages = append(ia.messages, newFromRun...)
+				}
+			}
+		}()
+
+		return &channelpkg.OutboundMsg{
+			Content: fmt.Sprintf("Message sent to background agent %q (instance=%q). Results will be notified when complete.", roleName, instance),
+		}, nil
+	}
+
+	// Foreground agents: run synchronously (blocks caller until complete)
 	out := Run(subCtx, cfg)
 
 	ia.mu.Lock()

--- a/channel/agent_channel.go
+++ b/channel/agent_channel.go
@@ -50,20 +50,35 @@ func (ac *AgentChannel) Start() error {
 	ac.cancel = cancel
 
 	ac.wg.Go(func() {
-		defer clipanic.Recover("channel.AgentChannel.Start", nil, false)
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case req := <-ac.inbox:
-				result, err := ac.runFn(ctx, req.task)
-				if err != nil {
-					result = "Error: " + err.Error()
-				}
-				select {
-				case req.replyCh <- result:
-				case <-ctx.Done():
-				}
+				// Recover inside the loop body so a panic in runFn
+				// doesn't kill the processing goroutine. Without this,
+				// a panic strands all pending requests (their replyCh
+				// never receives) and the AgentChannel hangs permanently.
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							clipanic.Report("channel.AgentChannel.runFn", ac.name, r)
+							errMsg := fmt.Sprintf("panic: %v", r)
+							select {
+							case req.replyCh <- errMsg:
+							case <-ctx.Done():
+							}
+						}
+					}()
+					result, err := ac.runFn(ctx, req.task)
+					if err != nil {
+						result = "Error: " + err.Error()
+					}
+					select {
+					case req.replyCh <- result:
+					case <-ctx.Done():
+					}
+				}()
 			}
 		}
 	})

--- a/channel/agent_channel_test.go
+++ b/channel/agent_channel_test.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -222,5 +223,42 @@ func TestAgentChannelConcurrentSends(t *testing.T) {
 
 	if completed.Load() != 10 {
 		t.Errorf("expected 10 completions, got %d", completed.Load())
+	}
+}
+
+func TestAgentChannelPanicRecovery(t *testing.T) {
+	// Verify that a panic in runFn does NOT kill the processing goroutine.
+	// The next request should succeed normally.
+	callCount := int32(0)
+	runFn := func(ctx context.Context, task string) (string, error) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			panic("intentional test panic")
+		}
+		return "ok: " + task, nil
+	}
+
+	ch := NewAgentChannel("test-panic", runFn)
+	if err := ch.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer ch.Stop()
+
+	// First call: should trigger panic, recover, and return error message.
+	result1, err := ch.Send(OutboundMsg{Content: "req1"})
+	if err != nil {
+		t.Fatalf("Send should not return error even after panic: %v", err)
+	}
+	if !strings.Contains(result1, "panic:") {
+		t.Errorf("expected panic error message, got: %s", result1)
+	}
+
+	// Second call: should succeed normally, proving the goroutine survived.
+	result2, err := ch.Send(OutboundMsg{Content: "req2"})
+	if err != nil {
+		t.Fatalf("second Send failed: %v", err)
+	}
+	if result2 != "ok: req2" {
+		t.Errorf("expected 'ok: req2', got: %s", result2)
 	}
 }

--- a/tools/create_chat.go
+++ b/tools/create_chat.go
@@ -130,7 +130,15 @@ func (t *CreateChatTool) createAgentChat(ctx *ToolContext, params *CreateChatPar
 	addr := "agent:" + params.Role + "/" + params.Instance
 	if ctx.RegisterAgentChannel != nil {
 		sendFn := func(sendCtx context.Context, msg string) (string, error) {
-			return im.SendInteractive(ctx, msg, params.Role, role.SystemPrompt, role.AllowedTools, role.Capabilities, params.Instance, effectiveModel)
+			// Use a copy of the ToolContext with the AgentChannel's
+			// long-lived context. The original ctx.Ctx belongs to the
+			// CreateChat tool call and is cancelled when that tool
+			// returns. Without this, SendInteractive would use a
+			// cancelled context, causing Run() to fail immediately
+			// or hang on subsequent SendMessage calls.
+			sendToolCtx := *ctx
+			sendToolCtx.Ctx = sendCtx
+			return im.SendInteractive(&sendToolCtx, msg, params.Role, role.SystemPrompt, role.AllowedTools, role.Capabilities, params.Instance, effectiveModel)
 		}
 		if regErr := ctx.RegisterAgentChannel(addr, sendFn); regErr != nil {
 			result += fmt.Sprintf("\n\nWarning: AgentChannel registration failed: %v", regErr)


### PR DESCRIPTION
## Summary

Fixes three bugs in CreateChat background agent sessions:

### Bug 1: AgentChannel panic kills processing goroutine → permanent hang

**Root cause**: `defer clipanic.Recover()` at the goroutine level means a panic in `runFn` exits the entire `for/select` loop. All pending requests are stranded (their `replyCh` never receives), and all future `Send()` calls block forever.

**Fix**: Move recovery inside the loop body so the goroutine survives and processes subsequent requests normally.

### Bug 2: create_chat.go sendFn uses cancelled ToolContext

**Root cause**: The `sendFn` closure captures the original `ToolContext` whose `Ctx` belongs to the `CreateChat` tool call. When `SendMessage` calls the `sendFn` later (possibly minutes later), `ctx.Ctx` is already cancelled. `SendInteractive` then uses this cancelled context, causing `Run()` to fail immediately or behave unpredictably.

**Fix**: `sendFn` creates a shallow copy of `ToolContext` with the AgentChannel's long-lived context (`sendCtx` parameter).

### Bug 3: Background agent subsequent sends lack BgTaskManager notification

**Root cause**: Only the initial `SpawnInteractiveSession` sent completion notifications via `BgTaskManager`. Subsequent `SendToInteractiveSession` calls for background agents had no notification at all — the parent agent never knew the turn completed.

**Fix**: `SendToInteractiveSession` sends `SubAgentBgNotifyCompleted` via `BgTaskMgr` when a background agent's `Run()` completes (same path as initial spawn). Also wires `OnIterationSnapshot` for incremental progress notifications during the run.

## Files Changed

| File | Change |
|------|--------|
| `channel/agent_channel.go` | Move panic recovery inside loop body |
| `channel/agent_channel_test.go` | Add `TestAgentChannelPanicRecovery` |
| `tools/create_chat.go` | Fix `sendFn` to use AgentChannel context |
| `agent/interactive.go` | Add BgTaskMgr notification + OnIterationSnapshot for bg sends |

## Test Results

All existing tests pass + new `TestAgentChannelPanicRecovery` test verifies the panic recovery fix.