### PR TITLE
fix: structured progress race, compressing phase, tool label cleanup

### DIFF
--- a/agent/engine_run.go
+++ b/agent/engine_run.go
@@ -205,7 +205,7 @@ func (s *runState) initProgress() {
 				s.structuredProgress.SubAgents = s.subAgentNodes
 				s.cfg.ProgressEventHandler(&ProgressEvent{
 					Lines:      copyLines(s.progressLines),
-					Structured: s.structuredProgress,
+					Structured: s.structuredProgress.Clone(),
 					Timestamp:  time.Now(),
 				})
 			}
@@ -348,10 +348,11 @@ func (s *runState) notifyProgress(extra string) {
 		// Attach structured SubAgent tree (if any) directly to the event,
 		// so consumers don't need to parse text lines.
 		s.structuredProgress.SubAgents = s.subAgentNodes
+		structured := s.structuredProgress.Clone()
 		s.progressMu.Unlock()
 		s.cfg.ProgressEventHandler(&ProgressEvent{
 			Lines:      snapshot,
-			Structured: s.structuredProgress,
+			Structured: structured,
 			Timestamp:  time.Now(),
 		})
 	}
@@ -610,7 +611,14 @@ func (s *runState) handleInputTooLong(ctx context.Context, retryNotifyCtx contex
 	}
 	if s.autoNotify {
 		s.progressLines = append(s.progressLines, fmt.Sprintf("> ✅ 强制压缩完成 → %d tokens", pipelineResult.NewTokenCount))
+		if s.structuredProgress != nil {
+			s.structuredProgress.Phase = PhaseThinking
+			s.structuredProgress.HistoryCompacted = true
+		}
 		s.notifyProgress("")
+	}
+	if s.structuredProgress != nil {
+		s.structuredProgress.HistoryCompacted = false
 	}
 
 	response, err := generateResponse(retryNotifyCtx, s.cfg.LLMClient, s.cfg.Model, s.messages, toolDefs, s.cfg.ThinkingMode, s.cfg.Stream, s.cfg.StreamContentFunc, s.cfg.StreamReasoningFunc)

--- a/agent/progress.go
+++ b/agent/progress.go
@@ -47,6 +47,34 @@ type StructuredProgress struct {
 	SubAgents []SubAgentNode
 }
 
+func (p *StructuredProgress) Clone() *StructuredProgress {
+	if p == nil {
+		return nil
+	}
+	cp := *p
+	cp.ActiveTools = append([]ToolProgress(nil), p.ActiveTools...)
+	cp.CompletedTools = append([]ToolProgress(nil), p.CompletedTools...)
+	cp.Todos = append([]TodoProgressItem(nil), p.Todos...)
+	cp.SubAgents = cloneSubAgentNodes(p.SubAgents)
+	if p.TokenUsage != nil {
+		tu := *p.TokenUsage
+		cp.TokenUsage = &tu
+	}
+	return &cp
+}
+
+func cloneSubAgentNodes(nodes []SubAgentNode) []SubAgentNode {
+	if len(nodes) == 0 {
+		return nil
+	}
+	cp := make([]SubAgentNode, len(nodes))
+	for i := range nodes {
+		cp[i] = nodes[i]
+		cp[i].Children = cloneSubAgentNodes(nodes[i].Children)
+	}
+	return cp
+}
+
 // ProgressPhase Agent 运行阶段。
 type ProgressPhase string
 

--- a/agent/regression_test.go
+++ b/agent/regression_test.go
@@ -135,6 +135,65 @@ func TestContextWindowExceeded_SetsPhase(t *testing.T) {
 	}
 }
 
