### PR TITLE
refactor(cli): consolidate 13 pending fields into cliPending struct

### DIFF
--- a/channel/cli/cli.go
+++ b/channel/cli/cli.go
@@ -132,55 +132,8 @@ func (c *CLIChannel) Start() error {
 	}
 
 	// Apply pending injections that were set before model existed
-	if c.pendingTrimHistoryFn != nil {
-		c.model.trimHistoryFn = c.pendingTrimHistoryFn
-	}
-	if c.pendingResetTokenStateFn != nil {
-		c.model.resetTokenStateFn = c.pendingResetTokenStateFn
-	}
-	if c.pendingCheckpointState != nil {
-		c.model.checkpointState = c.pendingCheckpointState
-	}
-	if c.pendingSendInboundFn != nil {
-		c.model.sendInboundFn = c.pendingSendInboundFn
-	}
-	// Apply pending remote bg task callbacks (remote mode: set before Start)
-	if c.pendingBgTaskCountFn != nil {
-		c.model.bgTaskCountFn = c.pendingBgTaskCountFn
-	}
-	if c.pendingBgTaskListFn != nil {
-		c.model.bgTaskListFn = c.pendingBgTaskListFn
-	}
-	if c.pendingBgTaskKillFn != nil {
-		c.model.bgTaskKillFn = c.pendingBgTaskKillFn
-	}
-	if c.pendingBgTaskCleanupFn != nil {
-		c.model.bgTaskCleanupFn = c.pendingBgTaskCleanupFn
-	}
-	if c.pendingPluginMgrFn != nil {
-		c.model.pluginMgrFn = c.pendingPluginMgrFn
-	}
-	if c.pendingWidgetRegistry != nil {
-		c.model.widgetRegistry = c.pendingWidgetRegistry
-		c.pendingWidgetRegistry.SetDefaultRenderFn(buildWidgetRenderFn(c.model.styles))
-		c.pendingWidgetRegistry.OnUpdated(func() {
-			select {
-			case c.asyncCh <- cliWidgetUpdateMsg{}:
-			default:
-			}
-		})
-		c.pendingWidgetRegistry = nil
-	}
-	if c.pendingRemotePluginCache != nil {
-		c.model.remotePluginCache = c.pendingRemotePluginCache
-		c.pendingRemotePluginCache.SetOnUpdated(func() {
-			select {
-			case c.asyncCh <- cliWidgetUpdateMsg{}:
-			default:
-			}
-		})
-		c.pendingRemotePluginCache = nil
-	}
+	c.applyPending()
+
 	// Set identity fields on the model.
 	c.model.channelName = "cli"
 	c.model.defaultChatID = c.config.ChatID
