### PR TITLE
fix(tui): 压缩spinner动画 + 压缩后TUI卡住 + Ctrl+C多余消息

### DIFF
--- a/channel/cli_agent_msg.go
+++ b/channel/cli_agent_msg.go
@@ -91,13 +91,23 @@ func (m *cliModel) handleAgentMessage(msg OutboundMsg) {
 
 		if cancelledIdx >= 0 {
 			streamingMsg := &m.messages[cancelledIdx]
-			streamingMsg.isPartial = false
-			streamingMsg.dirty = true
-			// Preserve any accumulated content from IsPartial updates.
-			// The cancel outbound has empty Content, but the streaming message
-			// may have accumulated text via IsPartial before the cancel.
-			// Do NOT overwrite existing content — keep what was streamed.
-			streamingMsg.iterations = m.cancelledTurnIterations()
+			if strings.TrimSpace(streamingMsg.content) != "" {
+				// Streaming message accumulated real content (e.g. partial LLM text).
+				// Finalize it as a completed message so the user keeps what was streamed.
+				streamingMsg.isPartial = false
+				streamingMsg.dirty = true
+				streamingMsg.iterations = m.cancelledTurnIterations()
+			} else {
+				// Empty streaming message (shell created by startAgentTurn).
+				// Remove it — keeping an empty assistant with stale iterations
+				// creates a phantom message that doesn't match DB history.
+				m.messages = append(m.messages[:cancelledIdx], m.messages[cancelledIdx+1:]...)
+				if m.streamingMsgIdx == cancelledIdx {
+					m.streamingMsgIdx = -1
+				} else if m.streamingMsgIdx > cancelledIdx {
+					m.streamingMsgIdx--
+				}
+			}
 		}
 		// Still clean up progress/streaming state for the cancelled turn.
 		// Do NOT endAgentTurn — the current turn (if any) must remain active.
@@ -117,7 +127,9 @@ func (m *cliModel) handleAgentMessage(msg OutboundMsg) {
 				}
 			}
 		}