+func TestRunCompressionEmitsCompressingAndCompactedSnapshots(t *testing.T) {
+	cm := &mockContextManager{
+		compressFn: func(_ context.Context, messages []llm.ChatMessage, _ llm.LLM, _ string) (*CompressResult, error) {
+			return &CompressResult{
+				LLMView:          messages[:2],
+				CompressedTokens: 5000,
+			}, nil
+		},
+	}
+
+	var events []*StructuredProgress
+	state := &runState{
+		cfg: RunConfig{
+			MaxOutputTokens:      4096,
+			LLMClient:            &mockLLM{},
+			Model:                "test-model",
+			ContextManager:       cm,
+			ContextManagerConfig: &ContextManagerConfig{MaxContextTokens: 200000},
+			SaveTokenState:       func(_, _ int64) {},
+			SaveContextTokens:    func(_ int64) {},
+			ProgressEventHandler: func(ev *ProgressEvent) {
+				events = append(events, ev.Structured)
+			},
+		},
+		messages: []llm.ChatMessage{
+			llm.NewSystemMessage("system"),
+			llm.NewUserMessage("hello"),
+			llm.NewAssistantMessage("hi"),
+			llm.NewUserMessage("complex task"),
+		},
+		tokenTracker:       NewTokenTracker(180000, 3000),
+		persistence:        NewPersistenceBridge(nil, 0),
+		structuredProgress: &StructuredProgress{Phase: PhaseThinking},
+		autoNotify:         true,
+		sessionCtx:         &hooks.SessionContext{},
+	}
+
+	state.runCompression(context.Background(), cm, 180000, 200000)
+
+	var sawCompressing, sawCompacted bool
+	for _, ev := range events {
+		if ev.Phase == PhaseCompressing {
+			sawCompressing = true
+		}
+		if ev.HistoryCompacted {
+			sawCompacted = true
+		}
+	}
+	if !sawCompressing {
+		t.Fatalf("runCompression did not emit PhaseCompressing event: %+v", events)
+	}
+	if !sawCompacted {
+		t.Fatalf("runCompression did not emit HistoryCompacted event: %+v", events)
+	}
+	if len(events) > 0 && events[len(events)-1].HistoryCompacted != true {
+		t.Fatalf("last captured event was mutated after emission: %+v", events[len(events)-1])
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Test 2: Per-iteration token persistence (SaveTokenState after each LLM call)
 // ---------------------------------------------------------------------------

--- a/channel/cli_msg_render.go
+++ b/channel/cli_msg_render.go
@@ -221,8 +221,17 @@ func (m *cliModel) renderMessage(msg *cliMessage) string {
 		// Right-align: body content width = contentWidth (same as user msg "You"),
 		// so guide(2) + body(cw-4) leaves 2 cols right padding.
 		const ansiReset = "\x1b[0m"
+		renderedGuide := guideSt.Render(guideSym)
+		if len(bodyLines) > 0 {
+			sb.WriteString(ansiReset)
+			sb.WriteString(renderedGuide)
+			sb.WriteString(ansiReset)
+			sb.WriteString("\n")
+		}
 		for _, l := range bodyLines {
-			sb.WriteString(ansiReset + guideSt.Render(guideSym) + ansiReset)
+			sb.WriteString(ansiReset)
+			sb.WriteString(renderedGuide)
+			sb.WriteString(ansiReset)
 			sb.WriteString(l)
 			sb.WriteString("\n")
 		}

--- a/channel/cli_progress_test.go
+++ b/channel/cli_progress_test.go
@@ -398,6 +398,71 @@ func TestStreamingSeparatorUsesAdjacentBlockKinds(t *testing.T) {
 	}
 }
 
+func TestRenderLiveIterationCompressingShowsStatus(t *testing.T) {
+	model := initTestModel()
+	model.locale = GetLocale("en")
+
+	rendered := stripAnsi(model.renderLiveIteration(&protocol.ProgressEvent{Phase: "compressing"}, 80, ""))
+
+	if !strings.Contains(rendered, "compressing") {
+		t.Fatalf("compressing phase should render status text, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "◇◇◇◇◇") {
+		t.Fatalf("compressing phase should not fall back to pulse spinner, got:\n%s", rendered)
+	}
+}
+
+func TestRenderToolTagsKeepsLabelsSingleLine(t *testing.T) {
+	model := initTestModel()
+
+	rendered := stripAnsi(model.renderToolTags([]protocol.ToolProgress{
+		{Name: "Shell", Label: "ssh remote\ncargo build\r\n--release", Status: "done"},
+	}, 80, &model.styles))
+
+	if strings.Contains(rendered, "\n  cargo") || strings.Contains(rendered, "\n--release") {
+		t.Fatalf("tool label should stay on one rendered line, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "ssh remote cargo build --release") {
+		t.Fatalf("tool label should normalize internal newlines, got:\n%s", rendered)
+	}
+}
+
+func TestRenderMessageAddsSpacerBeforeFirstToolBlock(t *testing.T) {
+	model := initTestModel()
+	msg := &cliMessage{
+		role:      "assistant",
+		timestamp: time.Now(),
+		iterations: []cliIterationSnapshot{
+			{
+				Iteration: 1,
+				Tools: []protocol.ToolProgress{
+					{Name: "Shell", Label: "first tool", Status: "done", Iteration: 1},
+				},
+			},
+		},
+		dirty: true,
+	}
+
+	rendered := stripAnsi(model.renderMessage(msg))
+	lines := strings.Split(rendered, "\n")
+	headerIdx := -1
+	for i, line := range lines {
+		if strings.Contains(line, "Assistant") {
+			headerIdx = i
+			break
+		}
+	}
+	if headerIdx < 0 || headerIdx+2 >= len(lines) {
+		t.Fatalf("assistant header not found or output too short:\n%s", rendered)
+	}
+	if strings.TrimSpace(lines[headerIdx+1]) != "┊" {
+		t.Fatalf("expected blank guide spacer after Assistant header, got %q in:\n%s", lines[headerIdx+1], rendered)
+	}
+	if !strings.Contains(lines[headerIdx+2], "first tool") {
+		t.Fatalf("expected first tool after spacer, got line %q in:\n%s", lines[headerIdx+2], rendered)
+	}
+}
+
 func TestFullRebuildWithStreamingCachesOnlyHistoryMessages(t *testing.T) {
 	model := initTestModel()
 	model.messages = []cliMessage{
@@ -521,6 +586,56 @@ func TestHistoryReloadForceFullRebuildDoesNotReuseStaleRenderedCache(t *testing.
 	if model.messages[0].rendered == "STALE_RENDERED_OUTPUT" {
 		t.Fatal("force history reload should re-render message instead of preserving stale rendered output")
 	}
+}
+
+func TestHistoryReloadKeepsPendingUserUntilHistoryConfirmsIt(t *testing.T) {
+	model := initTestModel()
+	pending := cliMessage{role: "user", content: "just sent", timestamp: time.Now(), dirty: true}
+	model.pendingUserMsg = &pending
+
+	reload := cliHistoryReloadMsg{
+		channelName: model.channelName,
+		chatID:      model.chatID,
+		history: []HistoryMessage{
+			{Role: "assistant", Content: "old reply", Timestamp: time.Now()},
+		},
+	}
+	model.handleHistoryReload(reload)
+	if model.pendingUserMsg == nil {
+		t.Fatal("pending user should remain when it was only restored locally")
+	}
+	if !hasUserMessage(model.messages, "just sent") {
+		t.Fatalf("pending user was not restored into messages: %+v", model.messages)
+	}
+
+	model.handleHistoryReload(reload)
+	if model.pendingUserMsg == nil {
+		t.Fatal("pending user should survive repeated stale history reloads")
+	}
+	if !hasUserMessage(model.messages, "just sent") {
+		t.Fatalf("pending user disappeared after repeated reload: %+v", model.messages)
+	}
+
+	model.handleHistoryReload(cliHistoryReloadMsg{
+		channelName: model.channelName,
+		chatID:      model.chatID,
+		history: []HistoryMessage{
+			{Role: "user", Content: "just sent", Timestamp: time.Now()},
+			{Role: "assistant", Content: "old reply", Timestamp: time.Now()},
+		},
+	})
+	if model.pendingUserMsg != nil {
+		t.Fatal("pending user should clear once history confirms it")
+	}
+}
+
+func hasUserMessage(messages []cliMessage, content string) bool {
+	for _, msg := range messages {
+		if msg.role == "user" && msg.content == content {
+			return true
+		}
+	}
+	return false
 }
 
 func appendRenderSnapshotCase(sb *strings.Builder, name, rendered string) {

--- a/channel/cli_render_turn.go
+++ b/channel/cli_render_turn.go
@@ -99,9 +99,7 @@ func appendTurnBlock(sb *strings.Builder, lastKind *turnBlockKind, hasBlock *boo
 	if !*hasBlock {
 		// First block starts immediately; renderReasoningBox includes a leading
 		// newline for historical callers, so normalize text before appending.
-	} else if block.kind == turnBlockPulse {
-		sb.WriteString("\n\n")
-	} else if *lastKind == block.kind {
+	} else if block.kind == turnBlockPulse || *lastKind == block.kind {
 		sb.WriteString("\n")
 	} else {
 		sb.WriteString("\n\n")
@@ -139,9 +137,9 @@ func (m *cliModel) renderToolTags(tools []protocol.ToolProgress, width int, s *c
 	}
 	var lines []string
 	for _, tool := range tools {
-		label := tool.Label
+		label := oneLineToolLabel(tool.Label)
 		if label == "" {
-			label = tool.Name
+			label = oneLineToolLabel(tool.Name)
 		}
 		label = truncateToWidth(label, maxLabelW)
 		var tag string
@@ -212,6 +210,11 @@ func (m *cliModel) renderReasoningBox(
 	return sb.String()
 }
 
+// renderLiveIteration renders the in-progress iteration.
+func (m *cliModel) renderLiveIteration(p *protocol.ProgressEvent, width int, fallbackContent string) string {
+	return renderTurnBlocks(m.liveIterationBlocks(p, width, fallbackContent))
+}
+
 func renderTurnBlocks(blocks []turnBlock) string {
 	var sb strings.Builder
 	var lastKind turnBlockKind
@@ -255,6 +258,14 @@ func (m *cliModel) liveIterationBlocks(p *protocol.ProgressEvent, width int, fal
 	s := &m.styles
 	var blocks []turnBlock
 	hasSpinner := false
+
+	if p.Phase == "compressing" {
+		hasSpinner = true
+		blocks = append(blocks, turnBlock{
+			kind: turnBlockPulse,
+			text: "  " + s.ProgressRunning.Render(m.locale.StatusCompressing),
+		})
+	}
 
 	if p.ReasoningStreamContent != "" {
 		hasSpinner = true
@@ -326,9 +337,9 @@ func (m *cliModel) renderLiveToolTags(tools []protocol.ToolProgress, width int) 
 
 	var sb strings.Builder
 	for _, tool := range tools {
-		label := tool.Label
+		label := oneLineToolLabel(tool.Label)
 		if label == "" {
-			label = tool.Name
+			label = oneLineToolLabel(tool.Name)
 		}
 		label = truncateToWidth(label, maxLabelW)
 		switch tool.Status {
@@ -364,4 +375,8 @@ func (m *cliModel) renderLiveToolTags(tools []protocol.ToolProgress, width int) 
 	}
 
 	return strings.TrimRight(sb.String(), "\n")
+}
+
+func oneLineToolLabel(label string) string {
+	return strings.Join(strings.Fields(label), " ")
 }

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -1110,8 +1110,9 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 			if !found {
 				m.pendingUserMsg.dirty = true
 				m.messages = append(m.messages, *m.pendingUserMsg)
+			} else {
+				m.pendingUserMsg = nil
 			}
-			m.pendingUserMsg = nil
 		}
 		// SuSwitchedHistory提示已移除 — 切换session静默完成
 	}
@@ -1367,8 +1368,9 @@ func (m *cliModel) handleHistoryReload(msg cliHistoryReloadMsg) {
 		if !found {
 			m.pendingUserMsg.dirty = true
 			newMessages = append(newMessages, *m.pendingUserMsg)
+		} else {
+			m.pendingUserMsg = nil
 		}
-		m.pendingUserMsg = nil
 	}
 	// Smart merge: reuse rendered cache from existing messages to avoid
 	// O(N) glamour re-rendering of ALL messages. Only truly new or changed

--- a/channel/cli_viewport.go
+++ b/channel/cli_viewport.go
@@ -416,6 +416,12 @@ func (m *cliModel) updateStreamingOnly() {
 	allLines := make([]string, 0, len(histLines)+1+len(completedLines)+len(liveLines)+2)
 	allLines = append(allLines, histLines...)
 	allLines = append(allLines, m.rc.streamHeaderLine) // header line
+	if len(completedLines) > 0 || len(liveLines) > 0 {
+		allLines = append(allLines, guidePrefix)
+		if w := lipgloss.Width(guidePrefix); w > liveMaxW {
+			liveMaxW = w
+		}
+	}
 	allLines = append(allLines, completedLines...)
 	allLines = append(allLines, liveLines...)
 	allLines = append(allLines, "") // trailing \n\n from renderMessage

--- a/channel/testdata/snapshots/render_turn_body_multi_iteration_live.snap
+++ b/channel/testdata/snapshots/render_turn_body_multi_iteration_live.snap
@@ -1,6 +1,5 @@
 === previous tool done then active empty next iteration renders pulse ===
   · ✓ Previous read succeeded
-
   ◇◇◇◇◇
 
 === previous content plus tool then active fallback stream text ===


### PR DESCRIPTION
## Summary

Follow-up to #130 (squash merged). Additional fixes built on top of master:

### Race fix
- **Clone `StructuredProgress` before sending to progress handler** — prevents concurrent mutation of shared slice fields (`ActiveTools`, `CompletedTools`, `SubAgents`) between the engine goroutine and the CLI renderer

### Compressing phase
- **Add compressing spinner in live iteration blocks** — shows `压缩中...` phase during forced compression, matching the text progress behavior

### Tool label cleanup
- **`oneLineToolLabel` helper** collapses multiline tool labels (from Read, Shell etc.) into single-line format for the compact tool tag display
- **Fix `pendingUserMsg` nil logic** — only clear when message was found in restored history, preventing lost pending user messages on session switch

### Rendering fixes
- **Pre-render guide prefix** in assistant message body for performance (avoid re-calling `guideSt.Render` per line)
- **Add guide prefix line before iteration body** in streaming update path for visual consistency

### Tests
- Regression tests for `StructuredProgress.Clone()` behavior
- Additional progress race test coverage