### PR TITLE
fix(cli): sidebar section header click panic + Shift+Up/Down history browse

### DIFF
--- a/channel/cli.go
+++ b/channel/cli.go
@@ -110,7 +110,9 @@ func (c *CLIChannel) Start() error {
 
 	// Load per-user UI preferences (sidebar collapse state, etc.)
 	prefs := tools.LoadPreferences(c.workDir, c.model.senderID)
-	c.model.sidebarCollapsedSections = prefs.SidebarCollapsed
+	if prefs.SidebarCollapsed != nil {
+		c.model.sidebarCollapsedSections = prefs.SidebarCollapsed
+	}
 
 	// CLI-side TodoManager for persisting todos across turns and session switches.
 	// Updated by syncProgressTodos during active turns and consumed by endAgentTurn

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -1862,7 +1862,9 @@ func (m *cliModel) handleEnterKey() (tea.Model, []tea.Cmd, bool) {
 // handleShiftUp handles Shift+Up for queue recall and input history browsing.
 func (m *cliModel) handleShiftUp() (tea.Model, []tea.Cmd, bool) {
 	// Shift+Up: recall queued message for editing / browse input history.
-	if m.panelMode == "" && m.textarea.Value() != "" {
+	// When actively browsing history (inputHistoryIdx >= 0), allow continued
+	// scrolling even though textarea has content (from the previous history entry).
+	if m.panelMode == "" && m.textarea.Value() != "" && m.inputHistoryIdx < 0 {
 		return m, nil, true
 	}
 	if !m.viewport.AtBottom() {
@@ -1881,9 +1883,9 @@ func (m *cliModel) handleShiftUp() (tea.Model, []tea.Cmd, bool) {
 	}
 	if m.panelMode == "" && !m.typing {
 		// 空输入时浏览历史
-		if m.textarea.Value() == "" && len(m.inputHistory) > 0 {
+		if (m.textarea.Value() == "" || m.inputHistoryIdx >= 0) && len(m.inputHistory) > 0 {
 			if m.inputHistoryIdx == -1 {
-				m.inputDraft = "" // 保存空草稿
+				m.inputDraft = m.textarea.Value() // 保存当前草稿
 				m.inputHistoryIdx = 0
 			} else if m.inputHistoryIdx < len(m.inputHistory)-1 {
 				m.inputHistoryIdx++
@@ -1899,7 +1901,8 @@ func (m *cliModel) handleShiftUp() (tea.Model, []tea.Cmd, bool) {
 // handleShiftDown handles Shift+Down for reverse input history browsing.
 func (m *cliModel) handleShiftDown() (tea.Model, []tea.Cmd, bool) {
 	// Shift+Down: browse input history backwards.
-	if m.panelMode == "" && m.textarea.Value() != "" {
+	// Only block when NOT in history browsing mode AND textarea has content.
+	if m.panelMode == "" && m.textarea.Value() != "" && m.inputHistoryIdx < 0 {
 		return m, nil, true
 	}
 	if !m.viewport.AtBottom() {


### PR DESCRIPTION
## Changes

### 1. Fix nil map panic on sidebar section header click

Clicking "Sessions"/"Todo"/"Tasks" section headers in the sidebar caused a panic:

```
panic=assignment to entry in nil map
    channel/cli_model.go:1675 → m.sidebarCollapsedSections[section] = true
```

**Root cause**: `LoadPreferences()` returns zero-value `UserPreferences` when the preferences file doesn't exist (first run or remote mode). `SidebarCollapsed` is nil, overwriting the initialized `make(map[string]bool)` at `cli.go:113`.

**Fix**: Add nil guard — only assign `prefs.SidebarCollapsed` when non-nil, preserving the initialized map.

### 2. Fix Shift+Up/Down only browsing one history entry

**Root cause**: After loading the first history entry into textarea, `textarea.Value()` becomes non-empty. The guard `if textarea.Value() != ""` at the top of `handleShiftUp`/`handleShiftDown` swallows all subsequent Shift+Up/Down keypresss, preventing further history browsing.

**Fix**: Skip the guard when `inputHistoryIdx >= 0` (actively browsing history). Also preserve user draft when entering history mode.

## Test Plan
- [x] `go build ./...` passes
- [x] `go test ./channel/...` passes
- [x] Manual: click sidebar section headers with no preferences file → no panic
- [x] Manual: Shift+Up scrolls through full input history