### PR TITLE
fix(channel): preserve streaming turn on history reload & done tool label coloring

### DIFF
--- a/channel/cli_progress_test.go
+++ b/channel/cli_progress_test.go
@@ -427,6 +427,30 @@ func TestRenderToolTagsKeepsLabelsSingleLine(t *testing.T) {
 	}
 }
 
+func TestRenderToolTagsColorsDoneAndErrorLabels(t *testing.T) {
+	model := initTestModel()
+	tools := []protocol.ToolProgress{
+		{Name: "Shell", Label: "success label", Status: "done"},
+		{Name: "Read", Label: "failure label", Status: "error"},
+	}
+
+	rendered := model.renderToolTags(tools, 80, &model.styles)
+	if !strings.Contains(rendered, model.styles.ProgressDone.Render("✓ success label")) {
+		t.Fatalf("done tool label should use success color, got:\n%q", rendered)
+	}
+	if !strings.Contains(rendered, model.styles.ProgressError.Render("✗ failure label")) {
+		t.Fatalf("error tool label should use error color, got:\n%q", rendered)
+	}
+
+	liveRendered := model.renderLiveToolTags(tools, 80)
+	if !strings.Contains(liveRendered, model.styles.ProgressDone.Render("✓ success label")) {
+		t.Fatalf("live done tool label should use success color, got:\n%q", liveRendered)
+	}
+	if !strings.Contains(liveRendered, model.styles.ProgressError.Render("✗ failure label")) {
+		t.Fatalf("live error tool label should use error color, got:\n%q", liveRendered)
+	}
+}
+
 func TestRenderMessageAddsSpacerBeforeFirstToolBlock(t *testing.T) {
 	model := initTestModel()
 	msg := &cliMessage{
@@ -626,6 +650,54 @@ func TestHistoryReloadKeepsPendingUserUntilHistoryConfirmsIt(t *testing.T) {
 	})
 	if model.pendingUserMsg != nil {
 		t.Fatal("pending user should clear once history confirms it")
+	}
+}
+
+func TestHistoryReloadPreservesActiveStreamingTurn(t *testing.T) {
+	model := initTestModel()
+	model.messages = []cliMessage{
+		{role: "user", content: "previous user", timestamp: time.Now(), dirty: true},
+		{role: "assistant", content: "previous reply", timestamp: time.Now(), dirty: true},
+		{role: "user", content: "current user", timestamp: time.Now(), dirty: true},
+	}
+	model.startAgentTurn()
+	model.iterationHistory = []cliIterationSnapshot{
+		{
+			Iteration: 1,
+			Thinking:  "current turn thinking",
+			Tools: []protocol.ToolProgress{
+				{Name: "Shell", Label: "running command", Status: "running", Iteration: 1},
+			},
+		},
+	}
+	model.progress = &protocol.ProgressEvent{Phase: "tool_exec", Iteration: 1}
+	streamingIdx := model.streamingMsgIdx
+
+	model.handleHistoryReload(cliHistoryReloadMsg{
+		channelName: model.channelName,
+		chatID:      model.chatID,
+		history: []HistoryMessage{
+			{Role: "user", Content: "previous user", Timestamp: time.Now()},
+			{Role: "assistant", Content: "previous reply", Timestamp: time.Now()},
+			{Role: "user", Content: "current user", Timestamp: time.Now()},
+		},
+	})
+
+	if model.streamingMsgIdx != streamingIdx {
+		t.Fatalf("streamingMsgIdx = %d, want active index %d", model.streamingMsgIdx, streamingIdx)
+	}
+	if model.streamingMsgIdx < 0 || model.streamingMsgIdx >= len(model.messages) {
+		t.Fatalf("streamingMsgIdx out of range after reload: %d messages=%d", model.streamingMsgIdx, len(model.messages))
+	}
+	streaming := model.messages[model.streamingMsgIdx]
+	if streaming.role != "assistant" || !streaming.isPartial {
+		t.Fatalf("active streaming assistant was not preserved: %+v", streaming)
+	}
+	if len(model.iterationHistory) != 1 || model.iterationHistory[0].Thinking != "current turn thinking" {
+		t.Fatalf("iteration history was not preserved: %+v", model.iterationHistory)
+	}
+	if !strings.Contains(model.viewport.View(), "running command") {
+		t.Fatalf("viewport lost current turn tools after reload:\n%s", stripAnsi(model.viewport.View()))
 	}
 }
 

