### PR TITLE
fix(tui): Ctrl+C 丢失用户消息 + 会话切换重复渲染 + AskUser 清空迭代

### DIFF
--- a/channel/cli_agent_msg.go
+++ b/channel/cli_agent_msg.go
@@ -119,7 +119,8 @@ func (m *cliModel) handleAgentMessage(msg OutboundMsg) {
 		}
 		m.streamingMsgIdx = -1
 		m.progress = nil
-		m.typing = false // clear typing indicator immediately after cancel
+		m.typing = false        // clear typing indicator immediately after cancel
+		m.turnCancelled = false // cancel complete, allow future turns
 		m.cancelTargetTurnID = 0
 		m.rc.valid = false
 		m.updateViewportContent()

--- a/channel/cli_agent_msg.go
+++ b/channel/cli_agent_msg.go
@@ -192,6 +192,59 @@ func (m *cliModel) handleAgentMessage(msg OutboundMsg) {
 		if len(bakeIterations) == 0 && m.streamingMsgIdx >= 0 && m.streamingMsgIdx < len(m.messages) {
 			bakeIterations = m.messages[m.streamingMsgIdx].iterations
 		}
+		// Append the last iteration from m.progress if it wasn't already
+		// captured in iterationHistory. The last iteration's data (tools,
+		// reasoning) is typically in m.progress but hasn't been snapshotted
+		// by snapshotIterationChange (which only fires on iteration N→N+1
+		// transitions). Without this, AskUser messages lose the last
+		// iteration's tools from the viewport.
+		// Guard: use lastCompletedTools (filtered per-iteration) instead of
+		// m.progress.CompletedTools (may contain stale tools from earlier
+		// iterations), and only run when the iteration is genuinely missing.
+		if m.progress != nil && m.lastSeenIteration >= 0 && msg.WaitingUser {
+			iterNum := m.lastSeenIteration
+			if m.progress.Iteration > 0 {
+				iterNum = m.progress.Iteration
+			}
+			alreadyBaked := false
+			for _, it := range bakeIterations {
+				if it.Iteration == iterNum {
+					alreadyBaked = true
+					break
+				}
+			}
+			if !alreadyBaked {
+				// Use lastCompletedTools — these are per-iteration filtered
+				// (cleared by snapshotIterationChange on N→N+1), unlike
+				// m.progress.CompletedTools which accumulates stale tools.
+				var finalTools []protocol.ToolProgress
+				finalTools = append(finalTools, m.lastCompletedTools...)
+				for _, t := range m.progress.ActiveTools {
+					if t.Status == "done" || t.Status == "error" {
+						if !containsToolProgress(finalTools, t) {
+							finalTools = append(finalTools, t)
+						}
+					}
+				}
+				reasoning := m.progress.Reasoning
+				if reasoning == "" && m.reasoningByIter != nil {
+					reasoning = m.reasoningByIter[iterNum]
+				}
+				if reasoning == "" {
+					reasoning = m.lastReasoning
+				}
+				snap := cliIterationSnapshot{
+					Iteration:   iterNum,
+					Thinking:    m.progress.Thinking,
+					Reasoning:   reasoning,
+					Tools:       finalTools,
+					ElapsedWall: time.Since(m.iterationStartTime).Milliseconds(),
+				}
+				if len(snap.Tools) > 0 || snap.Thinking != "" || snap.Reasoning != "" {
+					bakeIterations = append(bakeIterations, snap)
+				}
+			}
+		}
 
 		if m.streamingMsgIdx >= 0 && m.streamingMsgIdx < len(m.messages) {
 			// 更新流式消息为完整消息

--- a/channel/cli_askuser_render_test.go
+++ b/channel/cli_askuser_render_test.go
@@ -1,0 +1,180 @@
+package channel
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+	"xbot/protocol"
+)
+
+// TestAskUserViewportPreservesIterations verifies that when AskUser panel opens,
+// the viewport rendering of the previous assistant message still shows ALL iteration
+// data (tool names). The bug was that the last iteration's tools (from m.progress)
+// were not included in bakeIterations, so they disappeared when the message was finalized.
+func TestAskUserViewportPreservesIterations(t *testing.T) {
+	model := initTestModel()
+	model.startAgentTurn()
+	model.typingStartTime = time.Now()
+
+	// Simulate 2 iterations with tools
+	sendProgress(model, &protocol.ProgressEvent{Phase: "thinking", Iteration: 1})
+	sendProgress(model, &protocol.ProgressEvent{
+		Phase:     "tool_exec",
+		Iteration: 1,
+		CompletedTools: []protocol.ToolProgress{
+			{Name: "Read", Label: "Read go.mod", Status: "done", Elapsed: 500, Iteration: 1},
+		},
+	})
+	sendProgress(model, &protocol.ProgressEvent{Phase: "thinking", Iteration: 2})
+	sendProgress(model, &protocol.ProgressEvent{
+		Phase:     "tool_exec",
+		Iteration: 2,
+		CompletedTools: []protocol.ToolProgress{
+			{Name: "Shell", Label: "echo done", Status: "done", Elapsed: 200, Iteration: 2},
+		},
+	})
+
+	// Simulate the AskUser outbound message (non-partial, with WaitingUser)
+	askQuestions, _ := json.Marshal([]map[string]interface{}{
+		{"question": "Can you see the iterations?", "options": []string{"yes", "no"}},
+	})
+	model.Update(cliOutboundMsg{
+		msg: OutboundMsg{
+			Content:     "两次迭代完成，现在用 AskUser 提问：",
+			WaitingUser: true,
+			Metadata: map[string]string{
+				"ask_questions": string(askQuestions),
+			},
+		},
+	})
+
+	if model.panelMode != "askuser" {
+		t.Fatalf("Expected panelMode=askuser, got %q", model.panelMode)
+	}
+
+	// Verify the assistant message has iterations baked in
+	var assistantMsg *cliMessage
+	for idx := range model.messages {
+		msg := &model.messages[idx]
+		if msg.role == "assistant" && !msg.isPartial {
+			assistantMsg = msg
+		}
+	}
+	if assistantMsg == nil {
+		t.Fatal("No finalized assistant message found")
+	}
+
+	t.Logf("Assistant message iterations: %d", len(assistantMsg.iterations))
+	for _, it := range assistantMsg.iterations {
+		var tools []string
+		for _, t := range it.Tools {
+			tools = append(tools, t.Name)
+		}
+		t.Logf("  iteration %d: tools=%v", it.Iteration, tools)
+	}
+
+	// Verify tool names appear in the rendered output
+	rendered := model.renderMessage(assistantMsg)
+	if !strings.Contains(rendered, "Read") {
+		t.Errorf("Rendered output missing 'Read' tool:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "echo done") {
+		t.Errorf("Rendered output missing 'echo done' tool label:\n%s", rendered)
+	}
+}
+
+// TestAskUserAnswerPreservesViewportIterations verifies that after answering AskUser,
+// the previous assistant message still shows iteration data in viewport.
+func TestAskUserAnswerPreservesViewportIterations(t *testing.T) {
+	model := initTestModel()
+	model.startAgentTurn()
+	model.typingStartTime = time.Now()
+
+	// Simulate iteration with tools
+	sendProgress(model, &protocol.ProgressEvent{Phase: "thinking", Iteration: 1})
+	sendProgress(model, &protocol.ProgressEvent{
+		Phase:     "tool_exec",
+		Iteration: 1,
+		CompletedTools: []protocol.ToolProgress{
+			{Name: "Read", Label: "Read go.mod", Status: "done", Elapsed: 500, Iteration: 1},
+			{Name: "Grep", Label: "Search pattern", Status: "done", Elapsed: 200, Iteration: 1},
+		},
+	})
+	sendProgress(model, &protocol.ProgressEvent{Phase: "thinking", Iteration: 2})
+	sendProgress(model, &protocol.ProgressEvent{
+		Phase:     "tool_exec",
+		Iteration: 2,
+		CompletedTools: []protocol.ToolProgress{
+			{Name: "Shell", Label: "echo hello", Status: "done", Elapsed: 100, Iteration: 2},
+		},
+	})
+
+	// Send AskUser outbound
+	askQuestions, _ := json.Marshal([]map[string]interface{}{
+		{"question": "Continue?", "options": []string{"yes", "no"}},
+	})
+	model.Update(cliOutboundMsg{
+		msg: OutboundMsg{
+			Content:     "Done reading files",
+			WaitingUser: true,
+			Metadata: map[string]string{
+				"ask_questions": string(askQuestions),
+			},
+		},
+	})
+
+	if model.panelMode != "askuser" {
+		t.Fatalf("Expected panelMode=askuser, got %q", model.panelMode)
+	}
+
+	// Verify pre-answer: assistant has iterations
+	var preAnswerMsg *cliMessage
+	for i := range model.messages {
+		if model.messages[i].role == "assistant" && !model.messages[i].isPartial {
+			preAnswerMsg = &model.messages[i]
+		}
+	}
+	if preAnswerMsg == nil {
+		t.Fatal("No finalized assistant message found before answer")
+	}
+	if len(preAnswerMsg.iterations) == 0 {
+		t.Fatal("Pre-answer: assistant message has no iterations")
+	}
+	t.Logf("Pre-answer iterations: %d", len(preAnswerMsg.iterations))
+	for _, it := range preAnswerMsg.iterations {
+		var tools []string
+		for _, t := range it.Tools {
+			tools = append(tools, t.Name)
+		}
+		t.Logf("  iteration %d: tools=%v", it.Iteration, tools)
+	}
+
+	// Answer the AskUser question
+	if model.panelOnAnswer != nil {
+		model.panelOnAnswer(map[string]string{"q0": "yes"})
+	}
+
+	// After answer: find the pre-AskUser assistant message (non-partial, not the new streaming one)
+	var postAnswerMsg *cliMessage
+	for i := range model.messages {
+		if model.messages[i].role == "assistant" && !model.messages[i].isPartial {
+			postAnswerMsg = &model.messages[i]
+		}
+	}
+	if postAnswerMsg == nil {
+		t.Fatal("No finalized assistant message found after AskUser answer")
+	}
+	if len(postAnswerMsg.iterations) == 0 {
+		t.Fatal("Post-answer: assistant message lost its iterations!")
+	}
+
+	// Verify tool names in rendered output
+	rendered := model.renderMessage(postAnswerMsg)
+	if !strings.Contains(rendered, "Read") {
+		t.Errorf("Post-answer rendered output missing 'Read' tool:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "echo hello") {
+		t.Errorf("Post-answer rendered output missing 'echo hello' tool label:\n%s", rendered)
+	}
+}

--- a/channel/cli_ctrlc_test.go
+++ b/channel/cli_ctrlc_test.go
@@ -1,0 +1,159 @@
+package channel
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"xbot/protocol"
+)
+
+// TestCtrlC_UserMsgPreserved verifies that after Ctrl+C, the user message
+// remains visible in the viewport. The race condition occurs when:
+// 1. PhaseDone arrives after cancel (turnCancelled=true)
+// 2. endAgentTurn resets turnCancelled=false
+// 3. A stale progress event triggers auto-start turn
+// 4. This creates a new agentTurnID, confusing the cancel ack
+func TestCtrlC_UserMsgPreserved(t *testing.T) {
+	model := initTestModel()
+	model.typing = true
+	model.typingStartTime = time.Now()
+
+	// User sends a message
+	userMsg := cliMessage{role: "user", content: "请分析这个 bug", timestamp: time.Now(), dirty: true}
+	model.messages = append(model.messages, userMsg)
+	model.pendingUserMsg = &userMsg
+
+	// Agent starts working — streaming assistant message
+	oldTurnID := model.agentTurnID
+	model.streamingMsgIdx = len(model.messages)
+	model.messages = append(model.messages, cliMessage{
+		role: "assistant", content: "", timestamp: time.Now(),
+		isPartial: true, dirty: true, turnID: oldTurnID,
+	})
+
+	// Simulate some progress
+	sendProgress(model, &protocol.ProgressEvent{Phase: "thinking", Iteration: 1})
+	sendProgress(model, &protocol.ProgressEvent{
+		Phase:     "tool_exec",
+		Iteration: 1,
+		CompletedTools: []protocol.ToolProgress{
+			{Name: "Read", Label: "Read bug.go", Status: "done", Elapsed: 500, Iteration: 1},
+		},
+	})
+
+	// User presses Ctrl+C — set cancel state directly
+	// (sendCancel would try to send to agent channel which doesn't exist in tests)
+	model.cancelTargetTurnID = oldTurnID
+	model.turnCancelled = true
+	// Add the "已发送取消请求" system message (same as sendCancel does)
+	model.appendSystem(model.locale.CancelSent)
+	model.updateViewportContent()
+
+	// PhaseDone arrives (engine's progressFinalizer)
+	sendProgress(model, &protocol.ProgressEvent{
+		Phase:          "done",
+		Iteration:      1,
+		CompletedTools: []protocol.ToolProgress{{Name: "Read", Label: "Read bug.go", Status: "done", Elapsed: 500, Iteration: 1}},
+	})
+
+	// turnCancelled should still be true (preserved by our fix)
+	if !model.turnCancelled {
+		t.Error("turnCancelled should remain true after PhaseDone in cancel path (prevents auto-start race)")
+	}
+
+	// Now simulate the race: a stale progress event arrives after endAgentTurn
+	// With the fix, this should NOT trigger auto-start turn
+	sendProgress(model, &protocol.ProgressEvent{
+		Phase:     "thinking",
+		Iteration: 2,
+	})
+
+	// Verify agentTurnID didn't change (auto-start turn blocked)
+	if model.agentTurnID != oldTurnID {
+		t.Errorf("auto-start turn should NOT have fired: agentTurnID changed from %d to %d", oldTurnID, model.agentTurnID)
+	}
+
+	// Cancel ack arrives
+	model.Update(cliOutboundMsg{
+		msg: OutboundMsg{
+			Content:  "",
+			Metadata: map[string]string{"cancelled": "true"},
+		},
+	})
+
+	// turnCancelled should now be cleared
+	if model.turnCancelled {
+		t.Error("turnCancelled should be false after cancel ack")
+	}
+
+	// Final check: user message must still be present
+	hasUserMsg := false
+	for _, m := range model.messages {
+		if m.role == "user" && strings.Contains(m.content, "请分析这个 bug") {
+			hasUserMsg = true
+			break
+		}
+	}
+	if !hasUserMsg {
+		t.Fatal("User message disappeared after cancel flow")
+	}
+
+	// Verify viewport renders the user message
+	model.updateViewportContent()
+	vpContent := model.viewport.View()
+	if !strings.Contains(vpContent, "请分析这个 bug") {
+		t.Errorf("User message not visible in viewport after cancel flow.\nViewport:\n%s", vpContent)
+	}
+}
+
+// TestCtrlC_AutoStartRace specifically tests that endAgentTurn in the cancel
+// path does not allow stale progress events to trigger auto-start turn.
+func TestCtrlC_AutoStartRace(t *testing.T) {
+	model := initTestModel()
+	model.typing = true
+	model.typingStartTime = time.Now()
+
+	userMsg := cliMessage{role: "user", content: "帮我查一下", timestamp: time.Now(), dirty: true}
+	model.messages = append(model.messages, userMsg)
+	model.pendingUserMsg = &userMsg
+
+	oldTurnID := model.agentTurnID
+	model.cancelTargetTurnID = oldTurnID
+	model.streamingMsgIdx = len(model.messages)
+	model.messages = append(model.messages, cliMessage{
+		role: "assistant", content: "", timestamp: time.Now(),
+		isPartial: true, dirty: true, turnID: oldTurnID,
+	})
+
+	// Ctrl+C
+	model.turnCancelled = true
+
+	// PhaseDone → endAgentTurn
+	sendProgress(model, &protocol.ProgressEvent{Phase: "done", Iteration: 0})
+
+	// turnCancelled should be preserved (the fix)
+	if !model.turnCancelled {
+		t.Fatal("turnCancelled must remain true after endAgentTurn in cancel path")
+	}
+	if model.typing {
+		t.Error("typing should be false after endAgentTurn")
+	}
+
+	// Stale progress event → should NOT trigger auto-start turn
+	sendProgress(model, &protocol.ProgressEvent{Phase: "thinking", Iteration: 1})
+
+	if model.agentTurnID != oldTurnID {
+		t.Fatalf("auto-start turn fired unexpectedly: agentTurnID changed from %d to %d", oldTurnID, model.agentTurnID)
+	}
+
+	hasUserMsg := false
+	for _, m := range model.messages {
+		if m.role == "user" && m.content == "帮我查一下" {
+			hasUserMsg = true
+			break
+		}
+	}
+	if !hasUserMsg {
+		t.Fatal("User message disappeared in auto-start race!")
+	}
+}

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -816,6 +816,14 @@ func (m *cliModel) handleProgressDone(msg cliProgressMsg, prev *protocol.Progres
 		}
 		m.setTurnDoneProcessed(turnID)
 		m.endAgentTurn(turnID)
+		// Restore turnCancelled: endAgentTurn resets it to false (correct for
+		// normal completion), but in the cancel path we need it to stay true
+		// until the cancel ack arrives. Otherwise, stale progress events from
+		// the engine (e.g. mid-stream cancellation) trigger auto-start turn
+		// via handleProgressMsg's auto-start guard, creating a phantom turn
+		// that overwrites the cancel state and loses the user message from
+		// the viewport.
+		m.turnCancelled = true
 		if turnID == m.agentTurnID {
 			m.inputReady = true
 			if len(m.messageQueue) > 0 {
@@ -1156,6 +1164,27 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 			m.lastSeenIteration = msg.activeProgress.Iteration
 		}
 		m.progress = msg.activeProgress
+
+		// When an active turn is restored from the server snapshot, the
+		// last assistant message in DB history corresponds to the in-flight
+		// streaming message. Without marking it as isPartial + streamingMsgIdx,
+		// subsequent live outbound messages (arriving after suLoading=false)
+		// would create a NEW streaming message via handleAgentMessage's
+		// "if m.streamingMsgIdx < 0" branch — duplicating the assistant
+		// content in the viewport (DB version + live version).
+		// This is the same model as normal operation: the streaming message
+		// stays isPartial until endAgentTurn finalizes it.
+		if m.streamingMsgIdx < 0 {
+			for i := len(m.messages) - 1; i >= 0; i-- {
+				if m.messages[i].role == "assistant" {
+					m.messages[i].isPartial = true
+					m.messages[i].dirty = true
+					m.messages[i].turnID = m.agentTurnID
+					m.streamingMsgIdx = i
+					break
+				}
+			}
+		}
 
 		// Sync todos from server snapshot so the todo bar shows them
 		// immediately without waiting for the next live progress event.


### PR DESCRIPTION
## 修复三个 TUI 渲染 Bug

### Bug 1: AskUser 清空迭代 (f6ddf9ac)

**现象**：AskUser 面板打开时，最后一个迭代的工具数据从 viewport 消失。

**根因**：`handleAgentMessage` 的 `bakeIterations` 只从 `iterationHistory` 获取迭代数据，但 `snapshotIterationChange` 仅在迭代号 N→N+1 变化时触发快照。最后一个迭代的数据还在 `m.progress` 中，没有被 snapshot。

**修复**：在 `bakeIterations` 逻辑中，当 `WaitingUser=true` 且最后一个迭代未被包含时，从 `m.lastCompletedTools`（按迭代过滤）构建快照并追加。

### Bug 2: Ctrl+C 概率丢失用户消息 (f1ece94e)

**现象**：Ctrl+C 后 user message 从 viewport 消失，只显示"已发送取消请求"。重启 TUI 消息恢复。

**根因**：`handleProgressDone` cancel 路径调用 `endAgentTurn`，后者重置 `turnCancelled=false`。之后到达的 stale progress 事件触发 auto-start turn（`handleProgressMsg` 的 `!m.typing` guard），创建新 `agentTurnID`，覆盖 cancel 状态。

**修复**：`handleProgressDone` cancel 路径在 `endAgentTurn` 后恢复 `turnCancelled=true`，直到 cancel ack 到达才清除。

### Bug 3: 会话切换后 assistant 消息重复渲染 (f1ece94e)

**现象**：从别的会话切回来，viewport 中 assistant 消息（iterations、SubAgent 标记）重复出现。一开始正确，然后突然"上移+重复"。

**根因**：`handleSuHistoryLoad` 的 `acceptProgress` 路径恢复了 `m.typing=true` + `m.progress`，但没有设置 `streamingMsgIdx`。live outbound 到达时，`handleAgentMessage` 的 IsPartial 分支发现 `streamingMsgIdx=-1`，创建新 streaming message → DB 历史中已有同一条 → 重复。

**修复**：`acceptProgress` 路径中，将最后一条 assistant 消息标记为 `isPartial=true` 并设为 `streamingMsgIdx`，赋予 `agentTurnID`。与正常运行时一致。

## 测试

新增 4 个测试：
- `TestAskUserViewportPreservesIterations` — AskUser 打开后迭代渲染
- `TestAskUserAnswerPreservesViewportIterations` — 回答后迭代保留
- `TestCtrlC_UserMsgPreserved` — Ctrl+C 后 user msg 不消失
- `TestCtrlC_AutoStartRace` — auto-start turn 不误触发