@@ -209,19 +162,8 @@ func (c *CLIChannel) Start() error {
 	// so the backend also uses the correct LLM.
 	c.model.scheduleSessionLLMRestore()
 
-	// If RestoreSession ran before Start() (c.model was nil), it cached
-	// data in pendingHistory/pendingProgress. Convert to pendingSuRestore
-	// so Init() emits it as a suHistoryLoadMsg via the event loop.
-	if c.pendingHistory != nil || c.pendingProgress != nil {
-		c.model.pendingSuRestore = &suHistoryLoadMsg{
-			history:        c.pendingHistory,
-			channelName:    "cli",
-			chatID:         c.config.ChatID,
-			activeProgress: c.pendingProgress,
-		}
-		c.pendingHistory = nil
-		c.pendingProgress = nil
-	}
+	// History/progress was converted to pendingSuRestore inside applyPending().
+	// Nothing more to do here.
 
 	// Propagate late-injected services to model (set before Start() when model was nil)
 	if c.subscriptionMgr != nil {
@@ -406,6 +348,80 @@ func (c *CLIChannel) Start() error {
 	return nil
 }
 
+// applyPending flushes all deferred injections (set before model existed)
+// into the newly created model. Called once inside Start().
+func (c *CLIChannel) applyPending() {
+	p := &c.pending
+	m := c.model
+
+	// Simple callback assignments
+	if p.trimHistoryFn != nil {
+		m.trimHistoryFn = p.trimHistoryFn
+	}
+	if p.resetTokenStateFn != nil {
+		m.resetTokenStateFn = p.resetTokenStateFn
+	}
+	if p.checkpointState != nil {
+		m.checkpointState = p.checkpointState
+	}
+	if p.sendInboundFn != nil {
+		m.sendInboundFn = p.sendInboundFn
+	}
+	if p.bgTaskCountFn != nil {
+		m.bgTaskCountFn = p.bgTaskCountFn
+	}
+	if p.bgTaskListFn != nil {
+		m.bgTaskListFn = p.bgTaskListFn
+	}
+	if p.bgTaskKillFn != nil {
+		m.bgTaskKillFn = p.bgTaskKillFn
+	}
+	if p.bgTaskCleanupFn != nil {
+		m.bgTaskCleanupFn = p.bgTaskCleanupFn
+	}
+	if p.pluginMgrFn != nil {
+		m.pluginMgrFn = p.pluginMgrFn
+	}
+
+	// Widget registry needs render fn + update callback wiring
+	if p.widgetRegistry != nil {
+		m.widgetRegistry = p.widgetRegistry
+		p.widgetRegistry.SetDefaultRenderFn(buildWidgetRenderFn(m.styles))
+		p.widgetRegistry.OnUpdated(func() {
+			select {
+			case c.asyncCh <- cliWidgetUpdateMsg{}:
+			default:
+			}
+		})
+		p.widgetRegistry = nil
+	}
+
+	// Remote plugin cache needs update callback wiring
+	if p.remotePluginCache != nil {
+		m.remotePluginCache = p.remotePluginCache
+		p.remotePluginCache.SetOnUpdated(func() {
+			select {
+			case c.asyncCh <- cliWidgetUpdateMsg{}:
+			default:
+			}
+		})
+		p.remotePluginCache = nil
+	}
+
+	// History/progress: convert to pendingSuRestore so Init() emits
+	// it as a suHistoryLoadMsg via the event loop.
+	if p.history != nil || p.progress != nil {
+		m.pendingSuRestore = &suHistoryLoadMsg{
+			history:        p.history,
+			channelName:    "cli",
+			chatID:         c.config.ChatID,
+			activeProgress: p.progress,
+		}
+		p.history = nil
+		p.progress = nil
+	}
+}
+
 // Stop 停止 CLI 渠道
 func (c *CLIChannel) Stop() {
 	log.Info("CLI channel stopping...")
@@ -547,7 +563,7 @@ func (c *CLIChannel) SetApprovalState(state *protocol.ApprovalState) {
 // In remote mode, this forwards user messages to the server via backend.SendInbound
 // instead of the local bus (which has no agent loop).
 func (c *CLIChannel) SetSendInboundFn(fn func(ch.InboundMsg) bool) {
-	c.pendingSendInboundFn = fn
+	c.pending.sendInboundFn = fn
 }
 
 // SetBgTaskRemoteCallbacks configures remote-mode background task callbacks.
@@ -563,10 +579,10 @@ func (c *CLIChannel) SetBgTaskRemoteCallbacks(sessionKey string, countFn func() 
 		c.model.bgTaskCleanupFn = cleanupFn
 	} else {
 		// Model not created yet (Start() not called) — save as pending
-		c.pendingBgTaskCountFn = countFn
-		c.pendingBgTaskListFn = listFn
-		c.pendingBgTaskKillFn = killFn
-		c.pendingBgTaskCleanupFn = cleanupFn
+		c.pending.bgTaskCountFn = countFn
+		c.pending.bgTaskListFn = listFn
+		c.pending.bgTaskKillFn = killFn
+		c.pending.bgTaskCleanupFn = cleanupFn
 	}
 }
 
@@ -577,7 +593,7 @@ func (c *CLIChannel) SetPluginManager(fn func() *plugin.PluginManager) {
 	if c.model != nil {
 		c.model.pluginMgrFn = fn
 	} else {
-		c.pendingPluginMgrFn = fn
+		c.pending.pluginMgrFn = fn
 	}
 }
 
@@ -600,7 +616,7 @@ func (c *CLIChannel) SetWidgetRegistry(wr *plugin.WidgetRegistry) {
 			})
 		}
 	} else {
-		c.pendingWidgetRegistry = wr
+		c.pending.widgetRegistry = wr
 	}
 }
 
@@ -620,7 +636,7 @@ func (c *CLIChannel) SetRemotePluginCache(cache *remotePluginCache) {
 			})
 		}
 	} else {
-		c.pendingRemotePluginCache = cache
+		c.pending.remotePluginCache = cache
 	}
 }
 
