### PR TITLE
fix(webui): context menu & message UX improvements

### DIFF
--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -1285,8 +1285,11 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
                           </div>
                         )}
                         <div className="rounded-xl px-4 py-3 bg-blue-600 text-white markdown-body text-sm relative ml-auto user-msg"
-                             style={{ width: 'fit-content', overflowWrap: 'break-word' }}
+                             style={{ width: 'fit-content', overflowWrap: 'break-word', userSelect: 'text' }}
                              onContextMenu={(e) => {
+                               // Allow native context menu when text is selected (for copy)
+                               const selection = window.getSelection()
+                               if (selection && selection.toString().trim().length > 0) return
                                e.preventDefault()
                                setContextMenu({
                                  x: e.clientX,
@@ -1300,20 +1303,23 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
                              }}
                         >
                           <UserMessageContent content={turn.message.content} onPreview={(url) => setPreviewImage(url)} />
-                          {turn.message.ts && (
-                           <div className="text-xs mt-1 text-right text-blue-200/50 flex items-center justify-end gap-1">
-                             <span>{formatRelativeTime(turn.message.ts * 1000)}</span>
-                             {turn.message.status === 'sending' && <span className="animate-pulse"><IconClock className="inline" /></span>}
-                             {turn.message.status === 'failed' && <span className="text-red-300"><IconX className="inline" /> {t('sendFailed')}</span>}
-                             {turn.message.edited && <span className="italic">{t('edited')}</span>}
-                           </div>
-                          )}
                         </div>
+                        {turn.message.ts && (
+                         <div className="user-msg-timestamp">
+                           <span>{formatRelativeTime(turn.message.ts * 1000)}</span>
+                           {turn.message.status === 'sending' && <span className="animate-pulse"><IconClock className="inline" /></span>}
+                           {turn.message.status === 'failed' && <span className="text-red-400"><IconX className="inline" /> {t('sendFailed')}</span>}
+                           {turn.message.edited && <span className="italic">{t('edited')}</span>}
+                         </div>
+                        )}
                       </div>
                     </SwipeableMessage>
                   ) : (
                     <div className="mb-4" data-msg-id={turn.messages[0].id}
                       onContextMenu={(e) => {
+                        // Allow native context menu when text is selected (for copy)
+                        const selection = window.getSelection()
+                        if (selection && selection.toString().trim().length > 0) return
                         e.preventDefault()
                         const last = turn.messages[turn.messages.length - 1]
                         setContextMenu({

--- a/web/src/components/MessageActions.tsx
+++ b/web/src/components/MessageActions.tsx
@@ -67,28 +67,28 @@ export default function MessageActions({ onCopy, onDelete, onRegenerate, onReply
           {menuOpen && (
             <>
               <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(false)} />
-              <div className="absolute left-0 bottom-full mb-1 bg-slate-800 border border-slate-600 rounded-lg shadow-xl z-50 py-1 min-w-[140px]" role="menu" onKeyDown={(e) => { if (e.key === 'Escape') setMenuOpen(false) }}>
-                {onSnapshot && (
+              <div className="message-actions-popup" role="menu" onKeyDown={(e) => { if (e.key === 'Escape') setMenuOpen(false) }}>
+                 {onSnapshot && (
                   <button
-                    onClick={() => { onSnapshot(); setMenuOpen(false) }}
-                    className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-slate-700 hover:text-white transition-colors flex items-center gap-2"
-                    role="menuitem"
-                    data-testid="snapshot-btn"
+                   onClick={() => { onSnapshot(); setMenuOpen(false) }}
+                   className="message-actions-popup-item"
+                   role="menuitem"
+                   data-testid="snapshot-btn"
                   >
-                    <IconBookmark className="inline" /> {t('takeSnapshot')}
+                   <IconBookmark className="inline" /> {t('takeSnapshot')}
                   </button>
-                )}
-                {onDelete && (
+                 )}
+                 {onDelete && (
                   <button
-                    onClick={() => { onDelete(); setMenuOpen(false) }}
-                    className="w-full text-left px-3 py-2 text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 transition-colors flex items-center gap-2"
-                    role="menuitem"
-                    data-testid="delete-btn"
+                   onClick={() => { onDelete(); setMenuOpen(false) }}
+                   className="message-actions-popup-item message-actions-popup-danger"
+                   role="menuitem"
+                   data-testid="delete-btn"
                   >
-                    <IconTrash className="inline" /> {t('deleteMessage')}
+                   <IconTrash className="inline" /> {t('deleteMessage')}
                   </button>
-                )}
-              </div>
+                 )}
+                </div>
             </>
           )}
         </div>

--- a/web/src/styles/chat/context-menu.css
+++ b/web/src/styles/chat/context-menu.css
@@ -7,24 +7,12 @@
   z-index: 9999;
   min-width: 160px;
   max-width: 260px;
-  background: var(--color-surface, #1e293b);
-  border: 1px solid rgba(71, 85, 105, 0.5);
+  background: var(--bg-secondary, #1e293b);
+  border: 1px solid var(--border, rgba(71, 85, 105, 0.5));
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
-  backdrop-filter: blur(12px);
   padding: 4px;
-  animation: context-menu-appear 0.12s ease-out;
-}
-
-@keyframes context-menu-appear {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
+  overflow: visible;
 }
 
 .context-menu-item {
@@ -35,7 +23,7 @@
   padding: 8px 12px;
   border: none;
   background: none;
-  color: var(--color-text-secondary, #cbd5e1);
+  color: var(--text-secondary, #cbd5e1);
   font-size: 0.875rem;
   cursor: pointer;
   border-radius: 8px;
@@ -46,8 +34,8 @@
 
 .context-menu-item:hover,
 .context-menu-item:focus-visible {
-  background: rgba(71, 85, 105, 0.3);
-  color: var(--color-text-primary, #f1f5f9);
+  background: var(--bg-hover, rgba(71, 85, 105, 0.3));
+  color: var(--text-primary, #f1f5f9);
   outline: none;
 }
 

--- a/web/src/styles/chat/user-message.css
+++ b/web/src/styles/chat/user-message.css
@@ -24,3 +24,15 @@
 [data-theme="light"] .user-msg:hover {
   background: #e8e8e8 !important;
 }
+
+.user-msg-timestamp {
+  text-align: right;
+  margin-top: 2px;
+  padding-right: 4px;
+  font-size: 11px;
+  color: #ddd9d4;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+}

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -77,6 +77,76 @@
   background: rgba(0,0,0,0.04);
 }
 
+/* ═══ MESSAGE ACTIONS POPUP (three-dot menu) ═══ */
+.message-actions-popup {
+  position: absolute;
+  left: 0;
+  bottom: 100%;
+  margin-bottom: 4px;
+  background: var(--bg-secondary, #1e293b);
+  border: 1px solid var(--border, rgba(71,85,105,0.5));
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.35);
+  z-index: 50;
+  padding: 4px;
+  min-width: 140px;
+}
+
+.message-actions-popup-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: none;
+  color: var(--text-secondary, #cbd5e1);
+  font-size: 0.875rem;
+  cursor: pointer;
+  border-radius: 6px;
+  text-align: left;
+  white-space: nowrap;
+  transition: background 0.1s, color 0.1s;
+}
+
+.message-actions-popup-item:hover {
+  background: var(--bg-hover, rgba(71,85,105,0.3));
+  color: var(--text-primary, #f1f5f9);
+}
+
+.message-actions-popup-danger {
+  color: #f87171;
+}
+
+.message-actions-popup-danger:hover {
+  background: rgba(239,68,68,0.15);
+  color: #fca5a5;
+}
+
+[data-theme="light"] .message-actions-popup {
+  background: #ffffff;
+  border-color: #e2e8f0;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.12);
+}
+
+[data-theme="light"] .message-actions-popup-item {
+  color: #334155;
+}
+
+[data-theme="light"] .message-actions-popup-item:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+
+[data-theme="light"] .message-actions-popup-danger {
+  color: #dc2626;
+}
+
+[data-theme="light"] .message-actions-popup-danger:hover {
+  background: rgba(239,68,68,0.08);
+  color: #b91c1c;
+}
+
 /* ═══ AI MESSAGE ═══ */
 .assistant-msg {
   color: var(--text-primary) !important;


### PR DESCRIPTION
## Changes

- **User message timestamp**: moved outside bubble, right-aligned below bubble, color `#ddd9d4`
- **Right-click context menu**: allow native browser menu when text is selected (enables copy selection)
- **Three-dot popup menu**: replaced hardcoded `bg-slate-800` with CSS variable `--bg-secondary` solid background (fixes transparency issue)
- **Context menu CSS**: removed `backdrop-filter: blur()`, removed scale animation that caused incorrect height calculation
- **Light theme**: added proper light theme styles for all popup menus

## Test
- [x] `npm run build` passes
- [x] User message text is selectable
- [x] Right-click with selection shows native copy menu
- [x] Right-click without selection shows custom menu
- [x] Three-dot popup has solid background (not transparent)