--- a/channel/cli_render_turn.go
+++ b/channel/cli_render_turn.go
@@ -147,7 +147,7 @@ func (m *cliModel) renderToolTags(tools []protocol.ToolProgress, width int, s *c
 		case "error":
 			tag = s.ProgressError.Render("✗ " + label)
 		case "done":
-			tag = s.ProgressDone.Render("✓") + " " + s.TextMutedSt.Render(label)
+			tag = s.ProgressDone.Render("✓ " + label)
 		default:
 			tag = s.ProgressRunning.Render("● " + label)
 		}
@@ -353,9 +353,7 @@ func (m *cliModel) renderLiveToolTags(tools []protocol.ToolProgress, width int) 
 			sb.WriteString("  ")
 			sb.WriteString(s.ProgressDim.Render("·"))
 			sb.WriteString(" ")
-			sb.WriteString(s.ProgressDone.Render("✓"))
-			sb.WriteString(" ")
-			sb.WriteString(s.TextMutedSt.Render(label))
+			sb.WriteString(s.ProgressDone.Render("✓ " + label))
 			sb.WriteString("\n")
 		default: // running/active
 			var elapsedMs int64

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -1372,11 +1372,19 @@ func (m *cliModel) handleHistoryReload(msg cliHistoryReloadMsg) {
 			m.pendingUserMsg = nil
 		}
 	}
+	restoredStreamingIdx := -1
+	if !msg.forceFullRebuild && m.typing && m.streamingMsgIdx >= 0 && m.streamingMsgIdx < len(m.messages) {
+		streamingMsg := m.messages[m.streamingMsgIdx]
+		if streamingMsg.role == "assistant" && streamingMsg.isPartial {
+			restoredStreamingIdx = len(newMessages)
+			newMessages = append(newMessages, streamingMsg)
+		}
+	}
 	// Smart merge: reuse rendered cache from existing messages to avoid
 	// O(N) glamour re-rendering of ALL messages. Only truly new or changed
 	// messages need re-rendering. This is critical for sessions with hundreds
 	// of iterations where full rebuild would take seconds.
-	m.streamingMsgIdx = -1
+	m.streamingMsgIdx = restoredStreamingIdx
 	if msg.forceFullRebuild {
 		m.messages = newMessages
 		m.invalidateAllCache(false)

--- a/channel/cli_viewport.go
+++ b/channel/cli_viewport.go
@@ -278,6 +278,10 @@ func (m *cliModel) updateViewportContent() {
 
 	// 慢速路径：全量重建
 	m.fullRebuild()
+	if m.streamingMsgIdx >= 0 {
+		m.updateStreamingOnly()
+		return
+	}
 	// fullRebuild only rebuilds internal caches (cachedHistoryLines etc.)
 	// — it does NOT set viewport lines. Do that now so the viewport
 	// refreshes immediately, not on the next tick.


### PR DESCRIPTION
## Changes

### 1. History reload preserves active streaming turn
- `handleHistoryReload` now preserves the active streaming assistant message (`isPartial`) and `iterationHistory` when reloading during an active turn
- Prevents loss of progress state during compression-triggered reloads
- `streamingMsgIdx` is restored to the correct position instead of being reset to `-1`

### 2. Done tool label uses success color consistently
- `renderToolTags` and `renderLiveToolTags` now apply `ProgressDone` color to the full `✓ label` string
- Previously only the checkmark was colored, the label text was muted — inconsistent with error style where `✗ label` is fully colored

### 3. Viewport rebuild respects streaming state
- `updateViewportContent` short-circuits to `updateStreamingOnly` when a streaming message is active after `fullRebuild`
- Avoids unnecessary full viewport content rebuild during active streaming

## Test
- `TestRenderToolTagsColorsDoneAndErrorLabels` — verifies done/error label coloring
- `TestHistoryReloadPreservesActiveStreamingTurn` — verifies streaming turn preservation on reload