@@ -657,8 +673,8 @@ func (c *CLIChannel) RestoreSession(history []ch.HistoryMessage, activeProgress 
 	defer c.programMu.Unlock()
 	if c.model == nil {
 		// Model not created yet — cache for Start().
-		c.pendingHistory = history
-		c.pendingProgress = activeProgress
+		c.pending.history = history
+		c.pending.progress = activeProgress
 		return
 	}
 	if c.program == nil {
@@ -698,7 +714,7 @@ func (c *CLIChannel) SetTrimHistoryFn(fn func(cutoff time.Time) error) {
 	if c.model != nil {
 		c.model.trimHistoryFn = fn
 	}
-	c.pendingTrimHistoryFn = fn
+	c.pending.trimHistoryFn = fn
 }
 
 // SetResetTokenStateFn sets the callback for /rewind token state reset.
@@ -710,7 +726,7 @@ func (c *CLIChannel) SetResetTokenStateFn(fn func()) {
 	if c.model != nil {
 		c.model.resetTokenStateFn = fn
 	}
-	c.pendingResetTokenStateFn = fn
+	c.pending.resetTokenStateFn = fn
 }
 
 // ApplyInitialLayout applies layout settings (sidebar_width, sidebar_position, etc.)
@@ -747,7 +763,7 @@ func (c *CLIChannel) SetCheckpointState(state *protocol.CheckpointState) {
 	if c.model != nil {
 		c.model.checkpointState = state
 	}
-	c.pendingCheckpointState = state
+	c.pending.checkpointState = state
 }
 
 // InjectUserMessage 通知 CLI 有 user 消息被 agent 注入（如 bg task 完成通知）。

--- a/channel/cli/cli_types.go
+++ b/channel/cli/cli_types.go
@@ -437,6 +437,29 @@ type SessionPanelEntry struct {
 // ---------------------------------------------------------------------------
 
 // CLIChannel CLI 渠道实现
+// cliPending holds injections that arrive before c.model is created in Start().
+// All fields are nil/zero in local mode — only populated in remote mode where
+// callbacks are registered before Start() is called.
+// Flushed to model fields in a single applyPending() call inside Start().
+type cliPending struct {
+	// Function callbacks
+	trimHistoryFn     func(time.Time) error
+	resetTokenStateFn func()
+	sendInboundFn     func(ch.InboundMsg) bool
+	bgTaskCountFn     func() int
+	bgTaskListFn      func() []*BgTask
+	bgTaskKillFn      func(taskID string) error
+	bgTaskCleanupFn   func()
+	pluginMgrFn       func() *plugin.PluginManager
+
+	// Data objects (may need special wiring beyond simple assignment)
+	checkpointState   *protocol.CheckpointState
+	widgetRegistry    *plugin.WidgetRegistry
+	remotePluginCache *remotePluginCache
+	history           []ch.HistoryMessage     // cached before model is ready
+	progress          *protocol.ProgressEvent // cached before model is ready
+}
+
 type CLIChannel struct {
 	config  *CLIChannelConfig
 	msgChan chan ch.OutboundMsg // 接收 agent 回复的通道
@@ -492,21 +515,8 @@ type CLIChannel struct {
 	// Permission control
 	approvalState *protocol.ApprovalState // injected to wire CLIApprovalHandler after program creation
 
-	// Pending injections (set before model exists, applied in Start)
-	pendingTrimHistoryFn     func(time.Time) error
-	pendingResetTokenStateFn func()
-	pendingHistory           []ch.HistoryMessage     // remote mode: cached history before model is ready
-	pendingProgress          *protocol.ProgressEvent // remote mode: cached progress before model is ready
-	pendingCheckpointState   *protocol.CheckpointState
-	pendingSendInboundFn     func(ch.InboundMsg) bool
-	// Pending remote bg task callbacks (set before model exists in remote mode)
-	pendingBgTaskCountFn     func() int
-	pendingBgTaskListFn      func() []*BgTask
-	pendingBgTaskKillFn      func(taskID string) error // remote mode: forward to server
-	pendingBgTaskCleanupFn   func()                    // remote mode: cleanup completed tasks
-	pendingPluginMgrFn       func() *plugin.PluginManager
-	pendingWidgetRegistry    *plugin.WidgetRegistry // deferred from SetWidgetRegistry before model ready
-	pendingRemotePluginCache *remotePluginCache     // deferred from SetRemotePluginCache before model ready
+	// Pending injections (set before model exists, applied in Start via applyPending)
+	pending cliPending
 }
 
 // SettingsService is the interface needed by CLIChannel for settings panel.


### PR DESCRIPTION
## Summary

将 `CLIChannel` 上散落的 13 个 `pending*` 字段收拢为单一 `cliPending` 结构体 + 一个 `applyPending()` 方法。

## Background

CLIChannel 有 13 个 pending 缓冲字段，用于在 `model` 尚未创建（`Start()` 之前）时暂存回调函数和数据。这些字段在 `Start()` 内 `wireModel` 阶段被逐个检查并 flush 到 model。

**问题**：
- 13 个 `if c.pendingX != nil` 检查散落在 `Start()` 中（~60 行代码）
- 每个字段单独管理，新增 pending 字段时容易遗漏 flush
- 类型定义和 flush 逻辑没有内聚关系

## Changes

- 定义 `cliPending` 结构体，包含全部 13 个字段
- `CLIChannel.pendingX` × 13 → `CLIChannel.pending` (单一字段)
- `Start()` 中 60 行散落的 flush 逻辑 → `applyPending()` 方法
- 所有 `Set*` 方法中 `c.pendingX` → `c.pending.X`

## Verification
- ✅ `go build ./...`
- ✅ `go test ./...` (0 FAIL)
- ✅ `go vet ./channel/cli/`
- 零逻辑变更，纯结构重构