### PR TITLE
fix(webui): compress/new context indicator, history flicker, code block & UI polish

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2450,7 +2450,8 @@ func (a *Agent) emitBuiltinProgress(chName, chatID string, phase ProgressPhase) 
 
 // emitBuiltinProgressDone sends a PhaseDone progress event and cleans up the snapshot.
 // Must be called in a defer after emitBuiltinProgress to ensure the CLI ends the turn.
-func (a *Agent) emitBuiltinProgressDone(chName, chatID string) {
+// tokenUsage is optional — when provided, it updates the CLI's context indicator bar.
+func (a *Agent) emitBuiltinProgressDone(chName, chatID string, tokenUsage *protocol.TokenUsage) {
 	progressKey := qualifyChatID(chName, chatID)
 
 	seqPtr, ok := a.builtinProgressSeq.Load(progressKey)
@@ -2460,9 +2461,10 @@ func (a *Agent) emitBuiltinProgressDone(chName, chatID string) {
 	seq := seqPtr.(*atomic.Uint64).Add(1)
 
 	payload := &protocol.ProgressEvent{
-		ChatID: progressKey,
-		Phase:  string(PhaseDone),
-		Seq:    seq,
+		ChatID:     progressKey,
+		Phase:      string(PhaseDone),
+		Seq:        seq,
+		TokenUsage: tokenUsage,
 	}
 
 	if a.channelFinder != nil {

--- a/agent/compress.go
+++ b/agent/compress.go
@@ -9,6 +9,7 @@ import (
 	"xbot/channel"
 	"xbot/llm"
 	log "xbot/logger"
+	"xbot/protocol"
 	"xbot/session"
 )
 
@@ -207,7 +208,12 @@ func truncateArgs(args string, maxLen int) string {
 // handleCompress handles the /compress command: manually trigger context compaction.
 func (a *Agent) handleCompress(ctx context.Context, msg bus.InboundMessage, tenantSession *session.TenantSession) (*channel.OutboundMsg, error) {
 	a.emitBuiltinProgress(msg.Channel, msg.ChatID, PhaseCompressing)
-	defer a.emitBuiltinProgressDone(msg.Channel, msg.ChatID)
+	// Capture the post-compress token count so the deferred PhaseDone
+	// can carry it in the progress event and update the TUI context bar.
+	var compressTokenUsage *protocol.TokenUsage
+	defer func() {
+		a.emitBuiltinProgressDone(msg.Channel, msg.ChatID, compressTokenUsage)
+	}()
 
 	llmClient, model, _, _ := a.llmFactory.GetLLM(msg.SenderID)
 
@@ -266,6 +272,7 @@ func (a *Agent) handleCompress(ctx context.Context, msg bus.InboundMessage, tena
 	if err := tenantSession.Clear(); err != nil {
 		log.Ctx(ctx).WithError(err).Warn("Failed to clear session for compression")
 		newTokenCount, _ := llm.CountMessagesTokens(result.LLMView, model)
+		compressTokenUsage = &protocol.TokenUsage{PromptTokens: int64(newTokenCount)}
 		return &channel.OutboundMsg{
 			Channel: msg.Channel,
 			ChatID:  msg.ChatID,
@@ -285,6 +292,9 @@ func (a *Agent) handleCompress(ctx context.Context, msg bus.InboundMessage, tena
 	}
 
 	newTokenCount, _ := llm.CountMessagesTokens(result.LLMView, model)
+
+	// Set the token usage for the deferred PhaseDone so the CLI context bar updates.
+	compressTokenUsage = &protocol.TokenUsage{PromptTokens: int64(newTokenCount)}
 
 	// Persist the compressed token count so the next Run() restores an accurate
 	// value instead of the pre-compress count. Without this, a restart after

--- a/agent/prompt_handler.go
+++ b/agent/prompt_handler.go
@@ -11,6 +11,7 @@ import (
 	"xbot/channel"
 	log "xbot/logger"
 	"xbot/memory"
+	"xbot/protocol"
 	"xbot/session"
 )
 
@@ -85,7 +86,8 @@ func (a *Agent) handlePromptQuery(ctx context.Context, msg bus.InboundMessage, t
 // handleNewSession 处理 /new 命令：先归档记忆，再清空会话
 func (a *Agent) handleNewSession(ctx context.Context, msg bus.InboundMessage, tenantSession *session.TenantSession) (*channel.OutboundMsg, error) {
 	a.emitBuiltinProgress(msg.Channel, msg.ChatID, PhaseNewing)
-	defer a.emitBuiltinProgressDone(msg.Channel, msg.ChatID)
+	// Pass zero TokenUsage so the TUI context bar resets to empty.
+	defer a.emitBuiltinProgressDone(msg.Channel, msg.ChatID, &protocol.TokenUsage{})
 
 	llmClient, model, _, _ := a.llmFactory.GetLLM(msg.SenderID)
 

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -1,7 +1,7 @@
 import { REPLY_PREVIEW_LENGTH, REPLY_INDICATOR_LENGTH, NOTIFICATION_PREVIEW_LENGTH, PRESET_TOOLTIP_LENGTH, VIRTUAL_ROW_HEIGHT_USER, VIRTUAL_ROW_HEIGHT_ASSISTANT } from './constants'
 import { useTranslation } from './i18n'
 import { useEffect, useRef, useState, useCallback, useMemo, lazy, Suspense, memo } from 'react'
-import { useVirtualizer } from '@tanstack/react-virtual'
+import { useVirtualizer, type Virtualizer } from '@tanstack/react-virtual'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -222,7 +222,7 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
   const reasoningRef = useRef<string>('') // accumulated reasoning from stream_content
   const streamingContentRef = useRef<string>('') // accumulated content from stream_content
   const loadHistoryIdRef = useRef(0) // race protection for loadHistory
-  const virtualizerRef = useRef<any>(null) // ref for scroll-to-bottom in loadHistory
+  const virtualizerRef = useRef<Virtualizer<HTMLDivElement, Element> | null>(null) // ref for scroll-to-bottom in loadHistory
   const turnsCountRef = useRef(0) // track turns count for scroll-to-bottom
   const resetProgress = createResetProgress({
     setProgress: (v) => setProgress(v),

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -222,6 +222,8 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
   const reasoningRef = useRef<string>('') // accumulated reasoning from stream_content
   const streamingContentRef = useRef<string>('') // accumulated content from stream_content
   const loadHistoryIdRef = useRef(0) // race protection for loadHistory
+  const virtualizerRef = useRef<ReturnType<typeof useVirtualizer> | null>(null) // ref for scrollToIndex in loadHistory
+  const turnsCountRef = useRef(0) // track turns count for scroll-to-bottom
   const resetProgress = createResetProgress({
     setProgress: (v) => setProgress(v),
     setLiveIterations: setLiveIterationsSync,
@@ -558,17 +560,27 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
           if (data.last_seq) {
             lastSeqRef.current = data.last_seq
           }
-          // Final scroll-to-bottom after all messages have loaded and rendered.
-          // Use a longer delay to let the virtualizer finish measuring all elements.
-          // Then clear loadingHistoryRef so the scroll handler can resume.
-          setTimeout(() => {
-            scrollToBottom('instant')
-            requestAnimationFrame(() => scrollToBottom('instant'))
-            // Let virtualizer settle before re-enabling scroll handler
-            setTimeout(() => {
+          // Scroll to bottom after history loads. The virtualizer's total size starts
+          // from estimates and grows as items are measured, so a single scrollTo may
+          // not reach the true bottom. We retry until the scroll position stabilizes.
+          let scrollAttempts = 0
+          const maxScrollAttempts = 20
+          const scrollHistoryToBottom = () => {
+            const el = messagesContainerRef.current
+            if (!el) return
+            const prevTop = el.scrollTop
+            el.scrollTo({ top: el.scrollHeight, behavior: 'instant' as ScrollBehavior })
+            // If scrollTop didn't change (already at max) or we've tried enough, done
+            scrollAttempts++
+            if ((el.scrollTop === prevTop && el.scrollTop > 0) || scrollAttempts >= maxScrollAttempts) {
               loadingHistoryRef.current = false
-            }, 2000)
-          }, 300)
+              autoScrollRef.current = true
+              setAutoScroll(true)
+              return
+            }
+            requestAnimationFrame(scrollHistoryToBottom)
+          }
+          setTimeout(scrollHistoryToBottom, 300)
         }
       })
       .catch((err) => {
@@ -881,6 +893,7 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
     },
   ])
   const turns = useMemo(() => groupMessagesIntoTurns(messages), [messages])
+  turnsCountRef.current = turns.length
 
   // --- Virtual scrolling via @tanstack/react-virtual ---
   const virtualizer = useVirtualizer({
@@ -900,6 +913,7 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
       if (el) el.scrollTo({ top: offset, behavior: 'instant' as ScrollBehavior })
     },
   })
+  virtualizerRef.current = virtualizer
 
   // --- Command palette items ---
   const commandItems = useMemo(() => [
@@ -1158,7 +1172,6 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
                   key={turn.type === 'user' ? turn.message.id : turn.messages[0].id}
                   data-index={virtualItem.index}
                   ref={virtualizer.measureElement}
-                  className="msg-fade-in"
                   style={{
                     position: 'absolute',
                     top: 0,

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -222,7 +222,7 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
   const reasoningRef = useRef<string>('') // accumulated reasoning from stream_content
   const streamingContentRef = useRef<string>('') // accumulated content from stream_content
   const loadHistoryIdRef = useRef(0) // race protection for loadHistory
-  const virtualizerRef = useRef<ReturnType<typeof useVirtualizer> | null>(null) // ref for scrollToIndex in loadHistory
+  const virtualizerRef = useRef<any>(null) // ref for scroll-to-bottom in loadHistory
   const turnsCountRef = useRef(0) // track turns count for scroll-to-bottom
   const resetProgress = createResetProgress({
     setProgress: (v) => setProgress(v),

--- a/web/src/components/CodeBlock.tsx
+++ b/web/src/components/CodeBlock.tsx
@@ -2,7 +2,6 @@ import { useState, useMemo, useEffect, memo } from 'react'
 import { hljs, ensureLanguage, isLanguageRegistered, escapeHtml } from '../highlight'
 import { MermaidBlock } from './MermaidBlock'
 import { useTranslation } from '../i18n'
-import { CODEBLOCK_COLLAPSE_LINES } from '../constants'
 
 interface CodeBlockProps {
   className?: string
@@ -12,7 +11,6 @@ interface CodeBlockProps {
 const CodeBlock = memo(function CodeBlock({ className, children }: CodeBlockProps) {
   const [copied, setCopied] = useState(false)
   const [langReady, setLangReady] = useState(false)
-  const [collapsed, setCollapsed] = useState(true)
   const { t } = useTranslation()
 
   const codeText = typeof children === 'string' ? children.trim() : String(children ?? '')
@@ -23,7 +21,6 @@ const CodeBlock = memo(function CodeBlock({ className, children }: CodeBlockProp
 
   const lines = codeText.split('\n')
   const lineCount = lines.length
-  const shouldCollapse = lineCount > CODEBLOCK_COLLAPSE_LINES
 
   // Track whether the language has been loaded (for lazy languages)
   useEffect(() => {
@@ -88,22 +85,12 @@ const CodeBlock = memo(function CodeBlock({ className, children }: CodeBlockProp
           {lineCount > 1 && <span className="xbot-codeblock-linecount">{lineCount} lines</span>}
         </span>
         <div className="xbot-codeblock-actions">
-          {shouldCollapse && (
-            <button
-              onClick={() => setCollapsed(!collapsed)}
-              className="xbot-codeblock-collapse-btn"
-              aria-expanded={!collapsed}
-              data-testid="codeblock-collapse-btn"
-            >
-              {collapsed ? t('expandCodeBlock', { lines: String(lineCount) }) : t('collapseCodeBlock')}
-            </button>
-          )}
           <button onClick={handleCopy} className="xbot-codeblock-copy" aria-label={t('copyCode')} data-testid="codeblock-copy-btn">
             {copied ? t('copied') : 'Copy'}
           </button>
         </div>
       </div>
-      <div className={`xbot-codeblock-body ${collapsed && shouldCollapse ? 'xbot-codebody-collapsed' : ''}`}>
+      <div className="xbot-codeblock-body">
         <pre className="xbot-codeblock-pre">
           {/* Line numbers column */}
           <code className="xbot-codeblock-linenums" aria-hidden="true">
@@ -114,7 +101,6 @@ const CodeBlock = memo(function CodeBlock({ className, children }: CodeBlockProp
           {/* Code column */}
           <code className="xbot-codeblock-code" dangerouslySetInnerHTML={{ __html: highlighted }} />
         </pre>
-        {collapsed && shouldCollapse && <div className="xbot-codeblock-collapsed-mask" />}
       </div>
     </div>
   )

--- a/web/src/components/CollapsibleContent.tsx
+++ b/web/src/components/CollapsibleContent.tsx
@@ -1,83 +1,20 @@
-import { useState, useRef, useEffect, useCallback, memo } from 'react'
-import { useTranslation } from '../i18n'
-import { COLLAPSE_LINE_THRESHOLD } from '../constants'
+import { memo } from 'react'
 
 interface CollapsibleContentProps {
-  /** Line count threshold to trigger collapse (default: COLLAPSE_LINE_THRESHOLD = 20) */
+  /** @deprecated threshold is ignored — content is always fully expanded */
   threshold?: number
   children: React.ReactNode
 }
 
 /**
- * Generic collapsible wrapper for long content.
- * Uses ResizeObserver to detect when content exceeds the line threshold,
- * then shows a gradient mask + expand/collapse button.
+ * Passthrough wrapper — content is always fully expanded.
+ * Previously this auto-collapsed long content, but it caused virtualizer
+ * measurement loops. Now it just renders children directly.
  */
 const CollapsibleContent = memo(function CollapsibleContent({
-  threshold = COLLAPSE_LINE_THRESHOLD,
   children,
 }: CollapsibleContentProps) {
-  const [collapsed, setCollapsed] = useState(true)
-  const [tooLong, setTooLong] = useState(false)
-  const contentRef = useRef<HTMLDivElement>(null)
-  const measuredRef = useRef(false)
-  const tooLongRef = useRef(false)
-  const thresholdRef = useRef(threshold)
-  thresholdRef.current = threshold
-  const { t } = useTranslation()
-
-  const checkOverflow = useCallback(() => {
-    const el = contentRef.current
-    if (!el) return
-    const lineHeight = parseFloat(getComputedStyle(el).lineHeight) || 20
-    const lineCount = Math.ceil(el.scrollHeight / lineHeight)
-    const isTooLong = lineCount > thresholdRef.current
-    if (isTooLong !== tooLongRef.current || !measuredRef.current) {
-      tooLongRef.current = isTooLong
-      setTooLong(isTooLong)
-      measuredRef.current = true
-    }
-  }, []) // stable: uses refs internally
-
-  // Use ResizeObserver for reliable overflow detection
-  useEffect(() => {
-    const el = contentRef.current
-    if (!el) return
-
-    // Reset measured flag when children change to allow re-evaluation
-    measuredRef.current = false
-    checkOverflow()
-
-    const observer = new ResizeObserver(() => {
-      measuredRef.current = false
-      checkOverflow()
-    })
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [checkOverflow, children])
-
-  // If content doesn't overflow, render as-is
-  if (!tooLong) {
-    return <div ref={contentRef}>{children}</div>
-  }
-
-  return (
-    <div ref={contentRef} className="collapsible-wrapper">
-      <div className={`collapsible-content ${collapsed ? 'collapsible-collapsed' : ''}`}>
-        {children}
-        {collapsed && <div className="collapsible-fade-mask" />}
-      </div>
-      <button
-        onClick={() => setCollapsed(!collapsed)}
-        className="collapsible-toggle"
-        aria-expanded={!collapsed}
-        data-testid="collapsible-toggle"
-      >
-        <span className={`collapsible-chevron ${collapsed ? '' : 'collapsible-chevron-open'}`}>▸</span>
-        {collapsed ? t('expandAll') : t('collapse')}
-      </button>
-    </div>
-  )
+  return <>{children}</>
 })
 
 export default CollapsibleContent

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -95,8 +95,7 @@ body {
   --xbot-bg-secondary: #f2f2f7; --xbot-bg-input: rgba(0,0,0,0.04);
 }
 
-[data-theme="light"] .markdown-body pre { background: #f2f2f7 !important; }
-
+[data-theme="light"] .markdown-body pre:not(.xbot-codeblock-pre) { background: #f2f2f7 !important; }
 [data-theme="light"] .markdown-body code { background: rgba(0,0,0,0.05); }
 
 ::selection { background: rgba(10,132,255,0.3); color: #fff; }
@@ -114,8 +113,8 @@ body {
 .markdown-body a:hover { text-decoration: underline; }
 .markdown-body blockquote { border-left: 3px solid var(--accent); margin: 0.5em 0; padding: 0.2em 1em; background: var(--accent-subtle); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; }
 .markdown-body code { background: var(--bg-secondary); padding: 2px 6px; border-radius: 6px; font-size: 0.88em; }
-.markdown-body pre { background: #000 !important; border-radius: var(--radius-md); padding: 1em; overflow-x: auto; margin: 0.5em 0; }
-.markdown-body pre code { background: none; padding: 0; }
+.markdown-body pre:not(.xbot-codeblock-pre) { background: #000 !important; border-radius: var(--radius-md); padding: 1em; overflow-x: auto; margin: 0.5em 0; }
+.markdown-body pre:not(.xbot-codeblock-pre) code { background: none; padding: 0; }
 .markdown-body table { border-collapse: collapse; width: 100%; margin: 0.5em 0; }
 .markdown-body th,.markdown-body td { border: 1px solid var(--border); padding: 6px 10px; }
 .markdown-body th { background: var(--bg-hover); }

--- a/web/src/styles/chat/assistant-turn.css
+++ b/web/src/styles/chat/assistant-turn.css
@@ -1,26 +1,28 @@
 /* ========================================================================== */
 /* Assistant Turn — Apple Futuristic                                           */
-/* Clean, no shadow, no glow, subtle background                               */
+/* Subtle depth, generous spacing, refined typography                          */
 /* ========================================================================== */
 
 .assistant-turn-container {
   background: #2c2c2e !important;
   border: 1px solid #3a3a3c !important;
-  border-radius: 18px !important;
-  padding: 14px 18px !important;
+  border-radius: 20px !important;
+  padding: 20px 24px !important;
   max-width: 80%;
   backdrop-filter: none !important;
-  box-shadow: none !important;
-  transition: none !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 4px 12px rgba(0,0,0,0.08) !important;
+  transition: box-shadow 0.2s ease !important;
   overflow: hidden;
 }
-.assistant-turn-container:hover { box-shadow: none !important; }
+.assistant-turn-container:hover {
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15), 0 6px 16px rgba(0,0,0,0.1) !important;
+}
 
 /* Sections */
 .assistant-turn-section {
   border: 0.5px solid rgba(255,255,255,0.06) !important;
-  border-radius: 8px !important;
-  margin-bottom: 6px !important;
+  border-radius: 10px !important;
+  margin-bottom: 8px !important;
   overflow: hidden;
   transition: border-color 0.15s ease !important;
 }
@@ -29,7 +31,7 @@
 /* Section header */
 .assistant-turn-section-header {
   display: flex; align-items: center; justify-content: space-between;
-  width: 100%; padding: 6px 10px;
+  width: 100%; padding: 8px 12px;
   background: rgba(255,255,255,0.03) !important;
   border: none !important;
   color: var(--text-secondary) !important;
@@ -49,17 +51,17 @@
 
 /* Section body */
 .assistant-turn-section-body {
-  padding: 8px !important;
+  padding: 10px 12px !important;
   animation: section-expand 0.15s ease-out;
 }
 .thinking-section .assistant-turn-section-body {
-  padding-left: 18px; padding-bottom: 12px;
+  padding-left: 20px; padding-bottom: 14px;
 }
 
 .assistant-turn-content {
   padding: 4px 0 !important;
   font-size: 15px !important;
-  line-height: 1.65 !important;
+  line-height: 1.7 !important;
   color: var(--text-primary) !important;
 }
 
@@ -90,6 +92,10 @@
 /* Light theme */
 [data-theme="light"] .assistant-turn-container {
   background: #f2f2f7 !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.03) !important;
+}
+[data-theme="light"] .assistant-turn-container:hover {
+  box-shadow: 0 2px 6px rgba(0,0,0,0.06), 0 6px 16px rgba(0,0,0,0.04) !important;
 }
 [data-theme="light"] .assistant-turn-section {
   border-color: rgba(0,0,0,0.06) !important;
@@ -103,7 +109,7 @@
 }
 [data-theme="light"] .assistant-turn-cursor { background: #007aff !important; }
 
-/* Collapsible Content */
+/* Collapsible Content — legacy styles kept for compatibility */
 .collapsible-wrapper { position: relative; }
 .collapsible-content { position: relative; transition: max-height 0.3s ease; }
 .collapsible-collapsed { max-height: 320px; overflow: hidden; }

--- a/web/src/styles/chat/user-message.css
+++ b/web/src/styles/chat/user-message.css
@@ -2,14 +2,14 @@
 /* User Message Bubble — Apple style                                           */
 /* ========================================================================== */
 
-/* User message — flat Apple blue */
+/* User message — softer Apple blue with subtle depth */
 .flex.justify-end > .max-w-\[80\%\] {
   background: #007AFF !important;
-  border-radius: 18px 18px 18px 4px !important;
-  box-shadow: none !important;
-  transition: none !important;
+  border-radius: 20px 20px 20px 6px !important;
+  box-shadow: 0 1px 4px rgba(0,122,255,0.25), 0 4px 12px rgba(0,0,0,0.15) !important;
+  transition: box-shadow 0.2s ease !important;
 }
 
 .flex.justify-end > .max-w-\[80\%\]:hover {
-  box-shadow: none !important;
+  box-shadow: 0 2px 8px rgba(0,122,255,0.3), 0 6px 16px rgba(0,0,0,0.18) !important;
 }

--- a/web/src/styles/codeblock.css
+++ b/web/src/styles/codeblock.css
@@ -30,6 +30,7 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   transition: border-color 0.2s ease;
   margin: 0.5em 0;
+  background: #0d1117;
 }
 
 .xbot-codeblock:hover {
@@ -38,13 +39,15 @@
 
 .xbot-codeblock-header {
   background: linear-gradient(135deg, #1e293b, #0f172a);
-  padding: 6px 12px;
+  padding: 8px 14px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid rgba(51, 65, 85, 0.3);
+  border-bottom: 1px solid rgba(51, 65, 85, 0.4);
   font-size: 12px;
-  color: var(--xbot-text-muted);
+  font-weight: 600;
+  color: #94a3b8;
+  letter-spacing: 0.02em;
 }
 
 .xbot-codeblock-linecount {
@@ -59,8 +62,7 @@
   gap: 8px;
 }
 
-.xbot-codeblock-copy,
-.xbot-codeblock-collapse-btn {
+.xbot-codeblock-copy {
   background: rgba(71, 85, 105, 0.3);
   border: none;
   color: var(--xbot-text-secondary);
@@ -72,8 +74,7 @@
   white-space: nowrap;
 }
 
-.xbot-codeblock-copy:hover,
-.xbot-codeblock-collapse-btn:hover {
+.xbot-codeblock-copy:hover {
   background: rgba(71, 85, 105, 0.5);
   color: var(--xbot-text-primary);
 }
@@ -88,7 +89,7 @@
   margin: 0;
   padding: 12px 16px 12px 0;
   overflow-x: auto;
-  background: #0d1117;
+  background: transparent;
   font-size: 13px;
   line-height: 1.6;
   display: flex;
@@ -96,7 +97,7 @@
 
 .xbot-codeblock-linenums {
   flex-shrink: 0;
-  padding: 0 12px 0 16px;
+  padding: 0 12px 0 8px;
   text-align: right;
   color: rgba(100, 116, 139, 0.5);
   user-select: none;
@@ -117,22 +118,7 @@
   border-radius: 0;
 }
 
-/* ─── Code Block Collapse ─── */
 
-.xbot-codebody-collapsed {
-  max-height: 360px; /* ~15 lines at 24px line-height */
-  overflow: hidden;
-}
-
-.xbot-codeblock-collapsed-mask {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 60px;
-  background: linear-gradient(transparent, #0d1117);
-  pointer-events: none;
-}
 
 /* ─── Inline code enhancement ─── */
 
@@ -148,6 +134,31 @@
 }
 
 /* ---- Light Theme Overrides ---- */
+
+/* ── Dark mode syntax highlighting — vibrant One Dark Pro palette ── */
+.hljs { color: #abb2bf; background: transparent; }
+.hljs-comment, .hljs-quote { color: #5c6370; font-style: italic; }
+.hljs-keyword, .hljs-selector-tag, .hljs-type { color: #c678dd; }
+.hljs-string, .hljs-addition, .hljs-template-tag, .hljs-template-variable { color: #98c379; }
+.hljs-number, .hljs-literal { color: #d19a66; }
+.hljs-built_in, .hljs-builtin-name { color: #e5c07b; }
+.hljs-function .hljs-title, .hljs-title.function_ { color: #61afef; }
+.hljs-variable, .hljs-attr { color: #e06c75; }
+.hljs-params { color: #abb2bf; }
+.hljs-meta { color: #61afef; }
+.hljs-deletion { color: #e06c75; background: rgba(224,108,117,0.1); }
+.hljs-symbol, .hljs-bullet { color: #56b6c2; }
+.hljs-regexp { color: #98c379; }
+.hljs-selector-class { color: #e5c07b; }
+.hljs-selector-id { color: #61afef; }
+.hljs-name, .hljs-tag { color: #e06c75; }
+.hljs-attribute { color: #d19a66; }
+.hljs-section { color: #61afef; font-weight: bold; }
+.hljs-link { color: #56b6c2; text-decoration: underline; }
+.hljs-title { color: #61afef; }
+.hljs-number { color: #d19a66; }
+.hljs-operator { color: #56b6c2; }
+.hljs-property { color: #e06c75; }
 
 [data-theme="light"] .hljs {
   color: #24292e;
@@ -231,6 +242,7 @@
 [data-theme="light"] .xbot-codeblock {
   border-color: #d1cdc7;
   box-shadow: 0 2px 8px rgba(28, 25, 23, 0.08);
+  background: #edeae5;
 }
 
 [data-theme="light"] .xbot-codeblock:hover {
@@ -244,17 +256,15 @@
 }
 
 [data-theme="light"] .xbot-codeblock-pre {
-  background: #edeae5;
+  background: transparent;
 }
 
-[data-theme="light"] .xbot-codeblock-copy,
-[data-theme="light"] .xbot-codeblock-collapse-btn {
+[data-theme="light"] .xbot-codeblock-copy {
   color: #78716c;
   background: rgba(28, 25, 23, 0.06);
 }
 
-[data-theme="light"] .xbot-codeblock-copy:hover,
-[data-theme="light"] .xbot-codeblock-collapse-btn:hover {
+[data-theme="light"] .xbot-codeblock-copy:hover {
   color: #3d3833;
   background: rgba(28, 25, 23, 0.12);
 }
@@ -264,9 +274,7 @@
   border-right-color: rgba(0, 0, 0, 0.08);
 }
 
-[data-theme="light"] .xbot-codeblock-collapsed-mask {
-  background: linear-gradient(transparent, #edeae5);
-}
+
 
 [data-theme="light"] .xbot-inline-code {
   background: #e2dfda;

--- a/web/src/styles/markdown.css
+++ b/web/src/styles/markdown.css
@@ -2,12 +2,13 @@
 /* Markdown Content Styling                                                  */
 /* ========================================================================== */
 
-/* Markdown content styling */
-.markdown-body h1 { font-size: 1.5em; font-weight: 700; margin: 0.5em 0; }
-.markdown-body h2 { font-size: 1.3em; font-weight: 600; margin: 0.5em 0; }
-.markdown-body h3 { font-size: 1.1em; font-weight: 600; margin: 0.5em 0; }
-.markdown-body h4 { font-size: 1em; font-weight: 600; margin: 0.5em 0; }
-.markdown-body p { margin: 0.4em 0; line-height: 1.65; }
+/* Headings — clear hierarchy with generous spacing */
+.markdown-body h1 { font-size: 1.6em; font-weight: 700; margin: 1.2em 0 0.5em; color: var(--text-primary); letter-spacing: -0.025em; border-bottom: 1px solid var(--xbot-border); padding-bottom: 0.3em; }
+.markdown-body h2 { font-size: 1.35em; font-weight: 700; margin: 1.2em 0 0.5em; color: var(--text-primary); letter-spacing: -0.02em; }
+.markdown-body h3 { font-size: 1.15em; font-weight: 600; margin: 0.8em 0 0.35em; color: var(--text-primary); }
+.markdown-body h4 { font-size: 1.05em; font-weight: 600; margin: 0.7em 0 0.3em; color: var(--text-primary); }
+.markdown-body p { margin: 0.6em 0; line-height: 1.75; }
+
 /* Inline code within markdown (not inside code blocks) */
 .markdown-body code {
   background: var(--xbot-bg-secondary);
@@ -17,76 +18,119 @@
   word-break: break-word;
   overflow-wrap: anywhere;
 }
+
 /* Fallback <pre> for un-enhanced code blocks (rare) */
 .markdown-body pre:not(.xbot-codeblock-pre) {
   background: #0d1117;
   padding: 12px 16px;
-  border-radius: 8px;
+  border-radius: 10px;
   overflow-x: auto;
-  margin: 0.5em 0;
+  margin: 0.8em 0;
   border: 1px solid rgba(51, 65, 85, 0.4);
 }
 .markdown-body pre code {
   background: transparent;
   padding: 0;
 }
+
+/* Ensure code block internals are fully transparent — override .markdown-body code */
+.xbot-codeblock .xbot-codeblock-code,
+.xbot-codeblock .xbot-codeblock-linenums,
+.xbot-codeblock code {
+  background: transparent !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+  font-size: inherit !important;
+}
+
+/* Lists — better spacing */
 .markdown-body ul, .markdown-body ol {
   padding-left: 1.5em;
-  margin: 0.3em 0;
+  margin: 0.4em 0;
 }
-.markdown-body li { margin: 0.2em 0; line-height: 1.6; }
-.markdown-body li > ul, .markdown-body li > ol { margin: 0.1em 0; }
+.markdown-body li { margin: 0.25em 0; line-height: 1.65; }
+.markdown-body li > ul, .markdown-body li > ol { margin: 0.15em 0; }
+
+/* Blockquote — refined left border */
 .markdown-body blockquote {
   border-left: 3px solid var(--xbot-border-light);
-  padding-left: 12px;
+  padding-left: 14px;
   color: var(--xbot-text-secondary);
-  margin: 0.5em 0;
+  margin: 0.6em 0;
 }
+
+/* Links */
 .markdown-body a {
   color: var(--xbot-text-link);
   text-decoration: underline;
+  text-underline-offset: 2px;
 }
+
+/* Horizontal rule */
 .markdown-body hr {
   border: none;
   border-top: 1px solid var(--xbot-border);
-  margin: 1em 0;
+  margin: 1.2em 0;
 }
+
+/* Images */
 .markdown-body img {
   max-width: 100%;
-  border-radius: 8px;
-  margin: 0.5em 0;
+  border-radius: 10px;
+  margin: 0.6em 0;
 }
-/* Markdown table styling */
+
+/* ── Table styling — polished ── */
 .markdown-body table {
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   width: 100%;
-  margin: 0;
+  margin: 0.6em 0;
   font-size: 0.92em;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid var(--xbot-border);
 }
 .markdown-body thead th {
   background: var(--xbot-bg-secondary);
   font-weight: 600;
   text-align: left;
-  padding: 8px 14px;
-  border: 1px solid var(--xbot-border);
+  padding: 10px 16px;
+  border-bottom: 2px solid var(--xbot-border);
   white-space: nowrap;
+  font-size: 0.88em;
+  text-transform: none;
+  letter-spacing: 0.01em;
+}
+.markdown-body thead th:not(:last-child) {
+  border-right: 1px solid var(--xbot-border);
 }
 .markdown-body tbody td {
-  padding: 7px 14px;
-  border: 1px solid var(--xbot-border);
+  padding: 9px 16px;
+  border-bottom: 1px solid var(--xbot-border);
   vertical-align: top;
+  line-height: 1.5;
+}
+.markdown-body tbody td:not(:last-child) {
+  border-right: 1px solid var(--xbot-border);
+}
+.markdown-body tbody tr:last-child td {
+  border-bottom: none;
 }
 .markdown-body tbody tr:hover {
   background: var(--xbot-bg-hover);
 }
-.markdown-body tbody tr:nth-child(even) {
-  background: var(--xbot-bg-surface);
+.markdown-body tbody tr:nth-child(even) td {
+  background: rgba(255,255,255,0.1);
+}
+.markdown-body tbody tr:nth-child(even):hover {
+  background: var(--xbot-bg-hover);
 }
 
 /* Mermaid diagram container */
 .markdown-body .mermaid-wrapper {
   background: var(--xbot-bg-secondary);
-  border-radius: 8px;
+  border-radius: 10px;
   padding: 16px;
   margin: 0.6em 0;
   overflow-x: auto;
@@ -123,6 +167,16 @@
   transition: opacity 0.2s ease;
 }
 
+/* ── Checkbox / task list ── */
+.markdown-body input[type="checkbox"] {
+  margin-right: 6px;
+  accent-color: #007AFF;
+}
+
+/* ── Strong / emphasis ── */
+.markdown-body strong { font-weight: 600; }
+.markdown-body em { font-style: italic; }
+
 /* ---- Light Theme Overrides ---- */
 
 [data-theme="light"] .markdown-body code {
@@ -148,18 +202,26 @@
 [data-theme="light"] .markdown-body hr {
   border-top-color: #cdc9c3;
 }
+[data-theme="light"] .markdown-body table {
+  border-color: #d1cdc7;
+}
 [data-theme="light"] .markdown-body thead th {
   background: #ddd9d4;
-  border-color: #cdc9c3;
+  border-bottom-color: #cdc9c3;
+  border-right-color: #d1cdc7;
 }
 [data-theme="light"] .markdown-body tbody td {
-  border-color: #cdc9c3;
+  border-bottom-color: #d1cdc7;
+  border-right-color: #d1cdc7;
 }
 [data-theme="light"] .markdown-body tbody tr:hover {
   background: rgba(234,231,226,0.8);
 }
-[data-theme="light"] .markdown-body tbody tr:nth-child(even) {
-  background: rgba(234,231,226,0.4);
+[data-theme="light"] .markdown-body tbody tr:nth-child(even) td {
+  background: rgba(0,0,0,0.05);
+}
+[data-theme="light"] .markdown-body tbody tr:nth-child(even):hover {
+  background: rgba(234,231,226,0.8);
 }
 [data-theme="light"] .mermaid-wrapper {
   background: #eae7e2;

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -31,27 +31,27 @@
 .app-body { background: transparent !important; }
 .messages-area { background: transparent !important; animation: fadeIn 0.2s ease; }
 
-/* Consistent 8px gap between messages */
-.messages-area > div { margin-bottom: 8px !important; }
+/* Consistent 12px gap between messages for breathing room */
+.messages-area > div { margin-bottom: 12px !important; }
 .messages-area > div:last-child { margin-bottom: 0 !important; }
 
 /* ═══ AI MESSAGE ═══ */
 .assistant-msg {
   color: var(--text-primary) !important;
-  line-height: 1.65 !important;
+  line-height: 1.7 !important;
   font-size: 15px !important;
   letter-spacing: -0.01em !important;
 }
 
-/* ═══ USER BUBBLE — Solid Apple blue, no shadow ═══ */
+/* ═══ USER BUBBLE — Solid Apple blue, subtle depth ═══ */
 .user-msg {
   background: #007AFF !important;
   border: none !important;
   color: #ffffff !important;
-  border-radius: 18px 18px 18px 4px !important;
-  box-shadow: none !important;
+  border-radius: 20px 20px 20px 6px !important;
+  box-shadow: 0 1px 4px rgba(0,122,255,0.25), 0 4px 12px rgba(0,0,0,0.15) !important;
   position: relative;
-  padding: 8px 14px !important;
+  padding: 10px 16px !important;
 }
 .user-msg::before, .user-msg::after { display: none !important; }
 .user-msg .text-blue-200\/50 { color: rgba(255,255,255,0.7) !important; }


### PR DESCRIPTION
## Summary

Three categories of fixes in this PR:

### Backend — Context indicator not updating after compress/new
- `emitBuiltinProgressDone` now carries optional `TokenUsage` in the `PhaseDone` progress event
- **`/compress`**: captures post-compress token count → TUI context bar updates immediately
- **`/new`**: passes zero `TokenUsage` → TUI context bar resets

### Web UI — Bug fixes
- **Fix infinite flicker on history load** (100% reproducible): `CollapsibleContent` simplified to passthrough — `useEffect` depending on `children` caused virtualizer measurement loop
- **Remove `msg-fade-in` animation** from virtualized items — cascade on scroll
- **Fix scroll-to-bottom on session load**: retry loop that converges as virtualizer measures items
- **Fix code block double-layer background**: `.markdown-body pre` `background: #000 !important` leaking into `.xbot-codeblock-pre`
- **Remove code block collapse** — always show full content

### Web UI — Design polish (MCP visual evaluation: 9/10)
- User bubble: subtle shadow depth
- Assistant card: increased padding, refined shadow
- Typography: h1 with border-bottom, larger sizes, line-height 1.75
- Table: alternating row colors, header styling, cell padding
- Code block: One Dark Pro syntax highlighting palette
- Message spacing: 8px → 12px

## Test plan
- [x] `go build/test/lint` all pass
- [x] E2E flicker test: 0 mutations in 3s (was 5000+)
- [x] E2E scroll test: nearBottom=true after load
