### PR TITLE
fix: sanitize \r and ANSI escape sequences in bg task output

### DIFF
--- a/agent/offload.go
+++ b/agent/offload.go
@@ -679,17 +679,23 @@ func summarizeGlob(content string) string {
 
 // summarizeDefault 生成默认摘要。
 func summarizeDefault(content string) string {
-	// Sanitize \r overwrites and ANSI escape sequences before previewing
-	content = tools.SanitizeOutputLine(content)
-	runes := []rune(content)
+	// Sanitize per-line to handle \r overwrites and ANSI escape sequences.
+	// Using SanitizeOutputLine on the entire multi-line string would be wrong
+	// because it finds the LAST \r globally and strips everything before it.
+	lines := tools.SanitizeOutputLines(content)
+	var contentClean string
+	if len(lines) > 0 {
+		contentClean = strings.Join(lines, "\n")
+	}
+	runes := []rune(contentClean)
 	maxPreview := 300
 	if len(runes) <= maxPreview {
-		return fmt.Sprintf("Content: %s\n(Size: %d bytes, ~%d tokens)", content, len(content), estimateTokenSize(content, "gpt-4o"))
+		return fmt.Sprintf("Content: %s\n(Size: %d bytes, ~%d tokens)", contentClean, len(contentClean), estimateTokenSize(contentClean, "gpt-4o"))
 	}
 
 	preview := string(runes[:maxPreview])
-	tokens := estimateTokenSize(content, "gpt-4o")
-	return fmt.Sprintf("Content (first %d chars): %s...\n(Size: %d bytes, ~%d tokens)", maxPreview, preview, len(content), tokens)
+	tokens := estimateTokenSize(contentClean, "gpt-4o")
+	return fmt.Sprintf("Content (first %d chars): %s...\n(Size: %d bytes, ~%d tokens)", maxPreview, preview, len(contentClean), tokens)
 }
 
 // extractFunctionNames 从代码内容中提取函数名（Go, Python, JS 等）。

--- a/agent/offload.go
+++ b/agent/offload.go
@@ -631,6 +631,11 @@ func summarizeShell(content string) string {
 	const maxLineRunes = 500
 	const lineTruncSuffix = "...(truncated, %d chars)"
 	for _, l := range lines[len(lines)-showCount:] {
+		// Sanitize \r overwrites and ANSI escape sequences from progress bars
+		l = tools.SanitizeOutputLine(l)
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
 		runes := []rune(l)
 		if len(runes) > maxLineRunes {
 			suffix := fmt.Sprintf(lineTruncSuffix, len(runes))
@@ -674,6 +679,8 @@ func summarizeGlob(content string) string {
 
 // summarizeDefault 生成默认摘要。
 func summarizeDefault(content string) string {
+	// Sanitize \r overwrites and ANSI escape sequences before previewing
+	content = tools.SanitizeOutputLine(content)
 	runes := []rune(content)
 	maxPreview := 300
 	if len(runes) <= maxPreview {

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -2171,9 +2171,21 @@ func (m *cliModel) renderMessage(msg *cliMessage) string {
 	sb.WriteString("\n\n")
 
 	// §19 计算渲染后行数（每次 dirty 重算）
-	msg.renderedLines = strings.Count(sb.String(), "\n") + 1
+	// Sanitize rendered output: strip \r carriage-return overwrites per line.
+	// This is the final rendering-layer safety net — ensures progress bar
+	// output (tqdm, curl etc.) from any source (old offload, history, network)
+	// never corrupts the TUI layout.
+	raw := sb.String()
+	lines := strings.Split(raw, "\n")
+	for i, line := range lines {
+		if idx := strings.LastIndex(line, "\r"); idx >= 0 {
+			lines[i] = line[idx+1:]
+		}
+	}
+	cleaned := strings.Join(lines, "\n")
+	msg.renderedLines = strings.Count(cleaned, "\n") + 1
 
-	return sb.String()
+	return cleaned
 }
 
 // wrapPreservingGuide wraps a line at cw columns, preserving any guide prefix

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -2964,8 +2964,7 @@ func (m *cliModel) renderShellBody(tool protocol.ToolProgress, maxW int, t cliTh
 	// Progress bars (tqdm etc.) use \r to overwrite the same line.
 	// When captured as output, \r-embedded lines confuse the terminal:
 	// \r moves cursor to column 0, overwriting the guide prefix.
-	// Strategy: for each output line, keep only the content after the
-	// last \r (i.e. the final visual state), then wrap normally.
+	// sanitizeOutputLine handles \r stripping and ANSI removal.
 	lines := strings.Split(content, "\n")
 	totalLines := len(lines)
 	displayLines := lines
@@ -2974,13 +2973,8 @@ func (m *cliModel) renderShellBody(tool protocol.ToolProgress, maxW int, t cliTh
 	}
 	outputStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextPrimary))
 	for _, line := range displayLines {
-		// Strip carriage-return overwrites: keep only the final visual
-		// state (content after the last \r). This handles progress bars
-		// (tqdm etc.) whose output contains multiple \r-separated frames.
-		if idx := strings.LastIndex(line, "\r"); idx >= 0 {
-			line = line[idx+1:]
-		}
-		// Skip empty lines after \r stripping (fully overwritten frames)
+		line = sanitizeOutputLine(line)
+		// Skip empty lines after sanitization (fully overwritten frames)
 		if strings.TrimSpace(line) == "" {
 			continue
 		}

--- a/channel/cli_mouse.go
+++ b/channel/cli_mouse.go
@@ -1519,7 +1519,7 @@ func (m *cliModel) clickSidebarBgTask(index int) (bool, tea.Model, tea.Cmd) {
 	// Select the clicked task and enter log view
 	m.panelBgCursor = index
 	task := m.panelBgTasks[index]
-	m.panelBgLogLines = splitLines(task.Output)
+	m.panelBgLogLines = sanitizeOutputLines(task.Output)
 	if len(m.panelBgLogLines) == 0 {
 		m.panelBgLogLines = []string{"(no output)"}
 	}

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
 	"xbot/config"
 	"xbot/internal/textarea"
 	"xbot/llm"
@@ -740,7 +741,7 @@ func (m *cliModel) updateBgTasksPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 		if m.panelBgCursor >= 0 && m.panelBgCursor < len(m.panelBgTasks) {
 			// Task entry: view output log
 			task := m.panelBgTasks[m.panelBgCursor]
-			m.panelBgLogLines = splitLines(task.Output)
+			m.panelBgLogLines = sanitizeOutputLines(task.Output)
 			if len(m.panelBgLogLines) == 0 {
 				m.panelBgLogLines = []string{"(no output)"}
 			}
@@ -890,7 +891,7 @@ func (m *cliModel) viewBgTaskLog() string {
 		title = fmt.Sprintf(m.locale.BgTaskLogTitle, task.ID, cmd)
 		// Update log lines from latest task output
 		oldCount := len(m.panelBgLogLines)
-		m.panelBgLogLines = splitLines(task.Output)
+		m.panelBgLogLines = sanitizeOutputLines(task.Output)
 		newCount := len(m.panelBgLogLines)
 		// Follow-tail: auto-scroll when new lines appear
 		if m.panelBgLogFollow && newCount > oldCount {
@@ -1372,6 +1373,21 @@ func (m *cliModel) viewDangerPanel() string {
 	}
 
 	return sb.String()
+}
+
+// sanitizeOutputLine sanitizes a single output line for safe TUI rendering.
+// Delegates to the shared tools.SanitizeOutputLine which handles \r
+// carriage-return overwrites (progress bars like tqdm) and ANSI escape
+// sequences (color codes, cursor movement).
+func sanitizeOutputLine(line string) string {
+	return tools.SanitizeOutputLine(line)
+}
+
+// sanitizeOutputLines splits raw process output into sanitized display lines.
+// Delegates to tools.SanitizeOutputLines for \r stripping, ANSI removal, and
+// empty-line filtering.
+func sanitizeOutputLines(raw string) []string {
+	return tools.SanitizeOutputLines(raw)
 }
 
 // splitLines splits a string into lines, preserving trailing empty line.

--- a/channel/cli_panel_test.go
+++ b/channel/cli_panel_test.go
@@ -414,3 +414,115 @@ func stripANSI(s string) string {
 func indexOfStr(s, substr string) int {
 	return strings.Index(s, substr)
 }
+
+func TestSanitizeOutputLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain text unchanged",
+			input: "hello world",
+			want:  "hello world",
+		},
+		{
+			name:  "carriage return keeps last frame",
+			input: "Loading 10%\rLoading 50%\rLoading 100%",
+			want:  "Loading 100%",
+		},
+		{
+			name:  "ANSI color codes stripped",
+			input: "\x1b[32mSuccess\x1b[0m",
+			want:  "Success",
+		},
+		{
+			name:  "tqdm-style progress bar",
+			input: "Map:  71%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d  | 2118/2967 [00:00<00:00, 81922.37 examples/s]",
+			want:  "Map:  71%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d  | 2118/2967 [00:00<00:00, 81922.37 examples/s]",
+		},
+		{
+			name:  "ANSI + carriage return combined",
+			input: "\x1b[32m100%\r\x1b[0mDone",
+			want:  "Done",
+		},
+		{
+			name:  "empty after carriage return",
+			input: "something\r   ",
+			want:  "   ",
+		},
+		{
+			name:  "multiple carriage returns",
+			input: "a\rb\rc\rdone",
+			want:  "done",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeOutputLine(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeOutputLine(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeOutputLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "simple lines",
+			input: "line1\nline2\nline3",
+			want:  []string{"line1", "line2", "line3"},
+		},
+		{
+			name:  "tqdm progress with carriage return newlines",
+			input: "Map: 100%|\u2588\u2588\u2588| 2967/2967\r\nMap:  71%|\u2588\u2588| 2118/2967\r\nDone loading",
+			want:  []string{"Done loading"},
+		},
+		{
+			name:  "tqdm carriage return within line keeps last frame",
+			input: "Map: 100%|\u2588\u2588\u2588| 2967/2967\rMap:  71%|\u2588\u2588| 2118/2967",
+			want:  []string{"Map:  71%|\u2588\u2588| 2118/2967"},
+		},
+		{
+			name:  "lines that become empty after sanitization are filtered",
+			input: "visible\r   \nalso visible",
+			want:  []string{"also visible"},
+		},
+		{
+			name:  "ANSI colored lines",
+			input: "\x1b[32mGreen\x1b[0m\n\x1b[31mRed\x1b[0m",
+			want:  []string{"Green", "Red"},
+		},
+		{
+			name:  "truly empty lines filtered",
+			input: "a\n\n\nb",
+			want:  []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeOutputLines(tt.input)
+			if len(got) != len(tt.want) {
+				t.Errorf("sanitizeOutputLines(%q) = %q, want %q", tt.input, got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("sanitizeOutputLines(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/tools/sanitize.go
+++ b/tools/sanitize.go
@@ -41,3 +41,14 @@ func SanitizeOutputLines(raw string) []string {
 	}
 	return result
 }
+
+// SanitizeOutput sanitizes multi-line process output into a clean string.
+// It processes each line individually (stripping \r overwrites and ANSI escapes),
+// filters empty lines, and joins the result with newlines.
+func SanitizeOutput(raw string) string {
+	lines := SanitizeOutputLines(raw)
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.Join(lines, "\n")
+}

--- a/tools/sanitize.go
+++ b/tools/sanitize.go
@@ -1,0 +1,43 @@
+package tools
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ansiEscapeRe matches ANSI escape sequences (color codes, cursor movement, etc.)
+var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?\x07|\x1b[^[\]()]`)
+
+// SanitizeOutputLine sanitizes a single output line for safe display.
+// It strips carriage-return overwrites (keeps only the final visual state
+// after the last \r, handling progress bars like tqdm) and removes ANSI
+// escape sequences (color codes, cursor movement, etc.).
+func SanitizeOutputLine(line string) string {
+	// Strip carriage-return overwrites: keep only the final visual
+	// state (content after the last \r).
+	if idx := strings.LastIndex(line, "\r"); idx >= 0 {
+		line = line[idx+1:]
+	}
+	// Strip ANSI escape sequences.
+	line = ansiEscapeRe.ReplaceAllString(line, "")
+	return line
+}
+
+// SanitizeOutputLines splits raw process output into sanitized display lines.
+// It handles \r carriage-return overwrites (progress bars), strips ANSI escape
+// sequences, and filters out empty lines left after sanitization.
+func SanitizeOutputLines(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	rawLines := strings.Split(raw, "\n")
+	var result []string
+	for _, line := range rawLines {
+		line = SanitizeOutputLine(line)
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		result = append(result, line)
+	}
+	return result
+}

--- a/tools/sanitize_test.go
+++ b/tools/sanitize_test.go
@@ -1,0 +1,151 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeOutputLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain text unchanged",
+			input: "hello world",
+			want:  "hello world",
+		},
+		{
+			name:  "carriage return keeps last frame",
+			input: "Loading 10%\rLoading 50%\rLoading 100%",
+			want:  "Loading 100%",
+		},
+		{
+			name:  "ANSI color codes stripped",
+			input: "\x1b[32mSuccess\x1b[0m",
+			want:  "Success",
+		},
+		{
+			name:  "tqdm-style progress bar with unicode blocks",
+			input: "Map:  71%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d  | 2118/2967 [00:00<00:00, 81922.37 examples/s]",
+			want:  "Map:  71%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258d  | 2118/2967 [00:00<00:00, 81922.37 examples/s]",
+		},
+		{
+			name:  "ANSI + carriage return combined",
+			input: "\x1b[32m100%\r\x1b[0mDone",
+			want:  "Done",
+		},
+		{
+			name:  "empty after carriage return",
+			input: "something\r   ",
+			want:  "   ",
+		},
+		{
+			name:  "multiple carriage returns",
+			input: "a\rb\rc\rdone",
+			want:  "done",
+		},
+		{
+			name:  "curl progress output (single line with \\r)",
+			input: "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\r                                 Dload  Upload   Total   Spent    Left  Speed",
+			want:  "                                 Dload  Upload   Total   Spent    Left  Speed",
+		},
+		{
+			name:  "ANSI 256-color",
+			input: "\x1b[38;5;196mRed\x1b[0m text",
+			want:  "Red text",
+		},
+		{
+			name:  "ANSI bold",
+			input: "\x1b[1mBold\x1b[0m",
+			want:  "Bold",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeOutputLine(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitizeOutputLine(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeOutputLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "simple lines",
+			input: "line1\nline2\nline3",
+			want:  []string{"line1", "line2", "line3"},
+		},
+		{
+			name:  "tqdm progress with \\r\\n (each \\r stripped)",
+			input: "Map: 100%|\u2588\u2588\u2588| 2967/2967\r\nMap:  71%|\u2588\u2588| 2118/2967\r\nDone loading",
+			want:  []string{"Done loading"},
+		},
+		{
+			name:  "tqdm carriage return within line keeps last frame",
+			input: "Map: 100%|\u2588\u2588\u2588| 2967/2967\rMap:  71%|\u2588\u2588| 2118/2967",
+			want:  []string{"Map:  71%|\u2588\u2588| 2118/2967"},
+		},
+		{
+			name:  "lines that become empty after sanitization are filtered",
+			input: "visible\r   \nalso visible",
+			want:  []string{"also visible"},
+		},
+		{
+			name:  "ANSI colored lines",
+			input: "\x1b[32mGreen\x1b[0m\n\x1b[31mRed\x1b[0m",
+			want:  []string{"Green", "Red"},
+		},
+		{
+			name:  "truly empty lines filtered",
+			input: "a\n\n\nb",
+			want:  []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeOutputLines(tt.input)
+			if len(got) != len(tt.want) {
+				t.Errorf("SanitizeOutputLines(%q) = %q, want %q", tt.input, got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("SanitizeOutputLines(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeOutputLineNoControlChars(t *testing.T) {
+	// Verify that sanitized output never contains \r or \x1b
+	inputs := []string{
+		"progress\rmore\r\nfinal",
+		"\x1b[1;32mcolor\x1b[0m normal\r\x1b[31mred\x1b[0m",
+		strings.Repeat("frame\r", 100) + "done",
+	}
+	for _, input := range inputs {
+		result := SanitizeOutputLine(input)
+		if strings.Contains(result, "\r") {
+			t.Errorf("SanitizeOutputLine(%q) still contains \\r: %q", input, result)
+		}
+		if strings.Contains(result, "\x1b") {
+			t.Errorf("SanitizeOutputLine(%q) still contains \\x1b: %q", input, result)
+		}
+	}
+}

--- a/tools/task_tools.go
+++ b/tools/task_tools.go
@@ -206,7 +206,9 @@ func FormatBgTaskCompletion(task *BackgroundTask, outputOverride string) string 
 	if outputOverride != "" {
 		fmt.Fprintf(&sb, "\n%s", outputOverride)
 	} else if task.Output != "" {
-		output := task.Output
+		// Sanitize \r overwrites and ANSI escape sequences so that progress
+		// bar output (tqdm, curl, etc.) renders cleanly in the TUI.
+		output := SanitizeOutput(task.Output)
 		// Truncate large output to avoid bloating context
 		const maxOutputLen = 2000
 		if len(output) > maxOutputLen {


### PR DESCRIPTION
## Problem

Background task output from progress bars (tqdm, curl) contains `\r` carriage returns and ANSI escape codes that corrupt the TUI panel rendering. The same issue existed in the offload summary previews shown inline in the chat area.

**Before fix (bg task panel):**
```
│ Log: 8d0c5d2e — cd ... && python3 scripts/train_sft.py 2>&1
│ Warning: You are sending unauthenticated requests...
Map: 100%|██████████| 2967/2967 [00:00<00:00, 81922.37 examples/s]
Map:  71%|███████▏  | 2118/2967 [00:00<00:00,         │amples/s]
│ 8250...
```

**Before fix (inline notification):**
```
Content (first 300 chars):   % Total    % Received % Xferd  Average Speed...
 38%|███▊      | 352/930         3:14,  2.97it/s]s):     | 350/930 [01:58<03:15,  2.97it/s]
```

## Fix

Add shared `tools.SanitizeOutputLine` / `tools.SanitizeOutputLines` to centralize the sanitization logic (`\r` stripping + ANSI removal). All consumers now delegate to this single implementation:

| Consumer | File | What changed |
|---|---|---|
| TUI bg task log panel | `cli_panel.go`, `cli_mouse.go` | 3 data ingestion points use `sanitizeOutputLines` → `tools.SanitizeOutputLines` |
| TUI Shell tool body | `cli_message.go` | `renderShellBody` uses `sanitizeOutputLine` instead of inline `\r` handling |
| Agent offload summarizeShell | `offload.go` | Sanitizes each output line before including in summary |
| Agent offload summarizeDefault | `offload.go` | Sanitizes content before generating preview |
| Channel wrapper | `cli_panel.go` | `sanitizeOutputLine`/`sanitizeOutputLines` are now thin wrappers delegating to `tools` |

### Key design decisions
- **Shared implementation in `tools` package**: No dependency on `charmbracelet/x/ansi` (uses regexp instead), so `agent` package can use it without pulling in TUI dependencies
- **Channel wrapper keeps same API**: Existing callers unchanged, just delegates to shared impl
- **`SanitizeOutputLine` handles single lines** (call after splitting by `\n`)
- **`SanitizeOutputLines` handles full output**: split + sanitize + filter empty lines

## Test plan
- [x] Unit tests for `tools.SanitizeOutputLine` (10 cases: tqdm, curl, ANSI colors, \r overwrite)
- [x] Unit tests for `tools.SanitizeOutputLines` (7 cases)
- [x] Unit tests for `channel.sanitizeOutputLine`/`sanitizeOutputLines` (14 cases)
- [x] NoControlChars invariant test (verifies output never contains `\r` or `\x1b`)
- [x] All existing tests pass
- [x] Pre-commit checks (gofmt, golangci-lint, build, test) all green