-		m.streamingMsgIdx = -1
+		if m.streamingMsgIdx >= 0 {
+			m.streamingMsgIdx = -1
+		}
 		m.progress = nil
 		m.typing = false        // clear typing indicator immediately after cancel
 		m.turnCancelled = false // cancel complete, allow future turns

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -1196,6 +1196,7 @@ type cliModel struct {
 	splashFrame          int  // 当前 splash 动画帧索引
 	suLoading            bool // true = /su 切换用户后正在加载历史，显示 loading 画面
 	suPhaseDoneConfirmed bool // true = PhaseDone received during suLoading (server confirmed idle)
+	compressionReloading bool // true = HistoryCompacted 异步 reload 进行中，阻止 auto-start
 
 	// --- §16 Toast 通知队列 ---
 	toasts     []cliToastItem // Toast 队列（头部=当前显示）

--- a/channel/cli_progress_test.go
+++ b/channel/cli_progress_test.go
@@ -407,8 +407,8 @@ func TestRenderLiveIterationCompressingShowsStatus(t *testing.T) {
 	if !strings.Contains(rendered, "compressing") {
 		t.Fatalf("compressing phase should render status text, got:\n%s", rendered)
 	}
-	if strings.Contains(rendered, "◇◇◇◇◇") {
-		t.Fatalf("compressing phase should not fall back to pulse spinner, got:\n%s", rendered)
+	if !strings.Contains(rendered, "◇") {
+		t.Fatalf("compressing phase should show pulse spinner animation, got:\n%s", rendered)
 	}
 }
 
@@ -554,24 +554,13 @@ func TestCancelMessagePreservesCurrentUnsnappedIteration(t *testing.T) {
 	if model.streamingMsgIdx != -1 {
 		t.Fatalf("streamingMsgIdx = %d, want -1 after cancel", model.streamingMsgIdx)
 	}
-	var assistant *cliMessage
+	// Empty streaming message should be removed on cancel — it is a shell
+	// created by startAgentTurn with no content. Keeping it produces a
+	// phantom assistant message with stale iterations in the viewport.
 	for i := range model.messages {
 		if model.messages[i].role == "assistant" {
-			assistant = &model.messages[i]
-			break
+			t.Fatalf("empty streaming message should have been removed on cancel, got assistant at index %d", i)
 		}
-	}
-	if assistant == nil {
-		t.Fatal("expected cancelled assistant message")
-	}
-	if got := len(assistant.iterations); got != 2 {
-		t.Fatalf("cancelled assistant iterations = %d, want 2: %+v", got, assistant.iterations)
-	}
-	if assistant.iterations[1].Iteration != 2 || assistant.iterations[1].Thinking != "current unsnapped iteration" {
-		t.Fatalf("current unsnapped iteration was not preserved: %+v", assistant.iterations[1])
-	}
-	if len(assistant.iterations[1].Tools) != 1 || assistant.iterations[1].Tools[0].Label != "Current build" {
-		t.Fatalf("current unsnapped tools were not preserved: %+v", assistant.iterations[1].Tools)
 	}
 }
 

--- a/channel/cli_render_turn.go
+++ b/channel/cli_render_turn.go
@@ -261,9 +261,10 @@ func (m *cliModel) liveIterationBlocks(p *protocol.ProgressEvent, width int, fal
 
 	if p.Phase == "compressing" {
 		hasSpinner = true
+		frame := diamondPulseFrames[m.ticker.frame%len(diamondPulseFrames)]
 		blocks = append(blocks, turnBlock{
 			kind: turnBlockPulse,
-			text: "  " + s.ProgressRunning.Render(m.locale.StatusCompressing),
+			text: "  " + s.ProgressRunning.Render(frame) + " " + s.ProgressRunning.Render(m.locale.StatusCompressing),
 		})
 	}
 

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -384,7 +384,7 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 	// turn is paused (not ended). Late progress events from the engine must not
 	// trigger startAgentTurn → resetProgressState, which clears iterationHistory
 	// and makes all previous iterations disappear.
-	if !m.typing && !m.suLoading && msg.payload != nil && msg.payload.Phase != "done" && m.panelMode != "askuser" {
+	if !m.typing && !m.suLoading && !m.compressionReloading && msg.payload != nil && msg.payload.Phase != "done" && m.panelMode != "askuser" {
 		log.WithFields(log.Fields{
 			"phase":     msg.payload.Phase,
 			"iteration": msg.payload.Iteration,
@@ -519,6 +519,11 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 		m.lastThinking = ""
 		m.invalidateAllCache(true)
 		m.rc.invalidateProgress()
+		// Block auto-start until reload completes. Without this, progress
+		// events from the post-compression iteration trigger auto-start,
+		// creating a streaming message that gets wiped by handleHistoryReload's
+		// forceFullRebuild path — losing the streaming state and stalling TUI.
+		m.compressionReloading = true
 		// Do NOT GotoBottom here — compression can happen while the user
 		// is scrolled up reading old content. Forcing to bottom would
 		// lose their position. The subsequent reloadMessagesFromSession
@@ -1414,9 +1419,18 @@ func (m *cliModel) handleHistoryReload(msg cliHistoryReloadMsg) {
 	// messages need re-rendering. This is critical for sessions with hundreds
 	// of iterations where full rebuild would take seconds.
 	m.streamingMsgIdx = restoredStreamingIdx
+	// Compression reload complete — allow auto-start turn again.
+	m.compressionReloading = false
 	if msg.forceFullRebuild {
 		m.messages = newMessages
 		m.invalidateAllCache(false)
+		// If engine is still running, start turn immediately so new
+		// iterations get a streaming message. Without this, progress
+		// updates only appear in the progress panel — new iteration
+		// tools never render in the message area, making TUI look frozen.
+		if !m.typing && m.progress != nil && m.progress.Phase != "done" && m.panelMode != "askuser" {
+			m.startAgentTurn()
+		}
 		m.updateViewportContent()
 		log.WithField("count", len(m.messages)).Info("History reloaded after compression with full rebuild")
 		return


### PR DESCRIPTION
## 修复三个 TUI Bug

### Bug1: 压缩中无 spinner 动画
- `liveIterationBlocks` 中 compressing phase 的 `turnBlockPulse` 使用静态文字而非 `diamondPulseFrames` 动画帧
- 修复：加上 `m.ticker.frame` 驱动的脉冲动画

### Bug2: 压缩完成后 TUI 卡住不更新进度（最严重）
- `HistoryCompacted` 清空 messages 后异步 reload，期间 progress event 无法正确触发 auto-start turn
- reload 完成后 `forceFullRebuild` 只替换 messages 就返回，引擎还在跑但没有 streaming message
- 修复：
  - 加 `compressionReloading` 标志阻止 reload 期间 auto-start（防止 streaming message 被覆盖丢失）
  - reload 完成后立刻 `startAgentTurn()` 恢复 streaming 状态

### Bug3: Ctrl+C 后多余 assistant 消息
- cancel ack finalize 空 streaming message（`startAgentTurn` 创建的空壳）为正式 assistant（有 iterations 无 content）
- 导致多出一个空 assistant 消息，显示的 iterations 和之前的 assistant 重复
- 修复：空 streaming message 直接删除而非 finalize，有 content 时保留

### 测试
- `go test ./channel/` 全部通过
- `go test ./...` 全部通过
- pre-commit hooks 全部通过