### PR TITLE
refactor(cli): decompose cliModel God Object into 7 sub-structs

### DIFF
--- a/channel/cli/cli.go
+++ b/channel/cli/cli.go
@@ -115,7 +115,7 @@ func (c *CLIChannel) Start() error {
 	// Load per-user UI preferences (sidebar collapse state, etc.)
 	prefs := tools.LoadPreferences(c.workDir, c.model.senderID)
 	if prefs.SidebarCollapsed != nil {
-		c.model.sidebarCollapsedSections = prefs.SidebarCollapsed
+		c.model.layoutConfig.collapsedSects = prefs.SidebarCollapsed
 	}
 
 	// CLI-side TodoManager for persisting todos across turns and session switches.
@@ -125,10 +125,10 @@ func (c *CLIChannel) Start() error {
 
 	// Apply CLI flag overrides for layout
 	if c.config.SidebarWidthOverride > 0 {
-		c.model.sidebarWidth = c.config.SidebarWidthOverride
+		c.model.layoutConfig.sidebarWidth = c.config.SidebarWidthOverride
 	}
 	if c.config.NoSidebar {
-		c.model.sidebarEnabled = false
+		c.model.layoutConfig.sidebarEnabled = false
 	}
 
 	// Apply pending injections that were set before model existed

--- a/channel/cli/cli_agent_msg.go
+++ b/channel/cli/cli_agent_msg.go
@@ -25,7 +25,7 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 	// the DB version (with turnID = 0) — the dedup key role|timestamp differs
 	// because time.Now() ≠ DB timestamp, producing duplicate messages in
 	// m.messages that survive fullRebuild (symptom: entire chat block repeated).
-	if m.suLoading {
+	if m.splashState.suLoading {
 		log.WithFields(log.Fields{
 			"msg_chatid":   msg.ChatID,
 			"waiting_user": msg.WaitingUser,
@@ -138,8 +138,8 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 		}
 		// Still clean up progress/streaming state for the cancelled turn.
 		// Do NOT endAgentTurn — the current turn (if any) must remain active.
-		if m.progress != nil {
-			m.cacheTokenUsage(m.progress.TokenUsage)
+		if m.progressState.current != nil {
+			m.cacheTokenUsage(m.progressState.current.TokenUsage)
 		}
 		// Restore pendingUserMsg: startAgentTurn cleared it, but if the engine
 		// hasn't persisted the user message to DB yet (immediate Ctrl+C), a
@@ -158,7 +158,7 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 			m.streamingMsgIdx = -1
 		}
 		m.pendingToolSummary = nil // clear stale iteration data from cancelled turn
-		m.progress = nil
+		m.progressState.current = nil
 		m.typing = false        // clear typing indicator immediately after cancel
 		m.turnCancelled = false // cancel complete, allow future turns
 		m.cancelTargetTurnID = 0
@@ -178,14 +178,14 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 	// A late-arriving empty-content outbound (e.g. from engine cleanup) must
 	// not trigger endAgentTurn, which clears iterationHistory and makes all
 	// previous iterations disappear from the viewport.
-	if content == "" && !msg.WaitingUser && len(msg.ToolsUsed) == 0 && m.panelMode != "askuser" {
+	if content == "" && !msg.WaitingUser && len(msg.ToolsUsed) == 0 && m.panelState.mode != "askuser" {
 		// Persist token usage before clearing progress
-		if m.progress != nil {
-			m.cacheTokenUsage(m.progress.TokenUsage)
+		if m.progressState.current != nil {
+			m.cacheTokenUsage(m.progressState.current.TokenUsage)
 		}
 		m.streamingMsgIdx = -1
 		m.pendingToolSummary = nil // prevent cross-turn leak (same class as U1 A1 U2 A1 bug)
-		m.progress = nil
+		m.progressState.current = nil
 		m.setTurnReplyReceived(turnID)
 		m.endAgentTurn(turnID)
 		if turnID == m.agentTurnID {
@@ -235,25 +235,25 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 		var bakeIterations []cliIterationSnapshot
 		if m.isTurnDoneProcessed(turnID) && m.pendingToolSummary != nil {
 			bakeIterations = m.pendingToolSummary.iterations
-		} else if len(m.iterationHistory) > 0 {
-			bakeIterations = append([]cliIterationSnapshot{}, m.iterationHistory...)
+		} else if len(m.progressState.iterations) > 0 {
+			bakeIterations = append([]cliIterationSnapshot{}, m.progressState.iterations...)
 		}
 		if len(bakeIterations) == 0 && m.streamingMsgIdx >= 0 && m.streamingMsgIdx < len(m.messages) {
 			bakeIterations = m.messages[m.streamingMsgIdx].iterations
 		}
-		// Append the last iteration from m.progress if it wasn't already
+		// Append the last iteration from m.progressState.current if it wasn't already
 		// captured in iterationHistory. The last iteration's data (tools,
-		// reasoning) is typically in m.progress but hasn't been snapshotted
+		// reasoning) is typically in m.progressState.current but hasn't been snapshotted
 		// by snapshotIterationChange (which only fires on iteration N→N+1
 		// transitions). Without this, AskUser messages lose the last
 		// iteration's tools from the viewport.
 		// Guard: use lastCompletedTools (filtered per-iteration) instead of
-		// m.progress.CompletedTools (may contain stale tools from earlier
+		// m.progressState.current.CompletedTools (may contain stale tools from earlier
 		// iterations), and only run when the iteration is genuinely missing.
-		if m.progress != nil && m.lastSeenIteration >= 0 && msg.WaitingUser {
-			iterNum := m.lastSeenIteration
-			if m.progress.Iteration > 0 {
-				iterNum = m.progress.Iteration
+		if m.progressState.current != nil && m.progressState.lastIter >= 0 && msg.WaitingUser {
+			iterNum := m.progressState.lastIter
+			if m.progressState.current.Iteration > 0 {
+				iterNum = m.progressState.current.Iteration
 			}
 			alreadyBaked := false
 			for _, it := range bakeIterations {
@@ -265,17 +265,17 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 			if !alreadyBaked {
 				// Use lastCompletedTools — these are per-iteration filtered
 				// (cleared by snapshotIterationChange on N→N+1), unlike
-				// m.progress.CompletedTools which accumulates stale tools.
+				// m.progressState.current.CompletedTools which accumulates stale tools.
 				var finalTools []protocol.ToolProgress
 				finalTools = append(finalTools, m.lastCompletedTools...)
-				for _, t := range m.progress.ActiveTools {
+				for _, t := range m.progressState.current.ActiveTools {
 					if t.Status == "done" || t.Status == "error" {
 						if !containsToolProgress(finalTools, t) {
 							finalTools = append(finalTools, t)
 						}
 					}
 				}
-				reasoning := m.progress.Reasoning
+				reasoning := m.progressState.current.Reasoning
 				if reasoning == "" && m.reasoningByIter != nil {
 					reasoning = m.reasoningByIter[iterNum]
 				}
@@ -284,10 +284,10 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 				}
 				snap := cliIterationSnapshot{
 					Iteration:   iterNum,
-					Thinking:    m.progress.Thinking,
+					Thinking:    m.progressState.current.Thinking,
 					Reasoning:   reasoning,
 					Tools:       finalTools,
-					ElapsedWall: time.Since(m.iterationStartTime).Milliseconds(),
+					ElapsedWall: time.Since(m.progressState.iterStart).Milliseconds(),
 				}
 				if len(snap.Tools) > 0 || snap.Thinking != "" || snap.Reasoning != "" {
 					bakeIterations = append(bakeIterations, snap)
@@ -328,30 +328,30 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 		// 重置流式状态
 		m.streamingMsgIdx = -1
 		// Capture reasoning from progress before it might be cleared.
-		// Do NOT clear m.progress here — progress is only cleared by endAgentTurn.
+		// Do NOT clear m.progressState.current here — progress is only cleared by endAgentTurn.
 		// Intermediate text messages (e.g. thinking content) arrive while the agent
 		// is still running; clearing progress here would hide the progress panel
 		// and make it look like the turn ended prematurely.
-		// IMPORTANT: Do NOT fallback to m.progress.ReasoningStreamContent.
+		// IMPORTANT: Do NOT fallback to m.progressState.current.ReasoningStreamContent.
 		// ReasoningStreamContent is a streaming accumulator with no per-iteration
 		// boundary. When handleAgentMessage arrives after the next structured
-		// progress has advanced m.progress.Iteration, ReasoningStreamContent may
+		// progress has advanced m.progressState.current.Iteration, ReasoningStreamContent may
 		// still contain the previous iteration's content — causing the previous
 		// iteration's reasoning to be misattributed to m.reasoningByIter[newIter].
-		if turnID == m.agentTurnID && m.progress != nil {
-			reasoning := m.progress.Reasoning
+		if turnID == m.agentTurnID && m.progressState.current != nil {
+			reasoning := m.progressState.current.Reasoning
 			if reasoning != "" {
 				m.lastReasoning = reasoning
 				if m.reasoningByIter == nil {
 					m.reasoningByIter = make(map[int]string)
 				}
-				iter := m.progress.Iteration
+				iter := m.progressState.current.Iteration
 				if iter >= 0 {
 					m.reasoningByIter[iter] = reasoning
 				}
 			}
-			if m.progress.Thinking != "" {
-				m.lastThinking = m.progress.Thinking
+			if m.progressState.current.Thinking != "" {
+				m.lastThinking = m.progressState.current.Thinking
 			}
 		}
 		// Store captured thinking on the completed message for Thinking Box rendering.
@@ -453,7 +453,7 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 					// startAgentTurn clears pendingToolSummary (to prevent stale
 					// cross-turn data), so we must save iterationHistory AFTER
 					// the clear, not before.
-					savedIterHistory := append([]cliIterationSnapshot{}, m.iterationHistory...)
+					savedIterHistory := append([]cliIterationSnapshot{}, m.progressState.iterations...)
 					m.startAgentTurn()
 					if len(savedIterHistory) > 0 {
 						if m.pendingToolSummary == nil {
@@ -477,10 +477,10 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 		}
 
 		// Snapshot the final iteration before clearing
-		if m.lastSeenIteration >= 0 && (len(m.lastCompletedTools) > 0 || m.lastReasoning != "" || m.lastThinking != "") {
+		if m.progressState.lastIter >= 0 && (len(m.lastCompletedTools) > 0 || m.lastReasoning != "" || m.lastThinking != "") {
 			alreadySnapped := false
-			for _, s := range m.iterationHistory {
-				if s.Iteration == m.lastSeenIteration {
+			for _, s := range m.progressState.iterations {
+				if s.Iteration == m.progressState.lastIter {
 					alreadySnapped = true
 					break
 				}
@@ -489,23 +489,23 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 				// Filter tools by Iteration field to ensure correct attribution
 				var finalTools []protocol.ToolProgress
 				for _, t := range m.lastCompletedTools {
-					if t.Iteration == m.lastSeenIteration {
+					if t.Iteration == m.progressState.lastIter {
 						finalTools = append(finalTools, t)
 					}
 				}
 				reasoning := m.lastReasoning
 				if reasoning == "" && m.reasoningByIter != nil {
-					reasoning = m.reasoningByIter[m.lastSeenIteration]
+					reasoning = m.reasoningByIter[m.progressState.lastIter]
 				}
 				snap := cliIterationSnapshot{
-					Iteration:   m.lastSeenIteration,
+					Iteration:   m.progressState.lastIter,
 					Reasoning:   reasoning,
 					Thinking:    m.lastThinking,
 					Tools:       finalTools,
-					ElapsedWall: time.Since(m.iterationStartTime).Milliseconds(),
+					ElapsedWall: time.Since(m.progressState.iterStart).Milliseconds(),
 				}
 				if len(finalTools) > 0 || reasoning != "" || m.lastThinking != "" {
-					m.iterationHistory = append(m.iterationHistory, snap)
+					m.progressState.iterations = append(m.progressState.iterations, snap)
 				}
 			}
 		}
@@ -515,7 +515,7 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 		// The assistant message already has iterations from pendingToolSummary
 		// (if PhaseDone arrived first) or from iterationHistory (if not).
 		// The final snapshot just above may have added more iterations.
-		if len(m.iterationHistory) > 0 {
+		if len(m.progressState.iterations) > 0 {
 			asstIdx := m.findMessageByTurn(turnID, "assistant")
 			if asstIdx >= 0 {
 				existing := m.messages[asstIdx]
@@ -523,7 +523,7 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 				for _, it := range existing.iterations {
 					existingIters[it.Iteration] = true
 				}
-				for _, it := range m.iterationHistory {
+				for _, it := range m.progressState.iterations {
 					if !existingIters[it.Iteration] {
 						existing.iterations = append(existing.iterations, it)
 					}
@@ -560,16 +560,16 @@ func (m *cliModel) cancelledTurnIterations() []cliIterationSnapshot {
 	var iterations []cliIterationSnapshot
 	if m.pendingToolSummary != nil && len(m.pendingToolSummary.iterations) > 0 {
 		iterations = append(iterations, m.pendingToolSummary.iterations...)
-	} else if len(m.iterationHistory) > 0 {
-		iterations = append(iterations, m.iterationHistory...)
+	} else if len(m.progressState.iterations) > 0 {
+		iterations = append(iterations, m.progressState.iterations...)
 	}
-	if m.progress == nil {
+	if m.progressState.current == nil {
 		return append([]cliIterationSnapshot{}, iterations...)
 	}
 
-	iterNum := m.progress.Iteration
-	if iterNum == 0 && m.lastSeenIteration != 0 {
-		iterNum = m.lastSeenIteration
+	iterNum := m.progressState.current.Iteration
+	if iterNum == 0 && m.progressState.lastIter != 0 {
+		iterNum = m.progressState.lastIter
 	}
 	for _, it := range iterations {
 		if it.Iteration == iterNum {
@@ -577,13 +577,13 @@ func (m *cliModel) cancelledTurnIterations() []cliIterationSnapshot {
 		}
 	}
 
-	tools := append([]protocol.ToolProgress{}, m.progress.CompletedTools...)
-	for _, tool := range m.progress.ActiveTools {
+	tools := append([]protocol.ToolProgress{}, m.progressState.current.CompletedTools...)
+	for _, tool := range m.progressState.current.ActiveTools {
 		if !containsToolProgress(tools, tool) {
 			tools = append(tools, tool)
 		}
 	}
-	reasoning := m.progress.Reasoning
+	reasoning := m.progressState.current.Reasoning
 	if reasoning == "" && m.reasoningByIter != nil {
 		reasoning = m.reasoningByIter[iterNum]
 	}
@@ -592,10 +592,10 @@ func (m *cliModel) cancelledTurnIterations() []cliIterationSnapshot {
 	}
 	snap := cliIterationSnapshot{
 		Iteration:   iterNum,
-		Thinking:    m.progress.Thinking,
+		Thinking:    m.progressState.current.Thinking,
 		Reasoning:   reasoning,
 		Tools:       tools,
-		ElapsedWall: time.Since(m.iterationStartTime).Milliseconds(),
+		ElapsedWall: time.Since(m.progressState.iterStart).Milliseconds(),
 	}
 	if snap.Thinking != "" || snap.Reasoning != "" || len(snap.Tools) > 0 {
 		iterations = append(iterations, snap)

--- a/channel/cli/cli_animation.go
+++ b/channel/cli/cli_animation.go
@@ -60,22 +60,22 @@ func isCJK(r rune) bool {
 // advanceTypewriter advances both typewriters (stream + reasoning) on each tick.
 // Called every typewriterTickMsg (50ms) during streaming.
 func (m *cliModel) advanceTypewriter() {
-	if m.progress == nil {
-		m.twVisible = 0
-		m.rwVisible = 0
+	if m.progressState.current == nil {
+		m.progressState.twVisible = 0
+		m.progressState.rwVisible = 0
 		return
 	}
 
 	// Advance reasoning writer
-	if m.progress.ReasoningStreamContent != "" {
-		target := len([]rune(m.progress.ReasoningStreamContent))
-		m.advanceWriterCJK(&m.rwVisible, target, m.progress.ReasoningStreamContent, &m.rwCjkSkipTick)
+	if m.progressState.current.ReasoningStreamContent != "" {
+		target := len([]rune(m.progressState.current.ReasoningStreamContent))
+		m.advanceWriterCJK(&m.progressState.rwVisible, target, m.progressState.current.ReasoningStreamContent, &m.progressState.rwCjkSkip)
 	}
 
 	// Advance stream writer
-	if m.progress.StreamContent != "" {
-		target := len([]rune(m.progress.StreamContent))
-		m.advanceWriterCJK(&m.twVisible, target, m.progress.StreamContent, &m.twCjkSkipTick)
+	if m.progressState.current.StreamContent != "" {
+		target := len([]rune(m.progressState.current.StreamContent))
+		m.advanceWriterCJK(&m.progressState.twVisible, target, m.progressState.current.StreamContent, &m.progressState.twCjkSkip)
 	}
 }
 

--- a/channel/cli/cli_approval.go
+++ b/channel/cli/cli_approval.go
@@ -54,17 +54,17 @@ type approvalRequestMsg struct {
 
 // updateApprovalPanel handles key events for the approval dialog.
 func (m *cliModel) updateApprovalPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
-	if m.approvalEnteringDeny {
+	if m.panelState.approvalDenyMode {
 		var cmd tea.Cmd
-		m.approvalDenyInput, cmd = m.approvalDenyInput.Update(msg)
+		m.panelState.approvalDenyTA, cmd = m.panelState.approvalDenyTA.Update(msg)
 		m.rc.valid = false
 		switch msg.Code {
 		case tea.KeyEnter:
-			m.resolveApproval(false, strings.TrimSpace(m.approvalDenyInput.Value()))
+			m.resolveApproval(false, strings.TrimSpace(m.panelState.approvalDenyTA.Value()))
 			return true, m, nil
 		case tea.KeyEscape:
-			m.approvalEnteringDeny = false
-			m.approvalDenyInput.Blur()
+			m.panelState.approvalDenyMode = false
+			m.panelState.approvalDenyTA.Blur()
 			return true, m, nil
 		}
 		return true, m, cmd
@@ -72,23 +72,23 @@ func (m *cliModel) updateApprovalPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 
 	switch msg.Code {
 	case tea.KeyLeft, tea.KeyUp:
-		m.approvalCursor = 0 // Approve
+		m.panelState.approvalCursor = 0 // Approve
 		m.rc.valid = false
 		return true, m, nil
 	case tea.KeyRight, tea.KeyDown:
-		m.approvalCursor = 1 // Deny
+		m.panelState.approvalCursor = 1 // Deny
 		m.rc.valid = false
 		return true, m, nil
 	case tea.KeyTab:
-		m.approvalCursor = (m.approvalCursor + 1) % 2
+		m.panelState.approvalCursor = (m.panelState.approvalCursor + 1) % 2
 		m.rc.valid = false
 		return true, m, nil
 	case tea.KeyEnter:
-		if m.approvalCursor == 0 {
+		if m.panelState.approvalCursor == 0 {
 			m.resolveApproval(true, "")
 		} else {
-			m.approvalEnteringDeny = true
-			m.approvalDenyInput.Focus()
+			m.panelState.approvalDenyMode = true
+			m.panelState.approvalDenyTA.Focus()
 		}
 		return true, m, nil
 	case tea.KeyEscape:
@@ -102,8 +102,8 @@ func (m *cliModel) updateApprovalPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 			m.resolveApproval(true, "")
 			return true, m, nil
 		case "n", "N":
-			m.approvalEnteringDeny = true
-			m.approvalDenyInput.Focus()
+			m.panelState.approvalDenyMode = true
+			m.panelState.approvalDenyTA.Focus()
 			m.rc.valid = false
 			return true, m, nil
 		}
@@ -114,14 +114,14 @@ func (m *cliModel) updateApprovalPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 
 // resolveApproval sends the result and closes the approval panel.
 func (m *cliModel) resolveApproval(approved bool, denyReason string) {
-	if m.approvalResultCh != nil {
-		m.approvalResultCh <- protocol.ApprovalResult{Approved: approved, DenyReason: denyReason}
-		m.approvalResultCh = nil
+	if m.panelState.approvalCh != nil {
+		m.panelState.approvalCh <- protocol.ApprovalResult{Approved: approved, DenyReason: denyReason}
+		m.panelState.approvalCh = nil
 	}
-	m.approvalRequest = nil
-	m.approvalCursor = 0
-	m.approvalEnteringDeny = false
-	m.panelMode = ""
+	m.panelState.approvalReq = nil
+	m.panelState.approvalCursor = 0
+	m.panelState.approvalDenyMode = false
+	m.panelState.mode = ""
 	m.rc.valid = false
 }
 
@@ -129,12 +129,12 @@ func (m *cliModel) resolveApproval(approved bool, denyReason string) {
 
 // viewApprovalPanel renders the approval dialog content.
 func (m *cliModel) viewApprovalPanel() string {
-	if m.approvalRequest == nil {
+	if m.panelState.approvalReq == nil {
 		return ""
 	}
 
 	s := m.styles
-	req := m.approvalRequest
+	req := m.panelState.approvalReq
 	var sb strings.Builder
 
 	// Header
@@ -177,10 +177,10 @@ func (m *cliModel) viewApprovalPanel() string {
 	}
 
 	sb.WriteString("\n")
-	if m.approvalEnteringDeny {
+	if m.panelState.approvalDenyMode {
 		sb.WriteString(labelSt.Render("  Deny note: "))
 		sb.WriteString("\n")
-		sb.WriteString("  " + m.approvalDenyInput.View())
+		sb.WriteString("  " + m.panelState.approvalDenyTA.View())
 		sb.WriteString("\n")
 		sb.WriteString(labelSt.Render("  Enter submit deny, Esc back"))
 		sb.WriteString("\n\n")
@@ -195,7 +195,7 @@ func (m *cliModel) viewApprovalPanel() string {
 	inactiveSt := lipgloss.NewStyle().Foreground(s.PanelDesc.GetForeground()).Faint(true)
 
 	var approve, deny string
-	if m.approvalCursor == 0 {
+	if m.panelState.approvalCursor == 0 {
 		approve = activeSt.Render(approveLabel)
 		deny = inactiveSt.Render(denyLabel)
 	} else {

--- a/channel/cli/cli_askuser_late_test.go
+++ b/channel/cli/cli_askuser_late_test.go
@@ -38,7 +38,7 @@ func TestAskUserLateProgressClearsState(t *testing.T) {
 		},
 	})
 
-	iterCountBefore := len(model.iterationHistory)
+	iterCountBefore := len(model.progressState.iterations)
 	if iterCountBefore == 0 {
 		t.Fatalf("Expected iterationHistory to have entries, got 0")
 	}
@@ -57,8 +57,8 @@ func TestAskUserLateProgressClearsState(t *testing.T) {
 		},
 	})
 
-	if model.panelMode != "askuser" {
-		t.Fatalf("Expected panelMode=askuser, got %q", model.panelMode)
+	if model.panelState.mode != "askuser" {
+		t.Fatalf("Expected panelMode=askuser, got %q", model.panelState.mode)
 	}
 
 	// Now simulate a LATE progress event arriving after the panel is open.
@@ -71,11 +71,11 @@ func TestAskUserLateProgressClearsState(t *testing.T) {
 	})
 
 	// The late progress event should NOT clear iterationHistory.
-	if len(model.iterationHistory) == 0 {
+	if len(model.progressState.iterations) == 0 {
 		t.Error("BUG REPRODUCED: late progress event cleared iterationHistory after AskUser panel opened")
 	}
 
-	if model.progress == nil {
+	if model.progressState.current == nil {
 		t.Error("BUG: progress was cleared by late progress event's auto-start turn")
 	}
 }
@@ -118,13 +118,13 @@ func TestAskUserTickPreservesIterations(t *testing.T) {
 		},
 	})
 
-	iterCount := len(model.iterationHistory)
+	iterCount := len(model.progressState.iterations)
 
 	// Simulate tick
 	model.handleTickMsg()
 
-	if len(model.iterationHistory) != iterCount {
+	if len(model.progressState.iterations) != iterCount {
 		t.Errorf("Tick changed iterationHistory: before=%d after=%d",
-			iterCount, len(model.iterationHistory))
+			iterCount, len(model.progressState.iterations))
 	}
 }

--- a/channel/cli/cli_askuser_render_test.go
+++ b/channel/cli/cli_askuser_render_test.go
@@ -11,7 +11,7 @@ import (
 
 // TestAskUserViewportPreservesIterations verifies that when AskUser panel opens,
 // the viewport rendering of the previous assistant message still shows ALL iteration
-// data (tool names). The bug was that the last iteration's tools (from m.progress)
+// data (tool names). The bug was that the last iteration's tools (from m.progressState.current)
 // were not included in bakeIterations, so they disappeared when the message was finalized.
 func TestAskUserViewportPreservesIterations(t *testing.T) {
 	model := initTestModel()
@@ -50,8 +50,8 @@ func TestAskUserViewportPreservesIterations(t *testing.T) {
 		},
 	})
 
-	if model.panelMode != "askuser" {
-		t.Fatalf("Expected panelMode=askuser, got %q", model.panelMode)
+	if model.panelState.mode != "askuser" {
+		t.Fatalf("Expected panelMode=askuser, got %q", model.panelState.mode)
 	}
 
 	// Verify the assistant message has iterations baked in
@@ -125,8 +125,8 @@ func TestAskUserAnswerPreservesViewportIterations(t *testing.T) {
 		},
 	})
 
-	if model.panelMode != "askuser" {
-		t.Fatalf("Expected panelMode=askuser, got %q", model.panelMode)
+	if model.panelState.mode != "askuser" {
+		t.Fatalf("Expected panelMode=askuser, got %q", model.panelState.mode)
 	}
 
 	// Verify pre-answer: assistant has iterations
@@ -152,8 +152,8 @@ func TestAskUserAnswerPreservesViewportIterations(t *testing.T) {
 	}
 
 	// Answer the AskUser question
-	if model.panelOnAnswer != nil {
-		model.panelOnAnswer(map[string]string{"q0": "yes"})
+	if model.panelState.onAnswer != nil {
+		model.panelState.onAnswer(map[string]string{"q0": "yes"})
 	}
 
 	// After answer: find the pre-AskUser assistant message (non-partial, not the new streaming one)

--- a/channel/cli/cli_askuser_test.go
+++ b/channel/cli/cli_askuser_test.go
@@ -36,7 +36,7 @@ func TestAskUserIterationVisibility(t *testing.T) {
 	})
 
 	// Snapshot iteration history count
-	iterCountBefore := len(model.iterationHistory)
+	iterCountBefore := len(model.progressState.iterations)
 	if iterCountBefore == 0 {
 		t.Fatalf("Expected iterationHistory to have entries, got 0")
 	}
@@ -65,8 +65,8 @@ func TestAskUserIterationVisibility(t *testing.T) {
 	})
 
 	// After the outbound, the AskUser panel should be open
-	if model.panelMode != "askuser" {
-		t.Fatalf("Expected panelMode=askuser, got %q", model.panelMode)
+	if model.panelState.mode != "askuser" {
+		t.Fatalf("Expected panelMode=askuser, got %q", model.panelState.mode)
 	}
 
 	// typing should be false (openAskUserPanel sets it)
@@ -75,13 +75,13 @@ func TestAskUserIterationVisibility(t *testing.T) {
 	}
 
 	// CRITICAL CHECK: iterationHistory should still have entries
-	if len(model.iterationHistory) != iterCountBefore {
+	if len(model.progressState.iterations) != iterCountBefore {
 		t.Errorf("iterationHistory was cleared! Before=%d, After=%d",
-			iterCountBefore, len(model.iterationHistory))
+			iterCountBefore, len(model.progressState.iterations))
 	}
 
 	// progress should still be non-nil
-	if model.progress == nil {
+	if model.progressState.current == nil {
 		t.Error("progress should not be nil while AskUser panel is open")
 	}
 }
@@ -127,13 +127,13 @@ func TestAskUserIterationSurvivesAnswer(t *testing.T) {
 		},
 	})
 
-	if model.panelMode != "askuser" {
-		t.Fatalf("Expected panelMode=askuser, got %q", model.panelMode)
+	if model.panelState.mode != "askuser" {
+		t.Fatalf("Expected panelMode=askuser, got %q", model.panelState.mode)
 	}
 
 	// Simulate answer callback
-	if model.panelOnAnswer != nil {
-		model.panelOnAnswer(map[string]string{"q0": "yes"})
+	if model.panelState.onAnswer != nil {
+		model.panelState.onAnswer(map[string]string{"q0": "yes"})
 	}
 
 	// After answer: startAgentTurn clears iterationHistory, but

--- a/channel/cli/cli_cache.go
+++ b/channel/cli/cli_cache.go
@@ -59,13 +59,13 @@ func (m *cliModel) mergeMessagesPreservingCache(newMessages []cliMessage) bool {
 
 // resetProgressState resets iteration tracking for a new agent turn.
 func (m *cliModel) resetProgressState() {
-	m.iterationHistory = nil
-	m.lastSeenIteration = 0
-	m.lastProgressSeq = 0
+	m.progressState.iterations = nil
+	m.progressState.lastIter = 0
+	m.progressState.lastSeq = 0
 	m.lastReasoning = ""
 	m.reasoningByIter = nil
-	m.progress = nil
-	m.iterationStartTime = time.Now() // wall-clock start for iteration 0
+	m.progressState.current = nil
+	m.progressState.iterStart = time.Now() // wall-clock start for iteration 0
 	m.typingStartTime = time.Now()
 	m.rc.invalidateProgress()
 }
@@ -73,7 +73,7 @@ func (m *cliModel) resetProgressState() {
 // collectAllTools gathers all tools from iteration history into a flat slice.
 func (m *cliModel) collectAllTools() []protocol.ToolProgress {
 	var all []protocol.ToolProgress
-	for _, snap := range m.iterationHistory {
+	for _, snap := range m.progressState.iterations {
 		all = append(all, snap.Tools...)
 	}
 	return all
@@ -257,7 +257,7 @@ func (m *cliModel) fullRebuild() {
 			hmax = msgMaxW
 		}
 		// §21 搜索高亮：匹配消息前插入指示条
-		if m.searchMode && m.isSearchMatch(i) {
+		if m.searchState.mode && m.isSearchMatch(i) {
 			indicator := m.styles.SearchIndicator.Render("▸ ")
 			allWrappedLines = append(allWrappedLines, indicator)
 			runningLines++

--- a/channel/cli/cli_ctrlc_test.go
+++ b/channel/cli/cli_ctrlc_test.go
@@ -192,7 +192,7 @@ func TestCtrlC_CancelAckPreservesBakedIterations(t *testing.T) {
 	}
 
 	// Simulate iterations accumulated during the turn
-	model.iterationHistory = []cliIterationSnapshot{
+	model.progressState.iterations = []cliIterationSnapshot{
 		{
 			Iteration: 1,
 			Thinking:  "analyzing the code",
@@ -208,8 +208,8 @@ func TestCtrlC_CancelAckPreservesBakedIterations(t *testing.T) {
 			},
 		},
 	}
-	model.lastSeenIteration = 2
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.lastIter = 2
+	model.progressState.current = &protocol.ProgressEvent{
 		Phase:     "tool_exec",
 		Iteration: 2,
 	}
@@ -243,7 +243,7 @@ func TestCtrlC_CancelAckPreservesBakedIterations(t *testing.T) {
 		t.Fatal("handleProgressDone should have baked iterations into streaming message")
 	}
 	// Verify iterationHistory was cleared by endAgentTurn
-	if len(model.iterationHistory) != 0 {
+	if len(model.progressState.iterations) != 0 {
 		t.Fatal("iterationHistory should be cleared after endAgentTurn")
 	}
 
@@ -297,7 +297,7 @@ func TestCtrlC_CancelAckBakesIterationsWhenPhaseDoneNotArrived(t *testing.T) {
 	})
 
 	// Iteration history still available (PhaseDone hasn't arrived yet)
-	model.iterationHistory = []cliIterationSnapshot{
+	model.progressState.iterations = []cliIterationSnapshot{
 		{
 			Iteration: 1,
 			Tools: []protocol.ToolProgress{
@@ -305,7 +305,7 @@ func TestCtrlC_CancelAckBakesIterationsWhenPhaseDoneNotArrived(t *testing.T) {
 			},
 		},
 	}
-	model.progress = &protocol.ProgressEvent{Iteration: 1}
+	model.progressState.current = &protocol.ProgressEvent{Iteration: 1}
 
 	// Cancel ack arrives BEFORE PhaseDone
 	model.Update(cliOutboundMsg{

--- a/channel/cli/cli_cursor.go
+++ b/channel/cli/cli_cursor.go
@@ -7,12 +7,12 @@ import (
 // ensurePanelCursorVisible ensures the panel cursor line is within the visible area.
 // For settings panel: uses precise line calculation with inline overlay awareness.
 func (m *cliModel) ensurePanelCursorVisible() {
-	if m.panelMode == "settings" {
+	if m.panelState.mode == "settings" {
 		extra := 0
-		if m.panelEdit {
+		if m.panelState.editing {
 			extra = 3
-		} else if m.panelCombo && m.panelCursor < len(m.panelSchema) {
-			def := m.panelSchema[m.panelCursor]
+		} else if m.panelState.combo && m.panelState.cursor < len(m.panelState.schema) {
+			def := m.panelState.schema[m.panelState.cursor]
 			extra = min(len(def.Options), 8) + 1
 		}
 		m.ensureSettingsCursorVisible(extra)
@@ -32,16 +32,16 @@ func (m *cliModel) ensureBgCursorVisible() {
 	// Header line
 	cursorLine = 1
 	idx := 0
-	for _, task := range m.panelBgTasks {
+	for _, task := range m.panelState.bgTasks {
 		_ = task // tasks are always 1 line
-		if idx == m.panelBgCursor {
+		if idx == m.panelState.bgCursor {
 			break
 		}
 		cursorLine++
 		idx++
 	}
-	for _, ag := range m.panelBgAgents {
-		if idx == m.panelBgCursor {
+	for _, ag := range m.panelState.bgAgents {
+		if idx == m.panelState.bgCursor {
 			break
 		}
 		cursorLine++ // agent label line
@@ -53,14 +53,14 @@ func (m *cliModel) ensureBgCursorVisible() {
 
 	totalLines := cursorLine + 2 // +2 for header and bottom padding
 	if totalLines <= visibleH {
-		m.panelScrollY = 0
+		m.panelState.scrollY = 0
 		return
 	}
-	if cursorLine >= m.panelScrollY+visibleH {
-		m.panelScrollY = cursorLine - visibleH + 1
+	if cursorLine >= m.panelState.scrollY+visibleH {
+		m.panelState.scrollY = cursorLine - visibleH + 1
 	}
-	if cursorLine < m.panelScrollY {
-		m.panelScrollY = cursorLine
+	if cursorLine < m.panelState.scrollY {
+		m.panelState.scrollY = cursorLine
 	}
 }
 
@@ -71,17 +71,17 @@ func (m *cliModel) ensureBgCursorVisible() {
 func (m *cliModel) ensureSessionCursorVisible() {
 	visibleH := m.panelVisibleHeight()
 	// +1 for header line
-	cursorLine := m.panelSessionCursor + 1
-	totalLines := len(m.panelSessionItems) + 1
+	cursorLine := m.panelState.sessCursor + 1
+	totalLines := len(m.panelState.sessItems) + 1
 	if totalLines <= visibleH {
-		m.panelScrollY = 0
+		m.panelState.scrollY = 0
 		return
 	}
-	if cursorLine >= m.panelScrollY+visibleH {
-		m.panelScrollY = cursorLine - visibleH + 1
+	if cursorLine >= m.panelState.scrollY+visibleH {
+		m.panelState.scrollY = cursorLine - visibleH + 1
 	}
-	if cursorLine < m.panelScrollY {
-		m.panelScrollY = cursorLine
+	if cursorLine < m.panelState.scrollY {
+		m.panelState.scrollY = cursorLine
 	}
 }
 
@@ -103,14 +103,14 @@ func (m *cliModel) clampPanelScroll(rawContent string) {
 	total := strings.Count(rawContent, "\n") + 1
 	visible := m.panelVisibleHeight()
 	if total <= visible {
-		m.panelScrollY = 0
+		m.panelState.scrollY = 0
 		return
 	}
-	if m.panelScrollY < 0 {
-		m.panelScrollY = 0
+	if m.panelState.scrollY < 0 {
+		m.panelState.scrollY = 0
 	}
-	if m.panelScrollY > total-visible {
-		m.panelScrollY = total - visible
+	if m.panelState.scrollY > total-visible {
+		m.panelState.scrollY = total - visible
 	}
 }
 
@@ -126,12 +126,12 @@ func (m *cliModel) settingsCursorLine() int {
 	const headerLines = 2 // title + divider
 	line := headerLines
 	lastCat := ""
-	for i, def := range m.panelSchema {
+	for i, def := range m.panelState.schema {
 		if def.Category != lastCat {
 			lastCat = def.Category
 			line += 2 // blank line + category header
 		}
-		if i == m.panelCursor {
+		if i == m.panelState.cursor {
 			return line
 		}
 		line++
@@ -158,15 +158,15 @@ func (m *cliModel) ensureSettingsCursorVisible(extraLines int) {
 	neededTop := cursorLine
 
 	// If overlay extends below visible area, scroll down
-	if neededBottom > m.panelScrollY+visibleH {
-		m.panelScrollY = neededBottom - visibleH
+	if neededBottom > m.panelState.scrollY+visibleH {
+		m.panelState.scrollY = neededBottom - visibleH
 	}
 	// If cursor is above visible area, scroll up
-	if neededTop < m.panelScrollY {
-		m.panelScrollY = neededTop
+	if neededTop < m.panelState.scrollY {
+		m.panelState.scrollY = neededTop
 	}
-	if m.panelScrollY < 0 {
-		m.panelScrollY = 0
+	if m.panelState.scrollY < 0 {
+		m.panelState.scrollY = 0
 	}
 }
 
@@ -180,7 +180,7 @@ func (m *cliModel) ensureSettingsCursorVisible(extraLines int) {
 // Caches total line count in askPanelTotalLines for use by ensureAskUserVisible.
 func (m *cliModel) clampAskUserPanelScroll(rawContent string) {
 	total := strings.Count(rawContent, "\n") + 1
-	m.askPanelTotalLines = total
+	m.panelState.askTotalLines = total
 	fixedLines := 2 // titleBar + toast (no separate footer — hints are in-panel)
 	panelBorder := 2
 	viewportH := m.layoutViewportHeight()
@@ -189,14 +189,14 @@ func (m *cliModel) clampAskUserPanelScroll(rawContent string) {
 		visible = 3
 	}
 	if total <= visible {
-		m.askPanelScrollY = 0
+		m.panelState.askScrollY = 0
 		return
 	}
-	if m.askPanelScrollY < 0 {
-		m.askPanelScrollY = 0
+	if m.panelState.askScrollY < 0 {
+		m.panelState.askScrollY = 0
 	}
-	if m.askPanelScrollY > total-visible {
-		m.askPanelScrollY = total - visible
+	if m.panelState.askScrollY > total-visible {
+		m.panelState.askScrollY = total - visible
 	}
 }
 

--- a/channel/cli/cli_debug.go
+++ b/channel/cli/cli_debug.go
@@ -434,9 +434,9 @@ func (m *cliModel) renderDebugStats() string {
 
 	fmt.Fprintf(&sb, "\n── Session ──\n")
 	fmt.Fprintf(&sb, "Messages:   %d\n", len(m.messages))
-	if m.progress != nil {
-		fmt.Fprintf(&sb, "Iteration:  %d\n", m.progress.Iteration)
-		fmt.Fprintf(&sb, "History:    %d snapshots\n", len(m.iterationHistory))
+	if m.progressState.current != nil {
+		fmt.Fprintf(&sb, "Iteration:  %d\n", m.progressState.current.Iteration)
+		fmt.Fprintf(&sb, "History:    %d snapshots\n", len(m.progressState.iterations))
 	}
 	fmt.Fprintf(&sb, "Queue:      %d\n", len(m.messageQueue))
 	fmt.Fprintf(&sb, "Viewport H: %d\n", m.viewport.Height())

--- a/channel/cli/cli_helpers.go
+++ b/channel/cli/cli_helpers.go
@@ -78,7 +78,7 @@ func (m *cliModel) invalidateAllCache(updateViewport bool) {
 }
 
 func (m *cliModel) openSettingsFromQuickSwitch() {
-	if m.channel == nil || len(m.panelValuesBackup) == 0 {
+	if m.channel == nil || len(m.panelState.valuesBackup) == 0 {
 		return
 	}
 	schema := m.channel.SettingsSchema()
@@ -102,20 +102,20 @@ func (m *cliModel) openSettingsFromQuickSwitch() {
 	values := m.mergeCLISettingsValues()
 	// Overlay non-subscription values from backup (preserves user's in-memory edits).
 	// ch.Subscription quick switch should only refresh the active subscription-backed keys.
-	for k, v := range m.panelValuesBackup {
+	for k, v := range m.panelState.valuesBackup {
 		if isSubscriptionScopedSettingKey(k) {
 			continue
 		}
 		values[k] = v
 	}
-	cursor := m.panelCursorBackup
-	onSubmit := m.panelOnSubmitBackup
+	cursor := m.panelState.cursorBackup
+	onSubmit := m.panelState.onSubmitBackup
 	// Clear backup
-	m.panelValuesBackup = nil
-	m.panelOnSubmitBackup = nil
+	m.panelState.valuesBackup = nil
+	m.panelState.onSubmitBackup = nil
 	// Open panel with restored state
 	m.openSettingsPanel(schema, values, onSubmit)
-	m.panelCursor = cursor
+	m.panelState.cursor = cursor
 }
 
 func (m *cliModel) applyThemeAndRebuild(theme string) {
@@ -147,26 +147,26 @@ func (m *cliModel) applyLanguageChange(lang string) {
 // and invalidates the render cache so the viewport relayouts.
 func (m *cliModel) applyLayoutConfig(vals map[string]string) {
 	if v, ok := vals["layout_mode"]; ok && v != "" {
-		m.layoutMode = v
+		m.layoutConfig.mode = v
 	}
 	if v, ok := vals["sidebar_enabled"]; ok {
-		m.sidebarEnabled = ParseSettingBool(v)
+		m.layoutConfig.sidebarEnabled = ParseSettingBool(v)
 	}
 	if v, ok := vals["sidebar_width"]; ok {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			m.sidebarWidth = n
+			m.layoutConfig.sidebarWidth = n
 		}
 	}
 	if v, ok := vals["sidebar_position"]; ok && v != "" {
-		m.sidebarPosition = v
+		m.layoutConfig.sidebarPos = v
 	}
 	if v, ok := vals["chat_max_width"]; ok {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-			m.chatMaxWidth = n
+			m.layoutConfig.maxWidth = n
 		}
 	}
 	if v, ok := vals["chat_center"]; ok {
-		m.chatCenter = ParseSettingBool(v)
+		m.layoutConfig.center = ParseSettingBool(v)
 	}
 	m.rc.valid = false
 }
@@ -181,7 +181,7 @@ func (m *cliModel) doSaveSettings(onSubmit func(map[string]string), vals map[str
 	lang, hasLang := vals["language"]
 	// Capture feedback string now (m.locale is only safe to read in Update)
 	feedbackMsg := m.locale.SettingsSaved
-	if m.panelIsSetup {
+	if m.panelState.isSetup {
 		feedbackMsg = m.locale.SetupComplete
 	}
 
@@ -236,7 +236,7 @@ func (m *cliModel) reloadSettingsCaches() {
 // handleSettingsSavedMsg processes the async settings save result.
 // Called from Update() to apply theme/locale/layout changes and refresh the viewport.
 func (m *cliModel) handleSettingsSavedMsg(msg cliSettingsSavedMsg) tea.Cmd {
-	m.settingsSaving = false // unblock user input
+	m.panelState.settingsSaving = false // unblock user input
 	visualChanged := false
 	if msg.themeChanged {
 		m.applyThemeAndRebuild(msg.theme)
@@ -261,8 +261,8 @@ func (m *cliModel) handleSettingsSavedMsg(msg cliSettingsSavedMsg) tea.Cmd {
 		m.appendSystem(msg.feedbackMsg)
 	}
 	// After setup wizard completes, show welcome message with TUI usage tips.
-	if m.panelIsSetup {
-		m.panelIsSetup = false
+	if m.panelState.isSetup {
+		m.panelState.isSetup = false
 		if m.locale.SetupWelcome != "" {
 			m.appendSystem(m.locale.SetupWelcome)
 		}
@@ -281,8 +281,8 @@ func (m *cliModel) handleSettingsSavedMsg(msg cliSettingsSavedMsg) tea.Cmd {
 func (m *cliModel) submitAskAnswers() (bool, tea.Model, tea.Cmd) {
 	m.saveCurrentFreeInput()
 	answers := m.collectAskAnswers()
-	if m.panelOnAnswer != nil {
-		m.panelOnAnswer(answers)
+	if m.panelState.onAnswer != nil {
+		m.panelState.onAnswer(answers)
 	}
 	m.closePanel()
 	// NOTE: tickCmd() is NOT returned here. If agent is typing, the tick chain

--- a/channel/cli/cli_helpers_test.go
+++ b/channel/cli/cli_helpers_test.go
@@ -79,12 +79,12 @@ func TestIsSubscriptionScopedSettingKey(t *testing.T) {
 func TestOpenSettingsFromQuickSwitch_PreservesNonSubscriptionEdits(t *testing.T) {
 	model := newCLIModel()
 	model.channel = &CLIChannel{config: &CLIChannelConfig{}}
-	model.panelValuesBackup = map[string]string{
+	model.panelState.valuesBackup = map[string]string{
 		"theme":    "mono",
 		"language": "en",
 	}
-	model.panelCursorBackup = 1
-	model.panelOnSubmitBackup = func(map[string]string) {}
+	model.panelState.cursorBackup = 1
+	model.panelState.onSubmitBackup = func(map[string]string) {}
 	model.channel.config.GetCurrentValues = func() map[string]string {
 		return map[string]string{
 			"theme":    "midnight",
@@ -92,13 +92,13 @@ func TestOpenSettingsFromQuickSwitch_PreservesNonSubscriptionEdits(t *testing.T)
 		}
 	}
 	model.openSettingsFromQuickSwitch()
-	if model.panelMode != "settings" {
-		t.Fatalf("panelMode = %q, want settings", model.panelMode)
+	if model.panelState.mode != "settings" {
+		t.Fatalf("panelMode = %q, want settings", model.panelState.mode)
 	}
-	if got := model.panelValues["theme"]; got != "mono" {
+	if got := model.panelState.values["theme"]; got != "mono" {
 		t.Fatalf("theme = %q, want mono", got)
 	}
-	if got := model.panelValues["language"]; got != "en" {
+	if got := model.panelState.values["language"]; got != "en" {
 		t.Fatalf("language = %q, want en", got)
 	}
 }
@@ -461,10 +461,10 @@ func TestStartAgentTurn(t *testing.T) {
 	if model.inputReady {
 		t.Error("inputReady should be false after startAgentTurn")
 	}
-	if model.iterationHistory != nil {
+	if model.progressState.iterations != nil {
 		t.Error("iterationHistory should be nil after resetProgressState")
 	}
-	if model.lastSeenIteration != 0 {
+	if model.progressState.lastIter != 0 {
 		t.Error("lastSeenIteration should be 0 after resetProgressState")
 	}
 }
@@ -472,18 +472,18 @@ func TestStartAgentTurn(t *testing.T) {
 func TestStartAgentTurn_ResetsProgressState(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.iterationHistory = []cliIterationSnapshot{
+	model.progressState.iterations = []cliIterationSnapshot{
 		{Iteration: 1, Tools: []protocol.ToolProgress{{Name: "test"}}},
 	}
-	model.lastSeenIteration = 5
+	model.progressState.lastIter = 5
 
 	model.startAgentTurn()
 
-	if len(model.iterationHistory) != 0 {
-		t.Errorf("iterationHistory should be empty, got %d items", len(model.iterationHistory))
+	if len(model.progressState.iterations) != 0 {
+		t.Errorf("iterationHistory should be empty, got %d items", len(model.progressState.iterations))
 	}
-	if model.lastSeenIteration != 0 {
-		t.Errorf("lastSeenIteration = %d, want 0", model.lastSeenIteration)
+	if model.progressState.lastIter != 0 {
+		t.Errorf("lastSeenIteration = %d, want 0", model.progressState.lastIter)
 	}
 }
 
@@ -582,7 +582,7 @@ func TestApplyLanguageChange_EmptyLang(t *testing.T) {
 func TestClosePanelAndResume_NotTyping(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.panelMode = "settings"
+	model.panelState.mode = "settings"
 	model.typing = false
 
 	cont, _, cmd := model.closePanelAndResume()
@@ -593,15 +593,15 @@ func TestClosePanelAndResume_NotTyping(t *testing.T) {
 	if cmd != nil {
 		t.Error("cmd should be nil when not typing")
 	}
-	if model.panelMode != "" {
-		t.Errorf("panelMode = %q, want empty", model.panelMode)
+	if model.panelState.mode != "" {
+		t.Errorf("panelMode = %q, want empty", model.panelState.mode)
 	}
 }
 
 func TestClosePanelAndResume_Typing(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.panelMode = "askuser"
+	model.panelState.mode = "askuser"
 	model.typing = true
 
 	cont, _, cmd := model.closePanelAndResume()
@@ -613,35 +613,35 @@ func TestClosePanelAndResume_Typing(t *testing.T) {
 	if cmd != nil {
 		t.Error("cmd should be nil — tick chain managed by startAgentTurn")
 	}
-	if model.panelMode != "" {
-		t.Errorf("panelMode = %q, want empty", model.panelMode)
+	if model.panelState.mode != "" {
+		t.Errorf("panelMode = %q, want empty", model.panelState.mode)
 	}
 }
 
 func TestClosePanelAndResume_CleansUpPanelState(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.panelMode = "settings"
-	model.panelEdit = true
-	model.panelCombo = true
-	model.panelSchema = []channel.SettingDefinition{{Key: "test"}}
-	model.panelValues = map[string]string{"test": "value"}
+	model.panelState.mode = "settings"
+	model.panelState.editing = true
+	model.panelState.combo = true
+	model.panelState.schema = []channel.SettingDefinition{{Key: "test"}}
+	model.panelState.values = map[string]string{"test": "value"}
 
 	model.closePanelAndResume()
 
-	if model.panelMode != "" {
+	if model.panelState.mode != "" {
 		t.Error("panelMode should be cleared")
 	}
-	if model.panelEdit {
+	if model.panelState.editing {
 		t.Error("panelEdit should be false")
 	}
-	if model.panelCombo {
+	if model.panelState.combo {
 		t.Error("panelCombo should be false")
 	}
-	if model.panelSchema != nil {
+	if model.panelState.schema != nil {
 		t.Error("panelSchema should be nil")
 	}
-	if model.panelValues != nil {
+	if model.panelState.values != nil {
 		t.Error("panelValues should be nil")
 	}
 }
@@ -775,10 +775,10 @@ func TestIterToolsFlat_IterationsWithEmptyTools(t *testing.T) {
 func TestSubmitAskAnswers_CallsCallback(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.panelMode = "askuser"
+	model.panelState.mode = "askuser"
 
 	var received map[string]string
-	model.panelOnAnswer = func(answers map[string]string) {
+	model.panelState.onAnswer = func(answers map[string]string) {
 		received = answers
 	}
 
@@ -791,7 +791,7 @@ func TestSubmitAskAnswers_CallsCallback(t *testing.T) {
 	if cmd != nil {
 		t.Error("cmd should be nil when not typing")
 	}
-	if model.panelMode != "" {
+	if model.panelState.mode != "" {
 		t.Error("panel should be closed")
 	}
 	// received may be empty (no answers) but callback should have been called
@@ -801,7 +801,7 @@ func TestSubmitAskAnswers_CallsCallback(t *testing.T) {
 func TestSubmitAskAnswers_Typing(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.panelMode = "askuser"
+	model.panelState.mode = "askuser"
 	model.typing = true
 
 	cont, _, cmd := model.submitAskAnswers()
@@ -818,8 +818,8 @@ func TestSubmitAskAnswers_Typing(t *testing.T) {
 func TestSubmitAskAnswers_NilCallback(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.panelMode = "askuser"
-	model.panelOnAnswer = nil
+	model.panelState.mode = "askuser"
+	model.panelState.onAnswer = nil
 	model.typing = false
 
 	// Should not panic with nil callback
@@ -836,13 +836,13 @@ func TestSubmitAskAnswers_NilCallback(t *testing.T) {
 func TestSubmitAskAnswers_SavesCurrentFreeInputBeforeCollect(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.panelMode = "askuser"
-	model.panelItems = []askItem{{Question: "q1"}, {Question: "q2", Other: "stale"}}
-	model.panelTab = 1
-	model.panelAnswerTA = model.newPanelTextArea("custom", 50, 3)
+	model.panelState.mode = "askuser"
+	model.panelState.askItems = []askItem{{Question: "q1"}, {Question: "q2", Other: "stale"}}
+	model.panelState.askTab = 1
+	model.panelState.askAnswerTA = model.newPanelTextArea("custom", 50, 3)
 
 	model.saveCurrentFreeInput()
-	if got := model.panelItems[1].Other; got != "custom" {
+	if got := model.panelState.askItems[1].Other; got != "custom" {
 		t.Fatalf("panelItems[1].Other = %q, want custom", got)
 	}
 }
@@ -850,10 +850,10 @@ func TestSubmitAskAnswers_SavesCurrentFreeInputBeforeCollect(t *testing.T) {
 func TestCollectAskAnswers_UncheckedOptionsExcluded(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.panelItems = []askItem{
+	model.panelState.askItems = []askItem{
 		{Question: "color?", Options: []string{"Red", "Blue", "Green"}},
 	}
-	model.panelOptSel = map[int]map[int]bool{
+	model.panelState.askOptSel = map[int]map[int]bool{
 		0: {0: true, 1: false, 2: true},
 	}
 
@@ -867,10 +867,10 @@ func TestCollectAskAnswers_UncheckedOptionsExcluded(t *testing.T) {
 func TestCollectAskAnswers_AllUncheckedReturnsEmpty(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.panelItems = []askItem{
+	model.panelState.askItems = []askItem{
 		{Question: "color?", Options: []string{"Red", "Blue"}},
 	}
-	model.panelOptSel = map[int]map[int]bool{
+	model.panelState.askOptSel = map[int]map[int]bool{
 		0: {0: false, 1: false},
 	}
 
@@ -1179,7 +1179,7 @@ func TestSuHistoryLoad_TypingReconcile_AcceptProgress(t *testing.T) {
 	// Simulate restored session with typing=false (e.g. fresh connect,
 	// or session that was idle when saved).
 	m.typing = false
-	m.suLoading = true
+	m.splashState.suLoading = true
 
 	payload := &protocol.ProgressEvent{
 		ChatID:    "cli:/test",
@@ -1198,11 +1198,11 @@ func TestSuHistoryLoad_TypingReconcile_AcceptProgress(t *testing.T) {
 	if m.typing != true {
 		t.Fatalf("expected typing=true after acceptProgress, got typing=%v", m.typing)
 	}
-	if m.progress == nil {
+	if m.progressState.current == nil {
 		t.Fatal("expected progress to be restored from server snapshot, got nil")
 	}
-	if m.suLoading != false {
-		t.Fatalf("expected suLoading=false after handleSuHistoryLoad, got %v", m.suLoading)
+	if m.splashState.suLoading != false {
+		t.Fatalf("expected suLoading=false after handleSuHistoryLoad, got %v", m.splashState.suLoading)
 	}
 }
 
@@ -1219,7 +1219,7 @@ func TestSuHistoryLoad_TypingReconcile_Default(t *testing.T) {
 	// Simulate restored session with typing=true (old saved state).
 	// Even though the saved state says typing, the server knows better.
 	m.typing = true
-	m.suLoading = true
+	m.splashState.suLoading = true
 
 	msg := suHistoryLoadMsg{
 		channelName:    "cli",
@@ -1233,11 +1233,11 @@ func TestSuHistoryLoad_TypingReconcile_Default(t *testing.T) {
 	if m.typing != false {
 		t.Fatalf("expected typing=false after default (no active turn), got typing=%v", m.typing)
 	}
-	if m.progress != nil {
-		t.Fatalf("expected progress=nil after default (no active turn), got %v", m.progress)
+	if m.progressState.current != nil {
+		t.Fatalf("expected progress=nil after default (no active turn), got %v", m.progressState.current)
 	}
-	if m.suLoading != false {
-		t.Fatalf("expected suLoading=false, got %v", m.suLoading)
+	if m.splashState.suLoading != false {
+		t.Fatalf("expected suLoading=false, got %v", m.splashState.suLoading)
 	}
 }
 
@@ -1255,7 +1255,7 @@ func TestSuHistoryLoad_TypingReconcile_Error(t *testing.T) {
 	// Simulate restored session with typing=true (saved state).
 	// RPC fails — we cannot know the real state.
 	m.typing = true
-	m.suLoading = true
+	m.splashState.suLoading = true
 
 	msg := suHistoryLoadMsg{
 		channelName: "cli",
@@ -1268,11 +1268,11 @@ func TestSuHistoryLoad_TypingReconcile_Error(t *testing.T) {
 	if m.typing != false {
 		t.Fatalf("expected typing=false after RPC error (safe fallback), got typing=%v", m.typing)
 	}
-	if m.progress != nil {
-		t.Fatalf("expected progress=nil after RPC error, got %v", m.progress)
+	if m.progressState.current != nil {
+		t.Fatalf("expected progress=nil after RPC error, got %v", m.progressState.current)
 	}
-	if m.suLoading != false {
-		t.Fatalf("expected suLoading=false, got %v", m.suLoading)
+	if m.splashState.suLoading != false {
+		t.Fatalf("expected suLoading=false, got %v", m.splashState.suLoading)
 	}
 }
 
@@ -1288,7 +1288,7 @@ func TestSuHistoryLoad_StaleGuardDoesNotTouchState(t *testing.T) {
 	setupTestRemoteChannel(m)
 
 	m.typing = true
-	m.suLoading = true
+	m.splashState.suLoading = true
 
 	// Stale message: channelName/chatID doesn't match current session.
 	msg := suHistoryLoadMsg{
@@ -1303,8 +1303,8 @@ func TestSuHistoryLoad_StaleGuardDoesNotTouchState(t *testing.T) {
 	if m.typing != true {
 		t.Fatalf("stale msg should NOT change typing, got typing=%v", m.typing)
 	}
-	if m.suLoading != true {
-		t.Fatalf("stale msg should NOT clear suLoading, got %v", m.suLoading)
+	if m.splashState.suLoading != true {
+		t.Fatalf("stale msg should NOT clear suLoading, got %v", m.splashState.suLoading)
 	}
 }
 
@@ -1319,7 +1319,7 @@ func TestSuHistoryLoad_TypingReconcile_PhaseDoneIsDefault(t *testing.T) {
 	setupTestRemoteChannel(m)
 
 	m.typing = true // restored hint says typing
-	m.suLoading = true
+	m.splashState.suLoading = true
 
 	payload := &protocol.ProgressEvent{
 		ChatID:    "cli:/test",

--- a/channel/cli/cli_inbound.go
+++ b/channel/cli/cli_inbound.go
@@ -148,8 +148,8 @@ func (m *cliModel) sendMessage(content string) tea.Cmd {
 	// Background history loads are stale once the user initiates a new turn.
 	// If we don't clear suLoading, handleProgressMsg drops ALL progress events
 	// (line 391) and the session never enters typing state.
-	m.suLoading = false
-	m.suPhaseDoneConfirmed = false
+	m.splashState.suLoading = false
+	m.splashState.suPhaseConfirmed = false
 
 	// Save as pending user message so it survives session switches before
 	// the agent's eager-save to DB completes. Restored in handleSuHistoryLoad.

--- a/channel/cli/cli_model.go
+++ b/channel/cli/cli_model.go
@@ -132,22 +132,6 @@ type cliModel struct {
 	deleteWebUserFn func(username string) error
 	isAdminFn       func() bool
 
-	// --- Progress ---
-	progress               *protocol.ProgressEvent
-	iterationHistory       []cliIterationSnapshot       // 已完成迭代快照
-	lastSeenIteration      int                          // 上次进度事件的迭代号
-	lastProgressSeq        uint64                       // 上次进度事件的序列号（单调递增校验）
-	iterationStartTime     time.Time                    // current iteration wall-clock start time
-	sidebarHasBusySessions bool                         // true when any non-active sidebar session is busy (needs spinner tick)
-	unreadSessions         map[string]bool              // chatID → has unread results the user hasn't viewed yet
-	lastBusyStates         map[string]bool              // previous busy state per session, for detecting busy→idle transition
-	liveSessionStates      map[string]*liveSessionState // server-pushed session state overrides
-	typewriterTickActive   bool                         // true when typewriter tick chain (50ms) is running
-	twVisible              int                          // typewriter: runes currently visible in stream content
-	rwVisible              int                          // typewriter: runes currently visible in reasoning stream content
-	rwCjkSkipTick          bool                         // alternates each tick to halve CJK speed (reasoning)
-	twCjkSkipTick          bool                         // alternates each tick to halve CJK speed (stream)
-
 	// --- Session ---
 	workDir                string    // 工作目录（标题栏显示用）
 	remoteMode             bool      // 是否连接 remote backend（标题栏提示用）
@@ -170,7 +154,7 @@ type cliModel struct {
 	rc renderCache
 
 	// --- §2 工具可视化 ---
-	lastCompletedTools []protocol.ToolProgress // 每轮结束时快照，不依赖 m.progress 生命周期
+	lastCompletedTools []protocol.ToolProgress // 每轮结束时快照，不依赖 m.progressState.current 生命周期
 	lastReasoning      string                  // 最后一次迭代的 reasoning_content，在 progress 清除前捕获
 	reasoningByIter    map[int]string          // per-iteration reasoning，snapshot 时用于精确查找
 	lastThinking       string                  // 最后一次迭代的 thinking_content，在 progress 清除前捕获
@@ -208,87 +192,10 @@ type cliModel struct {
 	// here so handleAgentMessage can insert it at the correct position.
 	pendingToolSummary *cliMessage
 
-	// --- §12 Interactive Panel ---
-	// panelMode: ""=normal, "settings"=settings panel, "askuser"=ask user panel, "wizard"=setup wizard
-	panelMode      string
-	settingsSaving bool              // true while onSubmit is running in background; blocks user input
-	panelStack     []panelStackEntry // push/pop navigation stack for nested panels
-	panelCursor    int               // settings panel: selected item index
-	panelEdit      bool              // settings panel: editing current item
-	panelScrollY   int               // panel 滚动偏移（手动管理，不依赖 viewport）
-	panelEditTA    textarea.Model    // settings panel: inline editor
-	panelCombo     bool              // settings panel: combo dropdown open
-	panelComboIdx  int               // settings panel: combo selected option index
-	// --- Wizard state (step-by-step setup) ---
-	wizardStep    int // 0=language, 1=provider, 2=apikey, 3=done
-	wizardLangSel int // selected language index
-	wizardProvSel int // selected provider index
-	// --- Panel state backup (for quick switch round-trip) ---
-	panelValuesBackup   map[string]string              // saved panelValues before quick switch
-	panelCursorBackup   int                            // saved panelCursor before quick switch
-	panelOnSubmitBackup func(values map[string]string) // saved onSubmit callback
-	// --- AskUser panel ---
-	panelItems         []askItem              // askuser panel: question items
-	panelTab           int                    // askuser panel: current tab (question index)
-	panelOptSel        map[int]map[int]bool   // askuser panel: selected option indices per question
-	panelOptCursor     map[int]int            // askuser panel: highlighted option index per question
-	panelAnswerTA      textarea.Model         // askuser panel: free-input editor (no-options mode)
-	panelOtherTI       textinput.Model        // askuser panel: single-line Other input
-	wizardKeyTI        textinput.Model        // wizard: API key single-line input
-	askPanelScrollY    int                    // askuser panel: internal scroll offset for long content
-	askPanelTotalLines int                    // cached total line count for scroll clamping
-	panelSchema        []ch.SettingDefinition // settings panel: visible schema (filtered from panelSchemaFull)
-	panelSchemaFull    []ch.SettingDefinition // settings panel: full schema (before DependsOn filtering)
-	panelIsSetup       bool                   // true when panel was opened via /setup or first-run
-	// --- Approval panel ---
-	approvalRequest      *protocol.ApprovalRequest // pending approval request
-	approvalResultCh     chan<- protocol.ApprovalResult
-	approvalCursor       int                             // 0=approve, 1=deny
-	approvalDenyInput    textinput.Model                 // deny reason input
-	approvalEnteringDeny bool                            // true when editing deny reason
-	panelValues          map[string]string               // settings panel: current values
-	panelPrevProvider    string                          // previous llm_provider value for base_url auto-fill
-	panelOnSubmit        func(values map[string]string)  // callback on settings submit
-	panelOnAnswer        func(answers map[string]string) // callback on askuser answers (key=index, value=answer)
-	panelOnCancel        func()                          // callback on cancel
-
-	// --- Bg Tasks Panel ---
-	panelBgTasks   []*BgTask         // cached task list
-	panelBgAgents  []panelAgentEntry // cached agent list
-	panelBgCursor  int               // selected item index (tasks first, then agents)
-	panelBgViewing bool              // true = viewing log of selected task
-
-	panelBgLogLines  []string // cached log lines for viewing
-	panelBgLogFollow bool     // auto-scroll to bottom on new output (follow-tail)
-
-	// --- Sessions Panel ---
-	panelSessionItems         []SessionPanelEntry // cached session list
-	panelSessionCursor        int                 // selected item index
-	panelSessionViewing       bool                // true = viewing session messages
-	panelSessionConfirmDelete bool                // true = showing delete confirmation
-	panelSessionConfirmEntry  SessionPanelEntry   // entry pending deletion
-
-	// --- Danger Zone Panel ---
-	panelDangerItems   []dangerItem
-	panelDangerCursor  int
-	panelDangerConfirm bool // true = showing confirm input
-	panelDangerInput   textinput.Model
-	panelDangerOnExec  func(targetType string) error // callback to execute clear
-
 	// --- §13 Update Check ---
 
-	// --- Runner Panel ---
-	panelRunnerServerTI  textinput.Model     // server URL 输入
-	panelRunnerTokenTI   textinput.Model     // token 输入
-	panelRunnerWorkspace textinput.Model     // workspace 输入
-	panelRunnerEditField int                 // 当前编辑字段 (0=server, 1=token, 2=workspace)
-	updateNotice         *version.UpdateInfo // nil=nothing, non-nil=show notice
-	checkingUpdate       bool                // true while /update is in progress
-
-	// --- ch.Channel Config Panel ---
-	panelChannelItems  []string                     // channel names: ["web", "feishu", "qq", "napcat"]
-	panelChannelCursor int                          // selected channel index
-	panelChannelCfg    map[string]map[string]string // cached channel configs
+	updateNotice   *version.UpdateInfo // nil=nothing, non-nil=show notice
+	checkingUpdate bool                // true while /update is in progress
 
 	// --- §15 ch.Subscription / Model Quick Switch ---
 	quickSwitchMode          string              // ""=off, "subscription"=selecting subscription, "model"=selecting model
@@ -313,19 +220,7 @@ type cliModel struct {
 	// panelSubGeneration captures the generation when the settings panel opens.
 	// ApplySettings REFUSES to write per-subscription LLM fields if generations don't match.
 	// This is the structural guarantee against stale LLM values overwriting a new subscription.
-	subGeneration      int
-	panelSubGeneration int
-
-	// --- §14 Splash 画面 ---
-	splashDone           bool // true = splash 动画结束，进入正常界面
-	splashFrame          int  // 当前 splash 动画帧索引
-	suLoading            bool // true = /su 切换用户后正在加载历史，显示 loading 画面
-	suPhaseDoneConfirmed bool // true = PhaseDone received during suLoading (server confirmed idle)
-	compressionReloading bool // true = HistoryCompacted 异步 reload 进行中，阻止 auto-start
-
-	// --- §16 Toast 通知队列 ---
-	toasts     []cliToastItem // Toast 队列（头部=当前显示）
-	toastTimer bool           // true = toast 消除计时器已启动
+	subGeneration int
 
 	// --- §19 长消息折叠 ---
 	msgLineOffsets []int // 每条消息在 viewport 折行后 content 中的起始行号
@@ -345,48 +240,22 @@ type cliModel struct {
 	// Keyed by agentTurnID. Entries for old turns are cleaned up in startAgentTurn.
 	turnDoneFlags map[uint64]*turnDoneFlag
 
-	// --- §21 消息搜索 /search ---
-	searchMode    bool            // 是否处于搜索模式
-	searchQuery   string          // 搜索关键词
-	searchResults []int           // 匹配的消息索引列表
-	searchIdx     int             // 当前导航到的搜索结果索引（-1 = 未选择）
-	searchEditing bool            // true = 编辑搜索词, false = 导航结果
-	searchTI      textinput.Model // 搜索输入框
-
 	// --- Mouse support ---
 	mouseZones mouseZoneBuilder // zone tracker for mouse hit testing (rebuilt each View())
 
-	// --- Layout configuration ---
-	chatMaxWidth             int             // max content width (0 = unlimited)
-	chatCenter               bool            // center content in middle-width screens
-	layoutMode               string          // "auto" / "single" / "dual"
-	sidebarEnabled           bool            // show sidebar in wide screens
-	sidebarWidth             int             // sidebar width in chars
-	sidebarPosition          string          // "left" / "right"
-	sidebarVisible           bool            // runtime: is sidebar currently shown (user toggled with Ctrl+B)?
-	sidebarCollapsedSections map[string]bool // per-section collapse state: "sessions"/"todo"/"tasks" → true=collapsed
-	xShift                   int             // sidebar X offset for middleBlock, set during trackMainLayoutZones
+	easterEggState easterEggState
 
-	// Cached layout metrics (invalidated on resize / sidebar toggle).
-	// Eliminates repeated lipgloss.Render + ansi.StringWidth per chatWidth() call.
-	cachedSidebarRenderedWidth int // measured visual width of sidebar (0 = not yet computed)
-	cachedSidebarWidthKey      int // sidebarWidth at time of measurement (for invalidation)
-	cachedChatWidth            int // effective chat width (0 = not yet computed)
-	cachedChatWidthKey         int // m.width at time of measurement (for invalidation)
+	searchState searchState
 
-	// toolDisplayInfo
+	toastState toastState
 
-	// --- 🥚 Easter Eggs 彩蛋 ---
-	easterEgg       easterEggMode // 当前激活的彩蛋类型（"" = 无）
-	easterEggCustom string        // 彩蛋自定义内容（版本成就 art 等）
-	konamiBuffer    []string      // Konami Code 按键缓冲区
-	matrixCols      int           // Matrix 代码雨列数
-	matrixRows      int           // Matrix 代码雨行数
-	matrixDrops     []int         // Matrix 每列头部位置
-	matrixSpeeds    []int         // Matrix 每列下落速度
-	matrixTrailLen  []int         // Matrix 每列拖尾长度
-	matrixBuffer    [][]rune      // Matrix 字符缓冲区
-	versionHitTimes []time.Time   // /version 命令调用时间戳（三连检测）
+	splashState splashState
+
+	panelState panelState
+
+	layoutConfig layoutConfig
+
+	progressState progressState
 
 	channel             *CLIChannel     // back-reference to owning channel (set during Start)
 	cachedModelName     string          // cached model name for View() performance
@@ -519,7 +388,6 @@ func newCLIModel() *cliModel {
 		ready:           false,
 		typing:          false,
 		streamingMsgIdx: -1,
-		progress:        nil,
 		inputReady:      true,
 		locale:          ch.GetLocale(""),
 		inputHistory:    make([]string, 0, 100),
@@ -529,17 +397,21 @@ func newCLIModel() *cliModel {
 		channelName:     "cli",
 		expandedTools:   make(map[string]bool),
 		// Layout defaults
-		chatMaxWidth:             76,
-		chatCenter:               true,
-		layoutMode:               "auto",
-		sidebarEnabled:           true,
-		sidebarVisible:           true,
-		sidebarWidth:             30,
-		sidebarPosition:          "left",
-		sidebarCollapsedSections: make(map[string]bool),
-		unreadSessions:           make(map[string]bool),
-		lastBusyStates:           make(map[string]bool),
-		liveSessionStates:        make(map[string]*liveSessionState),
+		layoutConfig: layoutConfig{
+			maxWidth:       76,
+			center:         true,
+			mode:           "auto",
+			sidebarEnabled: true,
+			sidebarVisible: true,
+			sidebarWidth:   30,
+			sidebarPos:     "left",
+			collapsedSects: make(map[string]bool),
+		},
+		progressState: progressState{
+			unread:     make(map[string]bool),
+			busyStates: make(map[string]bool),
+			liveStates: make(map[string]*liveSessionState),
+		},
 	}
 }
 
@@ -794,13 +666,13 @@ func (m *cliModel) suLoadHistoryCmd() tea.Cmd {
 }
 
 func (m *cliModel) toggleSidebarSection(section string) {
-	if m.sidebarCollapsedSections == nil {
-		m.sidebarCollapsedSections = make(map[string]bool)
+	if m.layoutConfig.collapsedSects == nil {
+		m.layoutConfig.collapsedSects = make(map[string]bool)
 	}
-	if m.sidebarCollapsedSections[section] {
-		delete(m.sidebarCollapsedSections, section)
+	if m.layoutConfig.collapsedSects[section] {
+		delete(m.layoutConfig.collapsedSects, section)
 	} else {
-		m.sidebarCollapsedSections[section] = true
+		m.layoutConfig.collapsedSects[section] = true
 	}
 	m.saveSidebarCollapsedPrefs()
 }
@@ -811,6 +683,145 @@ func (m *cliModel) saveSidebarCollapsedPrefs() {
 		return
 	}
 	prefs := tools.LoadPreferences(m.workDir, m.senderID)
-	prefs.SidebarCollapsed = m.sidebarCollapsedSections
+	prefs.SidebarCollapsed = m.layoutConfig.collapsedSects
 	_ = tools.SavePreferences(m.workDir, m.senderID, prefs)
+}
+
+// easterEggState groups 10 fields for easteregg.
+type easterEggState struct {
+	mode           easterEggMode
+	customArt      string
+	konamiBuf      []string
+	matrixCols     int
+	matrixRows     int
+	matrixDrops    []int
+	matrixSpeeds   []int
+	matrixTrailLen []int
+	matrixBuf      [][]rune
+	versionHits    []time.Time
+}
+
+// searchState groups related fields extracted from cliModel.
+type searchState struct {
+	mode    bool
+	query   string
+	results []int
+	idx     int
+	editing bool
+	ti      textinput.Model
+}
+
+// toastState groups related fields extracted from cliModel.
+type toastState struct {
+	queue       []cliToastItem
+	timerActive bool
+}
+
+// splashState groups related fields extracted from cliModel.
+type splashState struct {
+	done             bool
+	frame            int
+	suLoading        bool
+	suPhaseConfirmed bool
+	compReloading    bool
+}
+
+// panelState groups 61 panel-related fields extracted from cliModel.
+type panelState struct {
+	mode              string
+	settingsSaving    bool
+	stack             []panelStackEntry
+	cursor            int
+	editing           bool
+	scrollY           int
+	editTA            textarea.Model
+	combo             bool
+	comboIdx          int
+	wizardStep        int
+	wizardLangSel     int
+	wizardProvSel     int
+	wizardKeyTI       textinput.Model
+	valuesBackup      map[string]string
+	cursorBackup      int
+	onSubmitBackup    func(values map[string]string)
+	askItems          []askItem
+	askTab            int
+	askOptSel         map[int]map[int]bool
+	askOptCursor      map[int]int
+	askAnswerTA       textarea.Model
+	askOtherTI        textinput.Model
+	askScrollY        int
+	askTotalLines     int
+	schema            []ch.SettingDefinition
+	schemaFull        []ch.SettingDefinition
+	isSetup           bool
+	approvalReq       *protocol.ApprovalRequest
+	approvalCh        chan<- protocol.ApprovalResult
+	approvalCursor    int
+	approvalDenyTA    textinput.Model
+	approvalDenyMode  bool
+	values            map[string]string
+	prevProvider      string
+	onSubmit          func(values map[string]string)
+	onAnswer          func(answers map[string]string)
+	onCancel          func()
+	bgTasks           []*BgTask
+	bgAgents          []panelAgentEntry
+	bgCursor          int
+	bgViewing         bool
+	bgLogLines        []string
+	bgLogFollow       bool
+	sessItems         []SessionPanelEntry
+	sessCursor        int
+	sessViewing       bool
+	sessConfirmDelete bool
+	sessConfirmEntry  SessionPanelEntry
+	dangerItems       []dangerItem
+	dangerCursor      int
+	dangerConfirm     bool
+	dangerInput       textinput.Model
+	dangerOnExec      func(targetType string) error
+	runnerServerTI    textinput.Model
+	runnerTokenTI     textinput.Model
+	runnerWS          textinput.Model
+	runnerEditField   int
+	channelItems      []string
+	channelCursor     int
+	channelCfg        map[string]map[string]string
+	subGeneration     int
+}
+
+// layoutConfig groups 13 fields extracted from cliModel.
+type layoutConfig struct {
+	maxWidth       int
+	center         bool
+	mode           string
+	sidebarEnabled bool
+	sidebarWidth   int
+	sidebarPos     string
+	sidebarVisible bool
+	collapsedSects map[string]bool
+	xShift         int
+	cachedSBWidth  int
+	cachedSBKey    int
+	cachedChatW    int
+	cachedChatKey  int
+}
+
+// progressState groups 14 fields extracted from cliModel.
+type progressState struct {
+	current      *protocol.ProgressEvent
+	iterations   []cliIterationSnapshot
+	lastIter     int
+	lastSeq      uint64
+	iterStart    time.Time
+	busySessions bool
+	unread       map[string]bool
+	busyStates   map[string]bool
+	liveStates   map[string]*liveSessionState
+	twActive     bool
+	twVisible    int
+	rwVisible    int
+	rwCjkSkip    bool
+	twCjkSkip    bool
 }

--- a/channel/cli/cli_model_session.go
+++ b/channel/cli/cli_model_session.go
@@ -109,22 +109,22 @@ func (m *cliModel) saveCurrentSession() {
 		m.turnDoneFlags = make(map[uint64]*turnDoneFlag)
 	}
 	m.savedSessions[key] = &sessionState{
-		progress:               m.progress,
+		progress:               m.progressState.current,
 		typing:                 m.typing,
 		agentTurnID:            m.agentTurnID,
 		inputReady:             m.inputReady,
 		needFlushQueue:         m.needFlushQueue,
-		lastProgressSeq:        m.lastProgressSeq,
-		twVisible:              m.twVisible,
-		rwVisible:              m.rwVisible,
-		iterationHistory:       m.iterationHistory,
-		lastSeenIteration:      m.lastSeenIteration,
+		lastProgressSeq:        m.progressState.lastSeq,
+		twVisible:              m.progressState.twVisible,
+		rwVisible:              m.progressState.rwVisible,
+		iterationHistory:       m.progressState.iterations,
+		lastSeenIteration:      m.progressState.lastIter,
 		streamingMsgIdx:        m.streamingMsgIdx,
 		typingStartTime:        m.typingStartTime,
 		lastReasoning:          m.lastReasoning,
 		lastThinking:           m.lastThinking,
 		turnCancelled:          m.turnCancelled,
-		typewriterTickActive:   m.typewriterTickActive,
+		typewriterTickActive:   m.progressState.twActive,
 		reasoningByIter:        m.reasoningByIter,
 		lastTokenUsage:         m.lastTokenUsage,
 		cachedMaxContextTokens: m.cachedMaxContextTokens,
@@ -154,22 +154,22 @@ func (m *cliModel) saveCurrentSession() {
 func (m *cliModel) restoreSession() {
 	key := m.sessionKey()
 	if saved, ok := m.savedSessions[key]; ok {
-		m.progress = saved.progress
+		m.progressState.current = saved.progress
 		m.typing = saved.typing
 		m.agentTurnID = saved.agentTurnID
 		m.inputReady = saved.inputReady
 		m.needFlushQueue = saved.needFlushQueue
-		m.lastProgressSeq = saved.lastProgressSeq
-		m.twVisible = saved.twVisible
-		m.rwVisible = saved.rwVisible
-		m.iterationHistory = saved.iterationHistory
-		m.lastSeenIteration = saved.lastSeenIteration
+		m.progressState.lastSeq = saved.lastProgressSeq
+		m.progressState.twVisible = saved.twVisible
+		m.progressState.rwVisible = saved.rwVisible
+		m.progressState.iterations = saved.iterationHistory
+		m.progressState.lastIter = saved.lastSeenIteration
 		m.streamingMsgIdx = saved.streamingMsgIdx
 		m.typingStartTime = saved.typingStartTime
 		m.lastReasoning = saved.lastReasoning
 		m.lastThinking = saved.lastThinking
 		m.turnCancelled = saved.turnCancelled
-		m.typewriterTickActive = saved.typewriterTickActive
+		m.progressState.twActive = saved.typewriterTickActive
 		m.reasoningByIter = saved.reasoningByIter
 		m.lastTokenUsage = saved.lastTokenUsage
 		m.cachedMaxContextTokens = saved.cachedMaxContextTokens
@@ -210,12 +210,12 @@ func (m *cliModel) restoreSession() {
 		delete(m.savedSessions, key) // clean up
 	} else {
 		// No saved state — reset to idle (NOT cancelled)
-		m.progress = nil
+		m.progressState.current = nil
 		m.typing = false
 		m.streamingMsgIdx = -1
-		m.iterationHistory = nil
+		m.progressState.iterations = nil
 		m.rc.invalidateProgress()
-		m.lastSeenIteration = 0
+		m.progressState.lastIter = 0
 		m.typingStartTime = time.Time{}
 		m.lastReasoning = ""
 		m.reasoningByIter = nil
@@ -225,10 +225,10 @@ func (m *cliModel) restoreSession() {
 		m.needFlushQueue = false
 		m.messageQueue = nil
 		m.queueEditing = false
-		m.lastProgressSeq = 0
-		m.twVisible = 0
-		m.rwVisible = 0
-		m.typewriterTickActive = false
+		m.progressState.lastSeq = 0
+		m.progressState.twVisible = 0
+		m.progressState.rwVisible = 0
+		m.progressState.twActive = false
 		m.pendingUserMsg = nil
 		m.agentTurnID = 0       // prevent stale turnDoneFlags match
 		m.textarea.SetValue("") // clear input for new/unsaved session
@@ -307,11 +307,11 @@ func (m *cliModel) resetToIdleState() {
 	m.pendingToolSummary = nil
 
 	// --- Progress State ---
-	m.progress = nil
-	m.iterationHistory = nil
-	m.lastSeenIteration = 0
-	m.lastProgressSeq = 0
-	m.iterationStartTime = time.Time{}
+	m.progressState.current = nil
+	m.progressState.iterations = nil
+	m.progressState.lastIter = 0
+	m.progressState.lastSeq = 0
+	m.progressState.iterStart = time.Time{}
 
 	// --- TODO State ---
 	m.todos = nil
@@ -336,59 +336,59 @@ func (m *cliModel) resetToIdleState() {
 	m.checkpointState = nil
 
 	// --- Panel State ---
-	m.panelMode = ""
-	m.settingsSaving = false
-	m.panelStack = nil
-	m.panelCursor = 0
-	m.panelEdit = false
-	m.panelScrollY = 0
-	m.panelEditTA = textarea.Model{}
-	m.panelCombo = false
-	m.panelComboIdx = 0
-	m.panelItems = nil
-	m.panelTab = 0
-	m.panelOptSel = make(map[int]map[int]bool)
-	m.panelOptCursor = make(map[int]int)
-	m.panelAnswerTA = textarea.Model{}
-	m.panelOtherTI = textinput.Model{}
-	m.askPanelScrollY = 0
-	m.askPanelTotalLines = 0
-	m.panelSchema = nil
-	m.approvalRequest = nil
-	m.approvalResultCh = nil
-	m.approvalCursor = 0
-	m.approvalDenyInput = textinput.Model{}
-	m.approvalEnteringDeny = false
-	m.panelValues = make(map[string]string)
-	m.panelPrevProvider = ""
-	m.panelOnSubmit = nil
-	m.panelOnAnswer = nil
-	m.panelOnCancel = nil
-	m.panelBgTasks = nil
-	m.panelBgAgents = nil
-	m.panelBgCursor = 0
-	m.panelBgViewing = false
-	m.panelBgLogLines = nil
-	m.panelBgLogFollow = false
-	m.panelSessionItems = nil
-	m.panelSessionCursor = 0
-	m.panelSessionViewing = false
-	m.panelSessionConfirmDelete = false
-	m.panelSessionConfirmEntry = SessionPanelEntry{}
-	m.panelDangerItems = nil
-	m.panelDangerCursor = 0
-	m.panelDangerConfirm = false
-	m.panelDangerInput = textinput.Model{}
-	m.panelDangerOnExec = nil
-	m.panelRunnerServerTI = textinput.Model{}
-	m.panelRunnerTokenTI = textinput.Model{}
-	m.panelRunnerWorkspace = textinput.Model{}
-	m.panelRunnerEditField = 0
+	m.panelState.mode = ""
+	m.panelState.settingsSaving = false
+	m.panelState.stack = nil
+	m.panelState.cursor = 0
+	m.panelState.editing = false
+	m.panelState.scrollY = 0
+	m.panelState.editTA = textarea.Model{}
+	m.panelState.combo = false
+	m.panelState.comboIdx = 0
+	m.panelState.askItems = nil
+	m.panelState.askTab = 0
+	m.panelState.askOptSel = make(map[int]map[int]bool)
+	m.panelState.askOptCursor = make(map[int]int)
+	m.panelState.askAnswerTA = textarea.Model{}
+	m.panelState.askOtherTI = textinput.Model{}
+	m.panelState.askScrollY = 0
+	m.panelState.askTotalLines = 0
+	m.panelState.schema = nil
+	m.panelState.approvalReq = nil
+	m.panelState.approvalCh = nil
+	m.panelState.approvalCursor = 0
+	m.panelState.approvalDenyTA = textinput.Model{}
+	m.panelState.approvalDenyMode = false
+	m.panelState.values = make(map[string]string)
+	m.panelState.prevProvider = ""
+	m.panelState.onSubmit = nil
+	m.panelState.onAnswer = nil
+	m.panelState.onCancel = nil
+	m.panelState.bgTasks = nil
+	m.panelState.bgAgents = nil
+	m.panelState.bgCursor = 0
+	m.panelState.bgViewing = false
+	m.panelState.bgLogLines = nil
+	m.panelState.bgLogFollow = false
+	m.panelState.sessItems = nil
+	m.panelState.sessCursor = 0
+	m.panelState.sessViewing = false
+	m.panelState.sessConfirmDelete = false
+	m.panelState.sessConfirmEntry = SessionPanelEntry{}
+	m.panelState.dangerItems = nil
+	m.panelState.dangerCursor = 0
+	m.panelState.dangerConfirm = false
+	m.panelState.dangerInput = textinput.Model{}
+	m.panelState.dangerOnExec = nil
+	m.panelState.runnerServerTI = textinput.Model{}
+	m.panelState.runnerTokenTI = textinput.Model{}
+	m.panelState.runnerWS = textinput.Model{}
+	m.panelState.runnerEditField = 0
 	m.updateNotice = nil
 	m.checkingUpdate = false
-	m.panelChannelItems = nil
-	m.panelChannelCursor = 0
-	m.panelChannelCfg = make(map[string]map[string]string)
+	m.panelState.channelItems = nil
+	m.panelState.channelCursor = 0
+	m.panelState.channelCfg = make(map[string]map[string]string)
 
 	// --- Quick Switch State ---
 	m.quickSwitchMode = ""
@@ -407,11 +407,11 @@ func (m *cliModel) resetToIdleState() {
 	m.paletteContributor = nil
 
 	// --- Typewriter State ---
-	m.typewriterTickActive = false
-	m.twVisible = 0
-	m.rwVisible = 0
-	m.rwCjkSkipTick = false
-	m.twCjkSkipTick = false
+	m.progressState.twActive = false
+	m.progressState.twVisible = 0
+	m.progressState.rwVisible = 0
+	m.progressState.rwCjkSkip = false
+	m.progressState.twCjkSkip = false
 
 	// --- Other State ---
 	m.inputHistory = nil
@@ -460,7 +460,7 @@ func (m *cliModel) postRestoreSessionSetup() []tea.Cmd {
 	//   it permanently blocks auto-start in the new session (Bug: stale flag leak).
 	// turnDoneFlags: per-turn reply/done tracking from the old session is meaningless
 	//   in the new session and can cause premature queue flush (Bug: stale flags).
-	m.compressionReloading = false
+	m.splashState.compReloading = false
 	m.turnDoneFlags = make(map[uint64]*turnDoneFlag)
 
 	// ── Session LLM state restoration ──────────────────────────
@@ -538,16 +538,16 @@ func (m *cliModel) postRestoreSessionSetup() []tea.Cmd {
 	if isRemote {
 		// Remote mode: discard all stale client-side turn state.
 		// The server RPC (handleSuHistoryLoad) is the single source of truth.
-		m.progress = nil
+		m.progressState.current = nil
 		m.typing = false
 		m.needFlushQueue = false
 		m.turnCancelled = false
-		m.typewriterTickActive = false
-		m.lastProgressSeq = 0
-		m.suPhaseDoneConfirmed = false
+		m.progressState.twActive = false
+		m.progressState.lastSeq = 0
+		m.splashState.suPhaseConfirmed = false
 		m.inputReady = false // stays false until handleSuHistoryLoad completes
-		m.suLoading = true
-		m.splashFrame = 0
+		m.splashState.suLoading = true
+		m.splashState.frame = 0
 
 		// Subscribe to the new session's chatID on the Hub.
 		if m.channel.config.BindChatFn != nil {
@@ -565,12 +565,12 @@ func (m *cliModel) postRestoreSessionSetup() []tea.Cmd {
 		// Agent sessions also need suLoadHistoryCmd (uses AgentSessionDumpFn
 		// for in-memory agent state, not DB RPC) to load progress + history.
 		if m.channelName == "agent" {
-			m.progress = nil
+			m.progressState.current = nil
 			m.typing = false
-			m.lastProgressSeq = 0
-			m.suPhaseDoneConfirmed = false
+			m.progressState.lastSeq = 0
+			m.splashState.suPhaseConfirmed = false
 			m.inputReady = false
-			m.suLoading = true
+			m.splashState.suLoading = true
 			cmds = append(cmds, m.suLoadHistoryCmd())
 		} else {
 			m.inputReady = true
@@ -593,11 +593,11 @@ func (m *cliModel) checkAndRestorePendingAskUser() tea.Cmd {
 		return nil
 	}
 	// Don't restore if already in an AskUser panel for this session.
-	if m.panelMode == "askuser" && m.askUserSession == m.chatID {
+	if m.panelState.mode == "askuser" && m.askUserSession == m.chatID {
 		return nil
 	}
 	// Don't restore if currently in another panel mode.
-	if m.panelMode != "" && m.panelMode != "askuser" {
+	if m.panelState.mode != "" && m.panelState.mode != "askuser" {
 		return nil
 	}
 

--- a/channel/cli/cli_mouse.go
+++ b/channel/cli/cli_mouse.go
@@ -266,13 +266,13 @@ func (m *cliModel) clickFooterHint(index int) (bool, tea.Model, tea.Cmd) {
 			m.quickSwitchMode = ""
 		} else if m.rewindMode {
 			m.rewindMode = false
-		} else if m.panelMode != "" {
+		} else if m.panelState.mode != "" {
 			m.closePanel()
 		}
 		return true, m, nil
 	case "enter":
-		if m.panelMode != "" {
-			return m.clickPanelItem(m.panelCursor)
+		if m.panelState.mode != "" {
+			return m.clickPanelItem(m.panelState.cursor)
 		}
 		return true, m, nil
 	case "tab":
@@ -303,14 +303,14 @@ func (m *cliModel) handleMouseWheel(msg tea.MouseWheelMsg) (bool, tea.Model, tea
 	case tea.MouseWheelUp:
 		// AskUser split layout: wheel always scrolls the askuser panel.
 		// The user controls the main viewport via Shift+↑/↓.
-		if m.panelMode == "askuser" {
-			m.askPanelScrollY = max(0, m.askPanelScrollY-3)
+		if m.panelState.mode == "askuser" {
+			m.panelState.askScrollY = max(0, m.panelState.askScrollY-3)
 			return true, m, nil
 		}
 		// Check if wheel is in panel area (non-askuser panels)
-		if m.panelMode != "" {
+		if m.panelState.mode != "" {
 			if m.isYInPanelBox(msg.Y) {
-				m.panelScrollY = max(0, m.panelScrollY-3)
+				m.panelState.scrollY = max(0, m.panelState.scrollY-3)
 				return true, m, nil
 			}
 		}
@@ -337,14 +337,14 @@ func (m *cliModel) handleMouseWheel(msg tea.MouseWheelMsg) (bool, tea.Model, tea
 	case tea.MouseWheelDown:
 		// AskUser split layout: wheel always scrolls the askuser panel.
 		// The user controls the main viewport via Shift+↑/↓.
-		if m.panelMode == "askuser" {
-			m.askPanelScrollY += 3
+		if m.panelState.mode == "askuser" {
+			m.panelState.askScrollY += 3
 			return true, m, nil
 		}
 		// Check if wheel is in panel area (non-askuser panels)
-		if m.panelMode != "" {
+		if m.panelState.mode != "" {
 			if m.isYInPanelBox(msg.Y) {
-				m.panelScrollY += 3
+				m.panelState.scrollY += 3
 				return true, m, nil
 			}
 		}
@@ -374,12 +374,12 @@ func (m *cliModel) handleMouseWheel(msg tea.MouseWheelMsg) (bool, tea.Model, tea
 
 // commitPanelEdit saves the current edit value back to panelValues.
 func (m *cliModel) commitPanelEdit() {
-	if !m.panelEdit || m.panelCursor >= len(m.panelSchema) {
+	if !m.panelState.editing || m.panelState.cursor >= len(m.panelState.schema) {
 		return
 	}
-	def := m.panelSchema[m.panelCursor]
+	def := m.panelState.schema[m.panelState.cursor]
 	if !def.ReadOnly {
-		m.panelValues[def.Key] = strings.TrimSpace(m.panelEditTA.Value())
+		m.panelState.values[def.Key] = strings.TrimSpace(m.panelState.editTA.Value())
 	}
 }
 
@@ -387,45 +387,45 @@ func (m *cliModel) commitPanelEdit() {
 // Single click: activate item (same as Enter) after moving cursor.
 // If currently in edit/combo mode, close the overlay first.
 func (m *cliModel) clickPanelItem(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode == "settings" && idx < len(m.panelSchema) {
+	if m.panelState.mode == "settings" && idx < len(m.panelState.schema) {
 		// Close any active overlay before switching to a new item
-		if m.panelEdit || m.panelCombo {
+		if m.panelState.editing || m.panelState.combo {
 			m.commitPanelEdit()
-			m.panelEdit = false
-			m.panelCombo = false
+			m.panelState.editing = false
+			m.panelState.combo = false
 		}
-		m.panelCursor = idx
+		m.panelState.cursor = idx
 		return m.activatePanelItem()
 	}
 	// For other panel modes that use panelItem zones
-	m.panelCursor = idx
+	m.panelState.cursor = idx
 	return true, m, nil
 }
 
 // clickPanelToggle handles clicking a toggle setting.
 func (m *cliModel) clickPanelToggle(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode != "settings" || idx >= len(m.panelSchema) {
+	if m.panelState.mode != "settings" || idx >= len(m.panelState.schema) {
 		return false, m, nil
 	}
 	// Close any active overlay first
-	if m.panelEdit || m.panelCombo {
+	if m.panelState.editing || m.panelState.combo {
 		m.commitPanelEdit()
-		m.panelEdit = false
-		m.panelCombo = false
+		m.panelState.editing = false
+		m.panelState.combo = false
 	}
-	def := m.panelSchema[idx]
+	def := m.panelState.schema[idx]
 	if def.ReadOnly || def.Type != ch.SettingTypeToggle {
 		return false, m, nil
 	}
-	cur := m.panelValues[def.Key]
-	m.panelValues[def.Key] = toggleVal(cur)
+	cur := m.panelState.values[def.Key]
+	m.panelState.values[def.Key] = toggleVal(cur)
 	return true, m, nil
 }
 
 // clickPanelOpenURL handles clicking the "获取密钥" button.
 // Opens the provider's API key management page in the default browser.
 func (m *cliModel) clickPanelOpenURL() (bool, tea.Model, tea.Cmd) {
-	provider := m.panelValues["llm_provider"]
+	provider := m.panelState.values["llm_provider"]
 	guide, ok := ch.ProviderSetupGuides[provider]
 	if !ok || guide.URL == "" {
 		return true, m, nil
@@ -436,11 +436,11 @@ func (m *cliModel) clickPanelOpenURL() (bool, tea.Model, tea.Cmd) {
 
 // clickPanelSave handles clicking the "保存设置" button.
 func (m *cliModel) clickPanelSave() (bool, tea.Model, tea.Cmd) {
-	onSubmit := m.panelOnSubmit
-	panelVals := m.panelValues
+	onSubmit := m.panelState.onSubmit
+	panelVals := m.panelState.values
 	m.closePanel()
 	if onSubmit != nil && panelVals != nil {
-		m.settingsSaving = true
+		m.panelState.settingsSaving = true
 		return true, m, m.doSaveSettings(onSubmit, panelVals)
 	}
 	return true, m, nil
@@ -454,32 +454,32 @@ func (m *cliModel) clickPanelCancel() (bool, tea.Model, tea.Cmd) {
 
 // clickPanelCombo handles clicking a combo/select setting.
 func (m *cliModel) clickPanelCombo(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode != "settings" || idx >= len(m.panelSchema) {
+	if m.panelState.mode != "settings" || idx >= len(m.panelState.schema) {
 		return false, m, nil
 	}
 	// Close any active overlay first (unless clicking same combo to toggle off)
-	def := m.panelSchema[idx]
+	def := m.panelState.schema[idx]
 	if def.ReadOnly || (def.Type != ch.SettingTypeCombo && def.Type != ch.SettingTypeSelect) {
 		return false, m, nil
 	}
-	m.panelCursor = idx
-	if m.panelCombo && m.panelCursor == idx {
+	m.panelState.cursor = idx
+	if m.panelState.combo && m.panelState.cursor == idx {
 		// Click same combo again to close
-		m.panelCombo = false
+		m.panelState.combo = false
 		return true, m, nil
 	}
 	// Close previous edit if any
-	if m.panelEdit {
+	if m.panelState.editing {
 		m.commitPanelEdit()
-		m.panelEdit = false
+		m.panelState.editing = false
 	}
-	m.panelCombo = true
-	m.panelComboIdx = 0
+	m.panelState.combo = true
+	m.panelState.comboIdx = 0
 	// Pre-select current value
-	cur := m.panelValues[def.Key]
+	cur := m.panelState.values[def.Key]
 	for i, opt := range def.Options {
 		if opt.Value == cur {
-			m.panelComboIdx = i
+			m.panelState.comboIdx = i
 			break
 		}
 	}
@@ -490,13 +490,13 @@ func (m *cliModel) clickPanelCombo(idx int) (bool, tea.Model, tea.Cmd) {
 
 // clickPanelComboItem handles clicking an item in an open combo dropdown.
 func (m *cliModel) clickPanelComboItem(optIdx int) (bool, tea.Model, tea.Cmd) {
-	if !m.panelCombo || m.panelCursor >= len(m.panelSchema) {
+	if !m.panelState.combo || m.panelState.cursor >= len(m.panelState.schema) {
 		return false, m, nil
 	}
-	def := m.panelSchema[m.panelCursor]
+	def := m.panelState.schema[m.panelState.cursor]
 	if optIdx < len(def.Options) {
-		m.panelValues[def.Key] = def.Options[optIdx].Value
-		m.panelCombo = false
+		m.panelState.values[def.Key] = def.Options[optIdx].Value
+		m.panelState.combo = false
 	}
 	return true, m, nil
 }
@@ -504,10 +504,10 @@ func (m *cliModel) clickPanelComboItem(optIdx int) (bool, tea.Model, tea.Cmd) {
 // activatePanelItem simulates pressing Enter on the current panel cursor item.
 // Handles both regular setting types and special entries (runner, danger, subscription).
 func (m *cliModel) activatePanelItem() (bool, tea.Model, tea.Cmd) {
-	if m.panelCursor >= len(m.panelSchema) {
+	if m.panelState.cursor >= len(m.panelState.schema) {
 		return false, m, nil
 	}
-	def := m.panelSchema[m.panelCursor]
+	def := m.panelState.schema[m.panelState.cursor]
 	if def.ReadOnly {
 		return true, m, nil
 	}
@@ -523,13 +523,13 @@ func (m *cliModel) activatePanelItem() (bool, tea.Model, tea.Cmd) {
 		m.openDangerPanelFromSettings()
 		return true, m, nil
 	case "subscription_manage":
-		m.panelValuesBackup = make(map[string]string, len(m.panelValues))
-		for k, v := range m.panelValues {
-			m.panelValuesBackup[k] = v
+		m.panelState.valuesBackup = make(map[string]string, len(m.panelState.values))
+		for k, v := range m.panelState.values {
+			m.panelState.valuesBackup[k] = v
 		}
-		m.panelCursorBackup = m.panelCursor
-		m.panelOnSubmitBackup = m.panelOnSubmit
-		m.panelMode = ""
+		m.panelState.cursorBackup = m.panelState.cursor
+		m.panelState.onSubmitBackup = m.panelState.onSubmit
+		m.panelState.mode = ""
 		m.relayoutViewport()
 		m.quickSwitchReturnToPanel = true
 		m.openQuickSwitch("subscription")
@@ -538,38 +538,38 @@ func (m *cliModel) activatePanelItem() (bool, tea.Model, tea.Cmd) {
 
 	switch def.Type {
 	case ch.SettingTypeToggle:
-		cur := m.panelValues[def.Key]
-		m.panelValues[def.Key] = toggleVal(cur)
+		cur := m.panelState.values[def.Key]
+		m.panelState.values[def.Key] = toggleVal(cur)
 		return true, m, nil
 	case ch.SettingTypeSelect:
 		opts := def.Options
 		if len(opts) == 0 {
 			return true, m, nil
 		}
-		cur := m.panelValues[def.Key]
+		cur := m.panelState.values[def.Key]
 		for i, opt := range opts {
 			if opt.Value == cur {
 				next := (i + 1) % len(opts)
-				m.panelValues[def.Key] = opts[next].Value
+				m.panelState.values[def.Key] = opts[next].Value
 				break
 			}
 		}
 		return true, m, nil
 	case ch.SettingTypeCombo:
-		if m.panelCombo {
-			m.panelCombo = false
+		if m.panelState.combo {
+			m.panelState.combo = false
 		} else if len(def.Options) > 0 {
-			m.panelCombo = true
-			m.panelComboIdx = 0
+			m.panelState.combo = true
+			m.panelState.comboIdx = 0
 			extraLines := 2 + min(len(def.Options), 8)
 			m.ensureSettingsCursorVisible(extraLines)
 		}
 		return true, m, nil
 	default:
 		// text/number/password/textarea: enter edit mode
-		m.panelEdit = true
-		m.panelEditTA = m.newPanelTextArea(m.panelValues[def.Key], 50, 1)
-		m.panelEditTA.Focus()
+		m.panelState.editing = true
+		m.panelState.editTA = m.newPanelTextArea(m.panelState.values[def.Key], 50, 1)
+		m.panelState.editTA.Focus()
 		m.ensureSettingsCursorVisible(3)
 		return true, m, nil
 	}
@@ -578,31 +578,31 @@ func (m *cliModel) activatePanelItem() (bool, tea.Model, tea.Cmd) {
 // --- AskUser click handlers ---
 
 func (m *cliModel) clickAskUserOption(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode != "askuser" || m.panelTab >= len(m.panelItems) {
+	if m.panelState.mode != "askuser" || m.panelState.askTab >= len(m.panelState.askItems) {
 		return false, m, nil
 	}
-	item := m.panelItems[m.panelTab]
+	item := m.panelState.askItems[m.panelState.askTab]
 	if idx >= len(item.Options) {
 		return false, m, nil
 	}
 	// Toggle selection
-	if m.panelOptSel[m.panelTab] == nil {
-		m.panelOptSel[m.panelTab] = make(map[int]bool)
+	if m.panelState.askOptSel[m.panelState.askTab] == nil {
+		m.panelState.askOptSel[m.panelState.askTab] = make(map[int]bool)
 	}
-	m.panelOptSel[m.panelTab][idx] = !m.panelOptSel[m.panelTab][idx]
+	m.panelState.askOptSel[m.panelState.askTab][idx] = !m.panelState.askOptSel[m.panelState.askTab][idx]
 	return true, m, nil
 }
 
 func (m *cliModel) clickAskUserTab(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode != "askuser" || idx >= len(m.panelItems) {
+	if m.panelState.mode != "askuser" || idx >= len(m.panelState.askItems) {
 		return false, m, nil
 	}
-	m.panelTab = idx
+	m.panelState.askTab = idx
 	return true, m, nil
 }
 
 func (m *cliModel) clickAskUserSubmit() (bool, tea.Model, tea.Cmd) {
-	if m.panelMode != "askuser" || m.panelOnAnswer == nil {
+	if m.panelState.mode != "askuser" || m.panelState.onAnswer == nil {
 		return false, m, nil
 	}
 	// Reuse the same submission logic as keyboard Enter (collectAskAnswers
@@ -692,29 +692,29 @@ func (m *cliModel) executeRewind() (bool, tea.Model, tea.Cmd) {
 // --- Approval click handler ---
 
 func (m *cliModel) clickApprovalBtn(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.approvalRequest == nil {
+	if m.panelState.approvalReq == nil {
 		return false, m, nil
 	}
 	if idx == 0 {
 		// Approve
-		m.approvalResultCh <- protocol.ApprovalResult{Approved: true}
-		m.approvalRequest = nil
-		m.panelMode = ""
+		m.panelState.approvalCh <- protocol.ApprovalResult{Approved: true}
+		m.panelState.approvalReq = nil
+		m.panelState.mode = ""
 		return true, m, nil
 	}
 	if idx == 1 {
 		// Deny
-		if m.approvalEnteringDeny {
+		if m.panelState.approvalDenyMode {
 			// Submit deny with reason
-			reason := m.approvalDenyInput.Value()
-			m.approvalResultCh <- protocol.ApprovalResult{Approved: false, DenyReason: reason}
-			m.approvalRequest = nil
-			m.panelMode = ""
+			reason := m.panelState.approvalDenyTA.Value()
+			m.panelState.approvalCh <- protocol.ApprovalResult{Approved: false, DenyReason: reason}
+			m.panelState.approvalReq = nil
+			m.panelState.mode = ""
 			return true, m, nil
 		}
-		m.approvalEnteringDeny = true
-		m.approvalDenyInput.Focus()
-		m.approvalCursor = 1
+		m.panelState.approvalDenyMode = true
+		m.panelState.approvalDenyTA.Focus()
+		m.panelState.approvalCursor = 1
 		return true, m, nil
 	}
 	return false, m, nil
@@ -731,7 +731,7 @@ func (m *cliModel) clickTextarea(x, y int) (bool, tea.Model, tea.Cmd) {
 	inputBox := m.styles.InputBox
 	borderLeftVisW := lipgloss.Width(lipgloss.RoundedBorder().Left)
 	contentOffset := borderLeftVisW + inputBox.GetPaddingLeft()
-	contentX := x - m.xShift - contentOffset
+	contentX := x - m.layoutConfig.xShift - contentOffset
 	if contentX < 0 {
 		contentX = 0
 	}
@@ -746,13 +746,13 @@ func (m *cliModel) clickTextarea(x, y int) (bool, tea.Model, tea.Cmd) {
 
 func (m *cliModel) clickPanelTextarea(x, y int) (bool, tea.Model, tea.Cmd) {
 	// Click on panel edit textarea
-	if m.panelEdit {
+	if m.panelState.editing {
 		contentX := x - 1
 		if contentX < 0 {
 			contentX = 0
 		}
-		y = y + m.panelEditTA.ScrollYOffset()
-		m.panelEditTA.ClickAt(contentX, y)
+		y = y + m.panelState.editTA.ScrollYOffset()
+		m.panelState.editTA.ClickAt(contentX, y)
 	}
 	return true, m, nil
 }
@@ -785,62 +785,62 @@ func (m *cliModel) clickCompletionsItem(idx int) (bool, tea.Model, tea.Cmd) {
 // --- Sessions click handler ---
 
 func (m *cliModel) clickSessionsItem(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode != "sessions" || idx >= len(m.panelSessionItems) {
+	if m.panelState.mode != "sessions" || idx >= len(m.panelState.sessItems) {
 		return false, m, nil
 	}
-	m.panelSessionCursor = idx
+	m.panelState.sessCursor = idx
 	return true, m, nil
 }
 
 // --- BgTasks click handler ---
 
 func (m *cliModel) clickBgTasksItem(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode != "bgtasks" {
+	if m.panelState.mode != "bgtasks" {
 		return false, m, nil
 	}
-	m.panelBgCursor = idx
+	m.panelState.bgCursor = idx
 	return true, m, nil
 }
 
 // --- Danger click handler ---
 
 func (m *cliModel) clickDangerItem(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode != "danger" || idx >= len(m.panelDangerItems) {
+	if m.panelState.mode != "danger" || idx >= len(m.panelState.dangerItems) {
 		return false, m, nil
 	}
-	m.panelDangerCursor = idx
+	m.panelState.dangerCursor = idx
 	return true, m, nil
 }
 
 // --- ch.Channel click handler ---
 
 func (m *cliModel) clickChannelItem(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode != "channel" || idx >= len(m.panelChannelItems) {
+	if m.panelState.mode != "channel" || idx >= len(m.panelState.channelItems) {
 		return false, m, nil
 	}
-	m.panelChannelCursor = idx
+	m.panelState.channelCursor = idx
 	return true, m, nil
 }
 
 // --- Runner field click handler ---
 
 func (m *cliModel) clickRunnerField(idx int) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode != "runner" {
+	if m.panelState.mode != "runner" {
 		return false, m, nil
 	}
 	// Focus the clicked textinput field
-	m.panelRunnerEditField = idx
+	m.panelState.runnerEditField = idx
 	// Blur all fields, focus selected one
-	m.panelRunnerServerTI.Blur()
-	m.panelRunnerTokenTI.Blur()
-	m.panelRunnerWorkspace.Blur()
+	m.panelState.runnerServerTI.Blur()
+	m.panelState.runnerTokenTI.Blur()
+	m.panelState.runnerWS.Blur()
 	switch idx {
 	case 0:
-		m.panelRunnerServerTI.Focus()
+		m.panelState.runnerServerTI.Focus()
 	case 1:
-		m.panelRunnerTokenTI.Focus()
+		m.panelState.runnerTokenTI.Focus()
 	case 2:
-		m.panelRunnerWorkspace.Focus()
+		m.panelState.runnerWS.Focus()
 	}
 	return true, m, nil
 }
@@ -879,7 +879,7 @@ func (m *cliModel) trackMainLayoutZones(zb *mouseZoneBuilder) {
 			}
 		}
 
-		if m.sidebarPosition == "right" {
+		if m.layoutConfig.sidebarPos == "right" {
 			// sidebar on right: middleBlock starts at 0, sidebar starts at chatWidth
 			sbXStart := m.chatWidth()
 			sbXEnd := m.width
@@ -932,7 +932,7 @@ func (m *cliModel) trackMainLayoutZones(zb *mouseZoneBuilder) {
 			xShift = sbVisW
 		}
 	}
-	m.xShift = xShift
+	m.layoutConfig.xShift = xShift
 
 	zb.skip(viewportH)
 
@@ -979,7 +979,7 @@ func (m *cliModel) trackMainLayoutZones(zb *mouseZoneBuilder) {
 
 	// Textarea content lines — interactive (click to position cursor).
 	// Full-row zone (XStart=-1): matches any X at textarea Y level.
-	// Coordinate offset is computed via m.xShift + InputBox border in clickTextarea.
+	// Coordinate offset is computed via m.layoutConfig.xShift + InputBox border in clickTextarea.
 	taH := m.textarea.Height()
 	if taH < 1 {
 		taH = 1
@@ -1020,7 +1020,7 @@ func (m *cliModel) trackPanelZones(zb *mouseZoneBuilder) {
 	visibleH := m.panelVisibleHeight()
 	contentStartY := zb.y
 
-	switch m.panelMode {
+	switch m.panelState.mode {
 	case "settings":
 		m.trackSettingsZones(zb, visibleH, contentStartY)
 	case "wizard":
@@ -1064,7 +1064,7 @@ func (m *cliModel) trackPanelZones(zb *mouseZoneBuilder) {
 // The rendering order is: header(1 line) + divider(1 line) + [category(2 lines) + items(1 line each)]...
 // Zones must account for scroll offset (panelScrollY).
 func (m *cliModel) trackSettingsZones(zb *mouseZoneBuilder, visibleH, contentStartY int) {
-	scrollY := m.panelScrollY
+	scrollY := m.panelState.scrollY
 
 	// Build the complete line map (same logic as viewSettingsPanel)
 	type lineInfo struct {
@@ -1083,8 +1083,8 @@ func (m *cliModel) trackSettingsZones(zb *mouseZoneBuilder, visibleH, contentSta
 	lines = append(lines, lineInfo{})
 
 	lastCat := ""
-	for i := range m.panelSchema {
-		def := m.panelSchema[i]
+	for i := range m.panelState.schema {
+		def := m.panelState.schema[i]
 		if def.Category != lastCat {
 			lastCat = def.Category
 			lines = append(lines, lineInfo{}) // blank line
@@ -1093,7 +1093,7 @@ func (m *cliModel) trackSettingsZones(zb *mouseZoneBuilder, visibleH, contentSta
 		lines = append(lines, lineInfo{isItem: true, itemIndex: i})
 
 		// Description lines shown when cursor is on this field.
-		if i == m.panelCursor && def.Description != "" {
+		if i == m.panelState.cursor && def.Description != "" {
 			descLines := strings.Count(def.Description, "\n") + 1
 			for k := 0; k < descLines; k++ {
 				lines = append(lines, lineInfo{})
@@ -1102,7 +1102,7 @@ func (m *cliModel) trackSettingsZones(zb *mouseZoneBuilder, visibleH, contentSta
 
 		// API Key field: always show "获取密钥" button line.
 		if def.Key == "llm_api_key" {
-			provider := m.panelValues["llm_provider"]
+			provider := m.panelState.values["llm_provider"]
 			if provider != "" {
 				guide, hasGuide := ch.ProviderSetupGuides[provider]
 				if hasGuide && guide.URL != "" {
@@ -1114,22 +1114,22 @@ func (m *cliModel) trackSettingsZones(zb *mouseZoneBuilder, visibleH, contentSta
 		}
 
 		// Inline overlay: combo/edit rendered right after cursor item (Crush-style)
-		if i == m.panelCursor {
-			if m.panelEdit {
+		if i == m.panelState.cursor {
+			if m.panelState.editing {
 				lines = append(lines, lineInfo{}) // input line
 				lines = append(lines, lineInfo{}) // hint line
 				lines = append(lines, lineInfo{}) // trailing newline
-			} else if m.panelCombo && len(def.Options) > 0 {
+			} else if m.panelState.combo && len(def.Options) > 0 {
 				maxShow := 8
 				start := 0
-				if m.panelComboIdx >= maxShow {
-					start = m.panelComboIdx - maxShow + 1
+				if m.panelState.comboIdx >= maxShow {
+					start = m.panelState.comboIdx - maxShow + 1
 				}
 				end := min(start+maxShow, len(def.Options))
 				for j := start; j < end; j++ {
 					lines = append(lines, lineInfo{isItem: true, itemIndex: -(j + 1)})
 					// Selected combo option may show a description line.
-					if j == m.panelComboIdx && def.Options[j].Description != "" {
+					if j == m.panelState.comboIdx && def.Options[j].Description != "" {
 						lines = append(lines, lineInfo{})
 					}
 				}
@@ -1139,7 +1139,7 @@ func (m *cliModel) trackSettingsZones(zb *mouseZoneBuilder, visibleH, contentSta
 	}
 
 	// Bottom buttons (when no overlay active)
-	if !m.panelEdit && !m.panelCombo {
+	if !m.panelState.editing && !m.panelState.combo {
 		lines = append(lines, lineInfo{})                                     // blank line
 		lines = append(lines, lineInfo{isButton: true, buttonAction: "save"}) // save+cancel buttons row
 		lines = append(lines, lineInfo{})                                     // keyboard hint line
@@ -1150,7 +1150,7 @@ func (m *cliModel) trackSettingsZones(zb *mouseZoneBuilder, visibleH, contentSta
 		info := lines[ln]
 		if info.isItem {
 			if info.itemIndex >= 0 {
-				def := m.panelSchema[info.itemIndex]
+				def := m.panelState.schema[info.itemIndex]
 				zoneID := "panelItem"
 				switch def.Type {
 				case ch.SettingTypeToggle:
@@ -1187,7 +1187,7 @@ func (m *cliModel) trackSettingsZones(zb *mouseZoneBuilder, visibleH, contentSta
 // Rendering order: header+help(1 line) + [deleteConfirm(1 line)] + items(1 line each).
 // Zones account for scroll offset (panelScrollY).
 func (m *cliModel) trackSessionsZones(zb *mouseZoneBuilder, visibleH int) {
-	scrollY := m.panelScrollY
+	scrollY := m.panelState.scrollY
 	lineIdx := 0
 
 	// Header + help line — always advance zb.y, only add zone if visible
@@ -1199,7 +1199,7 @@ func (m *cliModel) trackSessionsZones(zb *mouseZoneBuilder, visibleH int) {
 	lineIdx++
 
 	// Delete confirmation (if shown)
-	if m.panelSessionConfirmDelete {
+	if m.panelState.sessConfirmDelete {
 		if lineIdx >= scrollY {
 			zb.skip(1)
 		} else {
@@ -1208,7 +1208,7 @@ func (m *cliModel) trackSessionsZones(zb *mouseZoneBuilder, visibleH int) {
 		lineIdx++
 	}
 
-	for i := range m.panelSessionItems {
+	for i := range m.panelState.sessItems {
 		if lineIdx >= scrollY {
 			zb.add(1, "sessionsItem", i)
 		} else {
@@ -1223,11 +1223,11 @@ func (m *cliModel) trackSessionsZones(zb *mouseZoneBuilder, visibleH int) {
 func (m *cliModel) trackBgTasksZones(zb *mouseZoneBuilder, visibleH int) {
 	// Header + help line
 	zb.skip(1)
-	if m.panelBgViewing {
+	if m.panelState.bgViewing {
 		// Log view: header only, log lines are not clickable
 		return
 	}
-	for i := range m.panelBgTasks {
+	for i := range m.panelState.bgTasks {
 		zb.add(1, "bgtaskItem", i)
 	}
 }
@@ -1238,13 +1238,13 @@ func (m *cliModel) trackBgTasksZones(zb *mouseZoneBuilder, visibleH int) {
 func (m *cliModel) trackDangerZones(zb *mouseZoneBuilder, visibleH int) {
 	// Header line
 	zb.skip(1)
-	if m.panelDangerConfirm {
+	if m.panelState.dangerConfirm {
 		// Confirm sub-mode: 4 info lines + input line
 		zb.skip(4) // confirm text, desc, blank, type prompt
 		zb.add(1, "dangerInput", 0)
 	} else {
 		// Selection mode
-		for i := range m.panelDangerItems {
+		for i := range m.panelState.dangerItems {
 			zb.add(1, "dangerItem", i)
 		}
 	}
@@ -1255,7 +1255,7 @@ func (m *cliModel) trackDangerZones(zb *mouseZoneBuilder, visibleH int) {
 func (m *cliModel) trackChannelZones(zb *mouseZoneBuilder, visibleH int) {
 	// header+help line + empty line from "\n\n"
 	zb.skip(2)
-	for i := range m.panelChannelItems {
+	for i := range m.panelState.channelItems {
 		zb.add(1, "channelItem", i)
 	}
 }
@@ -1462,7 +1462,7 @@ func (m *cliModel) trackAskUserZones(zb *mouseZoneBuilder) {
 }
 
 func (m *cliModel) trackAskUserContentZones(zb *mouseZoneBuilder) {
-	if len(m.panelItems) == 0 {
+	if len(m.panelState.askItems) == 0 {
 		return
 	}
 
@@ -1476,14 +1476,14 @@ func (m *cliModel) trackAskUserContentZones(zb *mouseZoneBuilder) {
 	var lines []askLine
 
 	// Tab bar (if multiple questions): all tabs rendered on ONE line by viewAskUserPanel().
-	if len(m.panelItems) > 1 {
+	if len(m.panelState.askItems) > 1 {
 		lines = append(lines, askLine{isTabLine: true})
 		lines = append(lines, askLine{}) // blank line ("\n\n" → 1 blank after tab line)
 	}
 
 	// Current tab content
-	if m.panelTab >= 0 && m.panelTab < len(m.panelItems) {
-		item := m.panelItems[m.panelTab]
+	if m.panelState.askTab >= 0 && m.panelState.askTab < len(m.panelState.askItems) {
+		item := m.panelState.askItems[m.panelState.askTab]
 		// Question text (may wrap to multiple lines — not tracked as zones)
 		// Keep this in sync with viewAskUserPanel/ensureAskUserCursorVisible.
 		prefix := "❓ " + item.Question
@@ -1520,7 +1520,7 @@ func (m *cliModel) trackAskUserContentZones(zb *mouseZoneBuilder) {
 			// "Other" input (not tracked as click zone — textinput handles its own input)
 			lines = append(lines, askLine{})
 			// Submit button (only on last tab)
-			if m.panelTab == len(m.panelItems)-1 {
+			if m.panelState.askTab == len(m.panelState.askItems)-1 {
 				lines = append(lines, askLine{zoneID: "askUserSubmit", index: 0})
 			}
 		}
@@ -1528,7 +1528,7 @@ func (m *cliModel) trackAskUserContentZones(zb *mouseZoneBuilder) {
 	}
 
 	// Apply scroll offset: skip lines before askPanelScrollY, stop at visible height
-	scrollY := m.askPanelScrollY
+	scrollY := m.panelState.askScrollY
 	visibleH := m.askUserPanelVisibleHeight()
 	end := len(lines)
 	if end > scrollY+visibleH {
@@ -1541,12 +1541,12 @@ func (m *cliModel) trackAskUserContentZones(zb *mouseZoneBuilder) {
 			// All tabs on one line — register each with X bounds.
 			// PanelBox border(1) + padding(1) = 2 chars before content.
 			x := 2
-			for i := range m.panelItems {
+			for i := range m.panelState.askItems {
 				label := fmt.Sprintf(" %d ", i+1)
 				w := len(label)
 				zb.addX(0, x, x+w, "askUserTab", i)
 				x += w
-				if i < len(m.panelItems)-1 {
+				if i < len(m.panelState.askItems)-1 {
 					x += 1 // separator "│"
 				}
 			}
@@ -1620,24 +1620,24 @@ func (m *cliModel) clickSidebarBgTask(index int) (bool, tea.Model, tea.Cmd) {
 	m.openBgTasksPanel()
 
 	// Validate index against the panel's task list
-	if index < 0 || index >= len(m.panelBgTasks) {
+	if index < 0 || index >= len(m.panelState.bgTasks) {
 		return true, m, nil
 	}
 
 	// Select the clicked task and enter log view
-	m.panelBgCursor = index
-	task := m.panelBgTasks[index]
-	m.panelBgLogLines = sanitizeOutputLines(task.Output)
-	if len(m.panelBgLogLines) == 0 {
-		m.panelBgLogLines = []string{"(no output)"}
+	m.panelState.bgCursor = index
+	task := m.panelState.bgTasks[index]
+	m.panelState.bgLogLines = sanitizeOutputLines(task.Output)
+	if len(m.panelState.bgLogLines) == 0 {
+		m.panelState.bgLogLines = []string{"(no output)"}
 	}
-	m.panelBgViewing = true
-	m.panelScrollY = 0
-	m.panelBgLogFollow = true
+	m.panelState.bgViewing = true
+	m.panelState.scrollY = 0
+	m.panelState.bgLogFollow = true
 
 	// Push main-view onto navigator stack so ESC from log view
 	// closes the panel entirely (popPanel restores mode="" = main view).
-	m.panelStack = append(m.panelStack, panelStackEntry{mode: ""})
+	m.panelState.stack = append(m.panelState.stack, panelStackEntry{mode: ""})
 
 	return true, m, nil
 }

--- a/channel/cli/cli_msg_render.go
+++ b/channel/cli/cli_msg_render.go
@@ -132,16 +132,16 @@ func (m *cliModel) renderMessage(msg *cliMessage) string {
 		// Unified turn rendering: if this assistant message has iteration data,
 		// use renderTurnBody instead of separate thinking box + content.
 		// For streaming (isPartial) messages during busy state, also include
-		// live iteration data from m.iterationHistory + m.progress.
+		// live iteration data from m.progressState.iterations + m.progressState.current.
 		hasIterData := len(msg.iterations) > 0
-		isLiveTurn := msg.isPartial && m.typing && (len(m.iterationHistory) > 0 || m.progress != nil)
+		isLiveTurn := msg.isPartial && m.typing && (len(m.progressState.iterations) > 0 || m.progressState.current != nil)
 		if hasIterData || isLiveTurn {
 			var iterations []cliIterationSnapshot
 			var liveProgress *protocol.ProgressEvent
 			var fallbackContent string // content from streaming message when liveProgress has no stream text
 			if isLiveTurn {
-				iterations = m.iterationHistory
-				liveProgress = m.progress
+				iterations = m.progressState.iterations
+				liveProgress = m.progressState.current
 				fallbackContent = msg.content
 			} else {
 				iterations = msg.iterations

--- a/channel/cli/cli_panel.go
+++ b/channel/cli/cli_panel.go
@@ -35,32 +35,32 @@ type panelStackEntry struct {
 // The caller should set the new panelMode afterwards (via openXxxPanel).
 // Used when navigating from a parent panel (e.g. Settings) to a child panel.
 func (m *cliModel) pushPanel() {
-	m.panelStack = append(m.panelStack, panelStackEntry{
-		mode:     m.panelMode,
-		cursor:   m.panelCursor,
-		scrollY:  m.panelScrollY,
-		values:   m.panelValues,
-		schema:   m.panelSchema,
-		onSubmit: m.panelOnSubmit,
+	m.panelState.stack = append(m.panelState.stack, panelStackEntry{
+		mode:     m.panelState.mode,
+		cursor:   m.panelState.cursor,
+		scrollY:  m.panelState.scrollY,
+		values:   m.panelState.values,
+		schema:   m.panelState.schema,
+		onSubmit: m.panelState.onSubmit,
 	})
 }
 
 // pushPanelFromPalette saves a marker so that popPanel reopens the palette
 // instead of restoring a previous panel. Called when a palette command opens a panel.
 func (m *cliModel) pushPanelFromPalette() {
-	m.panelStack = append(m.panelStack, panelStackEntry{fromPalette: true})
+	m.panelState.stack = append(m.panelState.stack, panelStackEntry{fromPalette: true})
 }
 
 // popPanel restores the parent panel state from the navigation stack.
 // Returns true if a parent panel was restored, false if the stack is empty
 // (meaning we should close the panel entirely).
 func (m *cliModel) popPanel() bool {
-	if len(m.panelStack) == 0 {
+	if len(m.panelState.stack) == 0 {
 		return false
 	}
 	// Pop the last entry
-	entry := m.panelStack[len(m.panelStack)-1]
-	m.panelStack = m.panelStack[:len(m.panelStack)-1]
+	entry := m.panelState.stack[len(m.panelState.stack)-1]
+	m.panelState.stack = m.panelState.stack[:len(m.panelState.stack)-1]
 
 	if entry.fromPalette {
 		// Clean up current panel state entirely, then reopen palette
@@ -70,14 +70,14 @@ func (m *cliModel) popPanel() bool {
 	}
 
 	// Restore parent panel state
-	m.panelMode = entry.mode
-	m.panelCursor = entry.cursor
-	m.panelScrollY = entry.scrollY
-	m.panelValues = entry.values
-	m.panelSchema = entry.schema
-	m.panelOnSubmit = entry.onSubmit
-	m.panelEdit = false
-	m.panelCombo = false
+	m.panelState.mode = entry.mode
+	m.panelState.cursor = entry.cursor
+	m.panelState.scrollY = entry.scrollY
+	m.panelState.values = entry.values
+	m.panelState.schema = entry.schema
+	m.panelState.onSubmit = entry.onSubmit
+	m.panelState.editing = false
+	m.panelState.combo = false
 	m.relayoutViewport()
 	return true
 }
@@ -101,38 +101,38 @@ func (m *cliModel) renderSelLine(line string, w int) string {
 
 // closePanel deactivates any active panel.
 func (m *cliModel) closePanel() {
-	m.panelMode = ""
-	m.panelStack = nil
-	m.panelEdit = false
-	m.panelCombo = false
-	m.panelSchema = nil
-	m.panelValues = nil
-	m.panelPrevProvider = ""
-	m.panelOnSubmit = nil
-	m.panelItems = nil
-	m.panelTab = 0
-	m.panelOptSel = nil
-	m.panelOptCursor = nil
+	m.panelState.mode = ""
+	m.panelState.stack = nil
+	m.panelState.editing = false
+	m.panelState.combo = false
+	m.panelState.schema = nil
+	m.panelState.values = nil
+	m.panelState.prevProvider = ""
+	m.panelState.onSubmit = nil
+	m.panelState.askItems = nil
+	m.panelState.askTab = 0
+	m.panelState.askOptSel = nil
+	m.panelState.askOptCursor = nil
 	// Bg tasks/agents panel cleanup
 	m.cleanupCompletedBgTasks()
-	m.panelBgTasks = nil
-	m.panelBgAgents = nil
-	m.panelBgViewing = false
-	m.panelScrollY = 0
-	m.panelBgLogLines = nil
-	m.panelBgLogFollow = false
+	m.panelState.bgTasks = nil
+	m.panelState.bgAgents = nil
+	m.panelState.bgViewing = false
+	m.panelState.scrollY = 0
+	m.panelState.bgLogLines = nil
+	m.panelState.bgLogFollow = false
 	// Danger zone cleanup
-	m.panelDangerItems = nil
-	m.panelDangerCursor = 0
-	m.panelDangerConfirm = false
-	m.panelDangerOnExec = nil
+	m.panelState.dangerItems = nil
+	m.panelState.dangerCursor = 0
+	m.panelState.dangerConfirm = false
+	m.panelState.dangerOnExec = nil
 	// Runner panel cleanup
-	m.panelRunnerServerTI = textinput.Model{}
-	m.panelRunnerTokenTI = textinput.Model{}
-	m.panelRunnerWorkspace = textinput.Model{}
-	m.panelRunnerEditField = 0
+	m.panelState.runnerServerTI = textinput.Model{}
+	m.panelState.runnerTokenTI = textinput.Model{}
+	m.panelState.runnerWS = textinput.Model{}
+	m.panelState.runnerEditField = 0
 	// 恢复 viewport 到正常模式高度
-	m.panelScrollY = 0
+	m.panelState.scrollY = 0
 	m.relayoutViewport()
 }
 
@@ -162,12 +162,12 @@ func splitLines(s string) []string {
 // updatePanel handles key events when a panel is active.
 // Returns (handled, newModel, cmd).
 func (m *cliModel) updatePanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
-	if m.panelMode == "" {
+	if m.panelState.mode == "" {
 		return false, m, nil
 	}
 
 	handled, newModel, cmd := func() (bool, tea.Model, tea.Cmd) {
-		switch m.panelMode {
+		switch m.panelState.mode {
 		case "settings":
 			return m.updateSettingsPanel(msg)
 		case "wizard":
@@ -192,7 +192,7 @@ func (m *cliModel) updatePanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
 
 	// 对有 cursor 导航的 panel：cursor 超出可见区域时自动滚动
 	if handled {
-		switch m.panelMode {
+		switch m.panelState.mode {
 		case "settings":
 			m.ensurePanelCursorVisible()
 		case "askuser":
@@ -206,7 +206,7 @@ func (m *cliModel) updatePanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
 // viewPanel renders the active panel as a string.
 func (m *cliModel) viewPanel() string {
 	var raw string
-	switch m.panelMode {
+	switch m.panelState.mode {
 	case "settings":
 		raw = m.viewSettingsPanel()
 	case "wizard":

--- a/channel/cli/cli_panel_askuser.go
+++ b/channel/cli/cli_panel_askuser.go
@@ -27,19 +27,19 @@ type askItem struct {
 
 // openAskUserPanel activates the ask-user panel overlay.
 func (m *cliModel) openAskUserPanel(items []askItem, onAnswer func(map[string]string), onCancel func()) {
-	m.panelMode = "askuser"
-	// Do NOT clear m.progress here — the viewport above the AskUser panel
+	m.panelState.mode = "askuser"
+	// Do NOT clear m.progressState.current here — the viewport above the AskUser panel
 	// still renders the progress block (iteration history, tool calls, etc).
 	// Clearing it causes all iteration info from the current turn to disappear.
 	// Progress will be cleaned up by endAgentTurn when the turn actually finishes.
 	m.typing = false
 	m.relayoutViewport() // viewport gets split-layout height
-	m.panelItems = items
-	m.panelTab = 0
-	m.panelOptSel = make(map[int]map[int]bool)
-	m.panelOptCursor = make(map[int]int)
-	m.askPanelScrollY = 0
-	m.askPanelTotalLines = 0
+	m.panelState.askItems = items
+	m.panelState.askTab = 0
+	m.panelState.askOptSel = make(map[int]map[int]bool)
+	m.panelState.askOptCursor = make(map[int]int)
+	m.panelState.askScrollY = 0
+	m.panelState.askTotalLines = 0
 	ta := textarea.New()
 	ta.Placeholder = m.locale.PanelEditPlaceholder
 	ta.Prompt = "  "
@@ -49,7 +49,7 @@ func (m *cliModel) openAskUserPanel(items []askItem, onAnswer func(map[string]st
 	ta.SetHeight(3)
 	ta.KeyMap.InsertNewline.SetKeys("ctrl+j")
 	ta.Focus()
-	m.panelAnswerTA = ta
+	m.panelState.askAnswerTA = ta
 	// Initialize Other single-line input
 	ti := textinput.New()
 	ti.Placeholder = m.locale.PanelOtherPlaceholder
@@ -63,13 +63,13 @@ func (m *cliModel) openAskUserPanel(items []askItem, onAnswer func(map[string]st
 	tiStyles.Cursor.Color = m.styles.TICursor.GetForeground()
 	ti.SetStyles(tiStyles)
 	ti.Focus()
-	m.panelOtherTI = ti
-	m.panelOnAnswer = onAnswer
-	m.panelOnCancel = onCancel
+	m.panelState.askOtherTI = ti
+	m.panelState.onAnswer = onAnswer
+	m.panelState.onCancel = onCancel
 }
 
 func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
-	if m.panelTab < 0 || m.panelTab >= len(m.panelItems) {
+	if m.panelState.askTab < 0 || m.panelState.askTab >= len(m.panelState.askItems) {
 		return true, m, nil
 	}
 
@@ -101,33 +101,33 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 		m.viewport.ScrollDown(1)
 		return true, m, nil
 	case msg.String() == "ctrl+up":
-		m.askPanelScrollY -= 1
-		if m.askPanelScrollY < 0 {
-			m.askPanelScrollY = 0
+		m.panelState.askScrollY -= 1
+		if m.panelState.askScrollY < 0 {
+			m.panelState.askScrollY = 0
 		}
 		return true, m, nil
 	case msg.String() == "ctrl+down":
-		m.askPanelScrollY += 1
+		m.panelState.askScrollY += 1
 		// clamp happens in View via clampAskUserPanelScroll
 		return true, m, nil
 	case msg.String() == "pgup":
-		m.askPanelScrollY -= 5
-		if m.askPanelScrollY < 0 {
-			m.askPanelScrollY = 0
+		m.panelState.askScrollY -= 5
+		if m.panelState.askScrollY < 0 {
+			m.panelState.askScrollY = 0
 		}
 		return true, m, nil
 	case msg.String() == "pgdown":
-		m.askPanelScrollY += 5
+		m.panelState.askScrollY += 5
 		// clamp happens in View via clampAskUserPanelScroll
 		return true, m, nil
 	}
 
-	item := &m.panelItems[m.panelTab]
+	item := &m.panelState.askItems[m.panelState.askTab]
 	numOpts := len(item.Options)
 	hasOpts := numOpts > 0
-	isLastTab := m.panelTab == len(m.panelItems)-1
+	isLastTab := m.panelState.askTab == len(m.panelState.askItems)-1
 	// Cursor: 0..numOpts-1 (checkbox), numOpts (Other input), numOpts+1 (Submit, last tab only)
-	cursor := m.panelOptCursor[m.panelTab]
+	cursor := m.panelState.askOptCursor[m.panelState.askTab]
 	onOther := hasOpts && cursor == numOpts
 	onSubmit := hasOpts && isLastTab && cursor == numOpts+1
 
@@ -135,53 +135,53 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 	case msg.String() == "ctrl+s":
 		return m.submitAskAnswers()
 	case msg.Code == tea.KeyEsc:
-		if m.panelOnCancel != nil {
-			m.panelOnCancel()
+		if m.panelState.onCancel != nil {
+			m.panelState.onCancel()
 		}
 		m.closePanel()
 		return true, m, nil
 	case msg.Code == tea.KeyRight || msg.Code == tea.KeyTab:
-		if len(m.panelItems) > 1 && m.panelTab < len(m.panelItems)-1 {
+		if len(m.panelState.askItems) > 1 && m.panelState.askTab < len(m.panelState.askItems)-1 {
 			m.saveCurrentFreeInput()
-			m.panelTab++
+			m.panelState.askTab++
 			m.restoreFreeInput()
 		}
 		return true, m, nil
 	case msg.String() == "shift+tab" || msg.Code == tea.KeyLeft:
-		if len(m.panelItems) > 1 && m.panelTab > 0 {
+		if len(m.panelState.askItems) > 1 && m.panelState.askTab > 0 {
 			m.saveCurrentFreeInput()
-			m.panelTab--
+			m.panelState.askTab--
 			m.restoreFreeInput()
 		}
 		return true, m, nil
 	case msg.Code == tea.KeyUp:
 		if hasOpts {
 			if onOther {
-				m.panelOptCursor[m.panelTab] = numOpts - 1
+				m.panelState.askOptCursor[m.panelState.askTab] = numOpts - 1
 				m.ensureAskUserCursorVisible()
 				return true, m, nil
 			}
 			if onSubmit {
-				m.panelOptCursor[m.panelTab] = numOpts
+				m.panelState.askOptCursor[m.panelState.askTab] = numOpts
 				m.ensureAskUserCursorVisible()
 				return true, m, nil
 			}
 			if cursor > 0 {
-				m.panelOptCursor[m.panelTab] = cursor - 1
+				m.panelState.askOptCursor[m.panelState.askTab] = cursor - 1
 				// Auto-scroll panel up when cursor moves above visible area
 				m.ensureAskUserCursorVisible()
-			} else if cursor == 0 && m.askPanelScrollY > 0 {
+			} else if cursor == 0 && m.panelState.askScrollY > 0 {
 				// At top option and panel is scrolled — scroll content up
-				m.askPanelScrollY -= 1
-				if m.askPanelScrollY < 0 {
-					m.askPanelScrollY = 0
+				m.panelState.askScrollY -= 1
+				if m.panelState.askScrollY < 0 {
+					m.panelState.askScrollY = 0
 				}
 			}
 			return true, m, nil
 		}
 		m.autoExpandAskTA()
 		var cmd tea.Cmd
-		m.panelAnswerTA, cmd = m.panelAnswerTA.Update(msg)
+		m.panelState.askAnswerTA, cmd = m.panelState.askAnswerTA.Update(msg)
 		return true, m, cmd
 	case msg.Code == tea.KeyDown:
 		if hasOpts {
@@ -191,13 +191,13 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 			}
 			if onOther {
 				if isLastTab {
-					m.panelOptCursor[m.panelTab] = numOpts + 1
+					m.panelState.askOptCursor[m.panelState.askTab] = numOpts + 1
 					m.ensureAskUserCursorVisible()
 				}
 				return true, m, nil
 			}
 			if cursor < maxCursor {
-				m.panelOptCursor[m.panelTab] = cursor + 1
+				m.panelState.askOptCursor[m.panelState.askTab] = cursor + 1
 				// Auto-scroll panel down when cursor moves below visible area
 				m.ensureAskUserCursorVisible()
 			}
@@ -205,7 +205,7 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 		}
 		m.autoExpandAskTA()
 		var cmd tea.Cmd
-		m.panelAnswerTA, cmd = m.panelAnswerTA.Update(msg)
+		m.panelState.askAnswerTA, cmd = m.panelState.askAnswerTA.Update(msg)
 		return true, m, cmd
 	case msg.Code == tea.KeyEnter:
 		if hasOpts {
@@ -223,7 +223,7 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 			return m.submitAskAnswers()
 		}
 		m.saveCurrentFreeInput()
-		m.panelTab++
+		m.panelState.askTab++
 		m.restoreFreeInput()
 		return true, m, nil
 	case msg.Code == tea.KeySpace:
@@ -232,29 +232,29 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 				m.toggleOptAtCursor()
 			}
 			if cursor < numOpts+1 {
-				m.panelOptCursor[m.panelTab] = cursor + 1
+				m.panelState.askOptCursor[m.panelState.askTab] = cursor + 1
 			}
 			return true, m, nil
 		}
 		if onOther {
 			// Other 输入框：空格传给 textinput
 			var cmd tea.Cmd
-			m.panelOtherTI, cmd = m.panelOtherTI.Update(msg)
+			m.panelState.askOtherTI, cmd = m.panelState.askOtherTI.Update(msg)
 			return true, m, cmd
 		}
 		// No options: fall through to textarea
 		m.autoExpandAskTA()
 		var cmd tea.Cmd
-		m.panelAnswerTA, cmd = m.panelAnswerTA.Update(msg)
+		m.panelState.askAnswerTA, cmd = m.panelState.askAnswerTA.Update(msg)
 		return true, m, cmd
 	case len(msg.Text) > 0:
 		if hasOpts && !onOther {
-			m.panelOptCursor[m.panelTab] = numOpts
+			m.panelState.askOptCursor[m.panelState.askTab] = numOpts
 			m.restoreOtherInput()
 		}
 		if onOther {
 			var cmd tea.Cmd
-			m.panelOtherTI, cmd = m.panelOtherTI.Update(msg)
+			m.panelState.askOtherTI, cmd = m.panelState.askOtherTI.Update(msg)
 			return true, m, cmd
 		}
 		if hasOpts {
@@ -264,19 +264,19 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 		// No options: textarea
 		m.autoExpandAskTA()
 		var cmd tea.Cmd
-		m.panelAnswerTA, cmd = m.panelAnswerTA.Update(msg)
+		m.panelState.askAnswerTA, cmd = m.panelState.askAnswerTA.Update(msg)
 		return true, m, cmd
 	default:
 		if isCtrlJ(msg) {
 			if !hasOpts {
-				m.panelAnswerTA.InsertString("\n")
+				m.panelState.askAnswerTA.InsertString("\n")
 				m.autoExpandAskTA()
 			}
 			return true, m, nil
 		}
 		if onOther {
 			var cmd tea.Cmd
-			m.panelOtherTI, cmd = m.panelOtherTI.Update(msg)
+			m.panelState.askOtherTI, cmd = m.panelState.askOtherTI.Update(msg)
 			return true, m, cmd
 		}
 		if hasOpts {
@@ -284,7 +284,7 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 		}
 		m.autoExpandAskTA()
 		var cmd tea.Cmd
-		m.panelAnswerTA, cmd = m.panelAnswerTA.Update(msg)
+		m.panelState.askAnswerTA, cmd = m.panelState.askAnswerTA.Update(msg)
 		return true, m, cmd
 	}
 
@@ -292,23 +292,23 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 
 // toggleOptAtCursor toggles the checkbox at the current cursor position.
 func (m *cliModel) toggleOptAtCursor() {
-	tab := m.panelTab
-	if m.panelOptSel[tab] == nil {
-		m.panelOptSel[tab] = make(map[int]bool)
+	tab := m.panelState.askTab
+	if m.panelState.askOptSel[tab] == nil {
+		m.panelState.askOptSel[tab] = make(map[int]bool)
 	}
-	cursor := m.panelOptCursor[tab]
-	m.panelOptSel[tab][cursor] = !m.panelOptSel[tab][cursor]
+	cursor := m.panelState.askOptCursor[tab]
+	m.panelState.askOptSel[tab][cursor] = !m.panelState.askOptSel[tab][cursor]
 }
 
 // collectAskAnswers gathers answers from all questions.
 func (m *cliModel) collectAskAnswers() map[string]string {
 	answers := make(map[string]string)
-	for i, item := range m.panelItems {
+	for i, item := range m.panelState.askItems {
 		key := fmt.Sprintf("q%d", i)
 		hasOpts := len(item.Options) > 0
 		var parts []string
 		if hasOpts {
-			if sel, ok := m.panelOptSel[i]; ok && len(sel) > 0 {
+			if sel, ok := m.panelState.askOptSel[i]; ok && len(sel) > 0 {
 				// Iterate by index order (maps are unordered in Go)
 				for idx := 0; idx < len(item.Options); idx++ {
 					if sel[idx] {
@@ -317,8 +317,8 @@ func (m *cliModel) collectAskAnswers() map[string]string {
 				}
 			}
 			var otherText string
-			if i == m.panelTab {
-				otherText = strings.TrimSpace(m.panelOtherTI.Value())
+			if i == m.panelState.askTab {
+				otherText = strings.TrimSpace(m.panelState.askOtherTI.Value())
 			} else {
 				otherText = strings.TrimSpace(item.Other)
 			}
@@ -327,8 +327,8 @@ func (m *cliModel) collectAskAnswers() map[string]string {
 			}
 			answers[key] = strings.Join(parts, ", ")
 		} else {
-			if i == m.panelTab {
-				answers[key] = strings.TrimSpace(m.panelAnswerTA.Value())
+			if i == m.panelState.askTab {
+				answers[key] = strings.TrimSpace(m.panelState.askAnswerTA.Value())
 			} else {
 				answers[key] = strings.TrimSpace(item.Other)
 			}
@@ -339,55 +339,55 @@ func (m *cliModel) collectAskAnswers() map[string]string {
 
 // saveCurrentFreeInput saves textarea/textinput content for the current tab.
 func (m *cliModel) saveCurrentFreeInput() {
-	if m.panelTab < 0 || m.panelTab >= len(m.panelItems) {
+	if m.panelState.askTab < 0 || m.panelState.askTab >= len(m.panelState.askItems) {
 		return
 	}
-	item := &m.panelItems[m.panelTab]
+	item := &m.panelState.askItems[m.panelState.askTab]
 	if len(item.Options) > 0 {
-		item.Other = m.panelOtherTI.Value()
+		item.Other = m.panelState.askOtherTI.Value()
 	} else {
-		item.Other = m.panelAnswerTA.Value()
+		item.Other = m.panelState.askAnswerTA.Value()
 	}
 }
 
 // restoreFreeInput restores textarea/textinput content for the current tab.
 func (m *cliModel) restoreFreeInput() {
-	if m.panelTab < 0 || m.panelTab >= len(m.panelItems) {
+	if m.panelState.askTab < 0 || m.panelState.askTab >= len(m.panelState.askItems) {
 		return
 	}
-	item := m.panelItems[m.panelTab]
+	item := m.panelState.askItems[m.panelState.askTab]
 	if len(item.Options) > 0 {
-		m.panelOtherTI.SetValue(item.Other)
-		m.panelOtherTI.CursorEnd()
-		m.panelOtherTI.Focus()
+		m.panelState.askOtherTI.SetValue(item.Other)
+		m.panelState.askOtherTI.CursorEnd()
+		m.panelState.askOtherTI.Focus()
 	} else {
-		m.panelAnswerTA.SetValue(item.Other)
-		m.panelAnswerTA.CursorEnd()
-		m.panelAnswerTA.Focus()
+		m.panelState.askAnswerTA.SetValue(item.Other)
+		m.panelState.askAnswerTA.CursorEnd()
+		m.panelState.askAnswerTA.Focus()
 		m.autoExpandAskTA()
 	}
 }
 
 // restoreOtherInput restores the Other textinput for the current tab (options mode).
 func (m *cliModel) restoreOtherInput() {
-	if m.panelTab < 0 || m.panelTab >= len(m.panelItems) {
+	if m.panelState.askTab < 0 || m.panelState.askTab >= len(m.panelState.askItems) {
 		return
 	}
-	m.panelOtherTI.SetValue(m.panelItems[m.panelTab].Other)
-	m.panelOtherTI.CursorEnd()
+	m.panelState.askOtherTI.SetValue(m.panelState.askItems[m.panelState.askTab].Other)
+	m.panelState.askOtherTI.CursorEnd()
 }
 
 // autoExpandAskTA dynamically grows the textarea height based on content.
 func (m *cliModel) autoExpandAskTA() {
-	lines := strings.Count(m.panelAnswerTA.Value(), "\n") + 1
+	lines := strings.Count(m.panelState.askAnswerTA.Value(), "\n") + 1
 	if lines < 2 {
 		lines = 2
 	}
 	if lines > 6 {
 		lines = 6
 	}
-	if m.panelAnswerTA.Height() != lines {
-		m.panelAnswerTA.SetHeight(lines)
+	if m.panelState.askAnswerTA.Height() != lines {
+		m.panelState.askAnswerTA.SetHeight(lines)
 	}
 }
 
@@ -395,18 +395,18 @@ func (m *cliModel) autoExpandAskTA() {
 // cursor stays within the visible panel area. This provides automatic
 // edge-scrolling when navigating options with ↑/↓ keys.
 func (m *cliModel) ensureAskUserCursorVisible() {
-	if m.panelTab < 0 || m.panelTab >= len(m.panelItems) {
+	if m.panelState.askTab < 0 || m.panelState.askTab >= len(m.panelState.askItems) {
 		return
 	}
-	item := &m.panelItems[m.panelTab]
+	item := &m.panelState.askItems[m.panelState.askTab]
 	if len(item.Options) == 0 {
 		return
 	}
-	cursor := m.panelOptCursor[m.panelTab]
+	cursor := m.panelState.askOptCursor[m.panelState.askTab]
 	// Calculate exact line offset of the cursor by counting actual header lines.
 	// Tab bar: 2 lines (tabs + blank) if multiple questions, 0 otherwise.
 	headerLines := 0
-	if len(m.panelItems) > 1 {
+	if len(m.panelState.askItems) > 1 {
 		headerLines = 2 // tab bar + blank line
 	}
 	// Question: may be multiple lines after hardWrap.
@@ -441,17 +441,17 @@ func (m *cliModel) ensureAskUserCursorVisible() {
 		return
 	}
 	// Scroll up if cursor is above visible area
-	if cursorLine < m.askPanelScrollY+1 {
-		m.askPanelScrollY = cursorLine - 1
-		if m.askPanelScrollY < 0 {
-			m.askPanelScrollY = 0
+	if cursorLine < m.panelState.askScrollY+1 {
+		m.panelState.askScrollY = cursorLine - 1
+		if m.panelState.askScrollY < 0 {
+			m.panelState.askScrollY = 0
 		}
 	}
 	// Scroll down if cursor is below visible area
-	if cursorLine > m.askPanelScrollY+askVisibleH-1 {
-		m.askPanelScrollY = cursorLine - askVisibleH + 1
-		if m.askPanelScrollY < 0 {
-			m.askPanelScrollY = 0
+	if cursorLine > m.panelState.askScrollY+askVisibleH-1 {
+		m.panelState.askScrollY = cursorLine - askVisibleH + 1
+		if m.panelState.askScrollY < 0 {
+			m.panelState.askScrollY = 0
 		}
 	}
 }
@@ -482,15 +482,15 @@ func (m *cliModel) viewAskUserPanel() string {
 	var sb strings.Builder
 
 	// Tab bar (if multiple questions)
-	if len(m.panelItems) > 1 {
-		for i := range m.panelItems {
+	if len(m.panelState.askItems) > 1 {
+		for i := range m.panelState.askItems {
 			label := fmt.Sprintf(" %d ", i+1)
-			if i == m.panelTab {
+			if i == m.panelState.askTab {
 				sb.WriteString(activeTabStyle.Render(label))
 			} else {
 				sb.WriteString(inactiveTabStyle.Render(label))
 			}
-			if i < len(m.panelItems)-1 {
+			if i < len(m.panelState.askItems)-1 {
 				sb.WriteString(inactiveTabStyle.Render("│"))
 			}
 		}
@@ -498,9 +498,9 @@ func (m *cliModel) viewAskUserPanel() string {
 	}
 
 	// Current question
-	if m.panelTab >= 0 && m.panelTab < len(m.panelItems) {
-		item := m.panelItems[m.panelTab]
-		isLastTab := m.panelTab == len(m.panelItems)-1
+	if m.panelState.askTab >= 0 && m.panelState.askTab < len(m.panelState.askItems) {
+		item := m.panelState.askItems[m.panelState.askTab]
+		isLastTab := m.panelState.askTab == len(m.panelState.askItems)-1
 		// Wrap question text to fit inside PanelBox and its optional scrollbar.
 		qWrapWidth := m.askUserQuestionWrapWidth()
 		// Wrap first, then render style per-line to avoid lipgloss.Render
@@ -515,8 +515,8 @@ func (m *cliModel) viewAskUserPanel() string {
 
 		if hasOpts {
 			sb.WriteString("\n")
-			sel := m.panelOptSel[m.panelTab]
-			cursor := m.panelOptCursor[m.panelTab]
+			sel := m.panelState.askOptSel[m.panelState.askTab]
+			cursor := m.panelState.askOptCursor[m.panelState.askTab]
 			numOpts := len(item.Options)
 
 			// renderAskUserOption renders a single option with proper wrapping.
@@ -599,7 +599,7 @@ func (m *cliModel) viewAskUserPanel() string {
 			if tiWidth < 10 {
 				tiWidth = 10
 			}
-			m.panelOtherTI.SetWidth(tiWidth)
+			m.panelState.askOtherTI.SetWidth(tiWidth)
 			// Strip NUL bytes from textinput View(). When the input is empty,
 			// placeholderView() copies the placeholder string into a rune slice
 			// sized to Width()+1 and renders the unwritten slots as \x00.
@@ -611,7 +611,7 @@ func (m *cliModel) viewAskUserPanel() string {
 					return -1
 				}
 				return r
-			}, m.panelOtherTI.View())
+			}, m.panelState.askOtherTI.View())
 			sb.WriteString(tiView)
 			sb.WriteString("\n")
 
@@ -629,7 +629,7 @@ func (m *cliModel) viewAskUserPanel() string {
 			}
 		} else {
 			sb.WriteString("\n")
-			sb.WriteString(m.panelAnswerTA.View())
+			sb.WriteString(m.panelState.askAnswerTA.View())
 			sb.WriteString("\n")
 		}
 	}
@@ -638,26 +638,26 @@ func (m *cliModel) viewAskUserPanel() string {
 }
 
 func (m *cliModel) ensureAskUserVisible() {
-	if m.panelMode != "askuser" || m.panelTab < 0 || m.panelTab >= len(m.panelItems) {
+	if m.panelState.mode != "askuser" || m.panelState.askTab < 0 || m.panelState.askTab >= len(m.panelState.askItems) {
 		return
 	}
 	visible := m.askUserPanelVisibleHeight()
 	if visible <= 0 {
 		return
 	}
-	total := m.askPanelTotalLines
+	total := m.panelState.askTotalLines
 	if total == 0 {
 		return
 	}
 	if total <= visible {
-		m.askPanelScrollY = 0
+		m.panelState.askScrollY = 0
 		return
 	}
-	if m.askPanelScrollY < 0 {
-		m.askPanelScrollY = 0
+	if m.panelState.askScrollY < 0 {
+		m.panelState.askScrollY = 0
 	}
 	maxScroll := total - visible
-	if m.askPanelScrollY > maxScroll {
-		m.askPanelScrollY = maxScroll
+	if m.panelState.askScrollY > maxScroll {
+		m.panelState.askScrollY = maxScroll
 	}
 }

--- a/channel/cli/cli_panel_bgtasks.go
+++ b/channel/cli/cli_panel_bgtasks.go
@@ -10,34 +10,34 @@ import (
 
 // openBgTasksPanel opens the background tasks management panel.
 func (m *cliModel) openBgTasksPanel() {
-	m.panelMode = "bgtasks"
+	m.panelState.mode = "bgtasks"
 	m.relayoutViewport() // 缩小 viewport 为 panel 腾出空间
 
 	// Fetch tasks — use callback (works for both local and remote mode)
-	m.panelBgTasks = m.listBgTasks()
+	m.panelState.bgTasks = m.listBgTasks()
 
 	// Fetch agents and filter by current session
-	m.panelBgAgents = nil
+	m.panelState.bgAgents = nil
 	if m.agentListFn != nil {
 		allAgents := m.agentListFn()
 		for _, ag := range allAgents {
 			if ag.ParentChatID == "" || ag.ParentChatID == m.chatID {
-				m.panelBgAgents = append(m.panelBgAgents, ag)
+				m.panelState.bgAgents = append(m.panelState.bgAgents, ag)
 			}
 		}
 	}
 
-	m.panelBgCursor = 0
-	m.panelBgViewing = false
-	m.panelScrollY = 0
-	m.panelBgLogLines = nil
-	m.panelBgLogFollow = false
+	m.panelState.bgCursor = 0
+	m.panelState.bgViewing = false
+	m.panelState.scrollY = 0
+	m.panelState.bgLogLines = nil
+	m.panelState.bgLogFollow = false
 	// Clamp cursor
-	totalItems := len(m.panelBgTasks) + len(m.panelBgAgents)
+	totalItems := len(m.panelState.bgTasks) + len(m.panelState.bgAgents)
 	if totalItems == 0 {
-		m.panelBgCursor = -1
-	} else if m.panelBgCursor >= totalItems {
-		m.panelBgCursor = totalItems - 1
+		m.panelState.bgCursor = -1
+	} else if m.panelState.bgCursor >= totalItems {
+		m.panelState.bgCursor = totalItems - 1
 	}
 }
 
@@ -69,45 +69,45 @@ func (m *cliModel) killBgTask(taskID string) error {
 // Returns (handled, newModel, cmd).
 func (m *cliModel) updateBgTasksPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
 	// Refresh task list
-	m.panelBgTasks = m.listBgTasks()
-	totalItems := len(m.panelBgTasks)
+	m.panelState.bgTasks = m.listBgTasks()
+	totalItems := len(m.panelState.bgTasks)
 
 	// Log viewing sub-mode
-	if m.panelBgViewing {
+	if m.panelState.bgViewing {
 		switch {
 		case msg.Code == tea.KeyEsc || msg.String() == "ctrl+c":
 			// If navigator stack has a parent (e.g. sidebar direct-click),
 			// pop back to it (which closes the panel to main view).
 			// Otherwise, just exit log view back to task list.
 			if !m.popPanel() {
-				m.panelBgViewing = false
-				m.panelScrollY = 0
-				m.panelBgLogLines = nil
+				m.panelState.bgViewing = false
+				m.panelState.scrollY = 0
+				m.panelState.bgLogLines = nil
 			}
 			return true, m, nil
 		case msg.Code == tea.KeyUp:
-			m.panelScrollY -= 5
-			if m.panelScrollY < 0 {
-				m.panelScrollY = 0
+			m.panelState.scrollY -= 5
+			if m.panelState.scrollY < 0 {
+				m.panelState.scrollY = 0
 			}
-			m.panelBgLogFollow = false
+			m.panelState.bgLogFollow = false
 			return true, m, nil
 		case msg.Code == tea.KeyDown:
-			m.panelScrollY += 5
-			m.panelBgLogFollow = false
+			m.panelState.scrollY += 5
+			m.panelState.bgLogFollow = false
 			return true, m, nil
 		case msg.Code == tea.KeyPgUp:
-			m.panelScrollY -= m.panelVisibleHeight()
-			if m.panelScrollY < 0 {
-				m.panelScrollY = 0
+			m.panelState.scrollY -= m.panelVisibleHeight()
+			if m.panelState.scrollY < 0 {
+				m.panelState.scrollY = 0
 			}
-			m.panelBgLogFollow = false
+			m.panelState.bgLogFollow = false
 			return true, m, nil
 		default:
 			// PgDn: bubbletea doesn't have a constant, match by string
 			if msg.String() == "pgdown" {
-				m.panelScrollY += m.panelVisibleHeight()
-				m.panelBgLogFollow = false
+				m.panelState.scrollY += m.panelVisibleHeight()
+				m.panelState.bgLogFollow = false
 				return true, m, nil
 			}
 		}
@@ -125,57 +125,57 @@ func (m *cliModel) updateBgTasksPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 		return true, m, nil
 
 	case msg.Code == tea.KeyUp:
-		if m.panelBgCursor > 0 {
-			m.panelBgCursor--
+		if m.panelState.bgCursor > 0 {
+			m.panelState.bgCursor--
 			m.ensureBgCursorVisible()
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyDown || msg.String() == "ctrl+j":
-		if m.panelBgCursor < totalItems-1 {
-			m.panelBgCursor++
+		if m.panelState.bgCursor < totalItems-1 {
+			m.panelState.bgCursor++
 			m.ensureBgCursorVisible()
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyEnter:
-		if m.panelBgCursor >= 0 && m.panelBgCursor < len(m.panelBgTasks) {
+		if m.panelState.bgCursor >= 0 && m.panelState.bgCursor < len(m.panelState.bgTasks) {
 			// Task entry: view output log
-			task := m.panelBgTasks[m.panelBgCursor]
-			m.panelBgLogLines = sanitizeOutputLines(task.Output)
-			if len(m.panelBgLogLines) == 0 {
-				m.panelBgLogLines = []string{"(no output)"}
+			task := m.panelState.bgTasks[m.panelState.bgCursor]
+			m.panelState.bgLogLines = sanitizeOutputLines(task.Output)
+			if len(m.panelState.bgLogLines) == 0 {
+				m.panelState.bgLogLines = []string{"(no output)"}
 			}
-			m.panelBgViewing = true
-			m.panelScrollY = 0
-			m.panelBgLogFollow = true
+			m.panelState.bgViewing = true
+			m.panelState.scrollY = 0
+			m.panelState.bgLogFollow = true
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyDelete || msg.String() == "ctrl+d":
 		// Kill selected running task
-		if m.panelBgCursor >= 0 && m.panelBgCursor < len(m.panelBgTasks) {
-			task := m.panelBgTasks[m.panelBgCursor]
+		if m.panelState.bgCursor >= 0 && m.panelState.bgCursor < len(m.panelState.bgTasks) {
+			task := m.panelState.bgTasks[m.panelState.bgCursor]
 			if task.Status == BgTaskRunning {
 				if err := m.killBgTask(task.ID); err != nil {
 					m.showTempStatus(fmt.Sprintf(m.locale.KillFailed, err))
 					return true, m, m.clearTempStatusCmd()
 				}
 				// Refresh list after kill, filter out killed tasks
-				m.panelBgTasks = m.listBgTasks()
+				m.panelState.bgTasks = m.listBgTasks()
 				var running []*BgTask
-				for _, t := range m.panelBgTasks {
+				for _, t := range m.panelState.bgTasks {
 					if t.Status == BgTaskRunning {
 						running = append(running, t)
 					}
 				}
-				m.panelBgTasks = running
-				if len(m.panelBgTasks) == 0 {
+				m.panelState.bgTasks = running
+				if len(m.panelState.bgTasks) == 0 {
 					handled, m2, cmd := m.closePanelAndResume()
 					return handled, m2, cmd
 				}
-				if m.panelBgCursor >= len(m.panelBgTasks) {
-					m.panelBgCursor = len(m.panelBgTasks) - 1
+				if m.panelState.bgCursor >= len(m.panelState.bgTasks) {
+					m.panelState.bgCursor = len(m.panelState.bgTasks) - 1
 				}
 				return true, m, nil
 			}
@@ -188,7 +188,7 @@ func (m *cliModel) updateBgTasksPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 
 // viewBgTasksPanel renders the bg tasks panel.
 func (m *cliModel) viewBgTasksPanel() string {
-	if m.panelBgViewing {
+	if m.panelState.bgViewing {
 		return m.viewBgTaskLog()
 	}
 	return m.viewBgTaskList()
@@ -214,14 +214,14 @@ func (m *cliModel) viewBgTaskList() string {
 		contentW = 20
 	}
 
-	totalItems := len(m.panelBgTasks)
+	totalItems := len(m.panelState.bgTasks)
 
 	if totalItems == 0 {
 		sb.WriteString(s.PanelEmpty.Render(m.locale.BgTasksEmpty))
 	} else {
 		idx := 0
 		// Render tasks
-		for _, task := range m.panelBgTasks {
+		for _, task := range m.panelState.bgTasks {
 			elapsed := time.Since(task.StartedAt).Round(time.Second)
 			if task.FinishedAt != nil {
 				elapsed = task.FinishedAt.Sub(task.StartedAt).Round(time.Second)
@@ -243,7 +243,7 @@ func (m *cliModel) viewBgTaskList() string {
 			}
 
 			prefix := "  "
-			if idx == m.panelBgCursor {
+			if idx == m.panelState.bgCursor {
 				prefix = cursorStyle.Render("▸")
 			}
 
@@ -286,22 +286,22 @@ func (m *cliModel) viewBgTaskLog() string {
 	latestTasks := m.listBgTasks()
 
 	var title string
-	if m.panelBgCursor >= 0 && m.panelBgCursor < len(latestTasks) {
-		task := latestTasks[m.panelBgCursor]
+	if m.panelState.bgCursor >= 0 && m.panelState.bgCursor < len(latestTasks) {
+		task := latestTasks[m.panelState.bgCursor]
 		cmd := truncateToWidth(task.Command, contentW-12)
 		title = fmt.Sprintf(m.locale.BgTaskLogTitle, task.ID, cmd)
 		// Update log lines from latest task output
-		oldCount := len(m.panelBgLogLines)
-		m.panelBgLogLines = sanitizeOutputLines(task.Output)
-		newCount := len(m.panelBgLogLines)
+		oldCount := len(m.panelState.bgLogLines)
+		m.panelState.bgLogLines = sanitizeOutputLines(task.Output)
+		newCount := len(m.panelState.bgLogLines)
 		// Follow-tail: auto-scroll when new lines appear
-		if m.panelBgLogFollow && newCount > oldCount {
+		if m.panelState.bgLogFollow && newCount > oldCount {
 			visibleH := m.panelVisibleHeight() - 1 // -1 for header line
-			m.panelScrollY = max(0, newCount-visibleH)
+			m.panelState.scrollY = max(0, newCount-visibleH)
 		}
-	} else if m.panelBgCursor >= 0 && m.panelBgCursor < len(m.panelBgTasks) {
+	} else if m.panelState.bgCursor >= 0 && m.panelState.bgCursor < len(m.panelState.bgTasks) {
 		// Fallback to cached task list if refresh returned empty
-		task := m.panelBgTasks[m.panelBgCursor]
+		task := m.panelState.bgTasks[m.panelState.bgCursor]
 		cmd := truncateToWidth(task.Command, contentW-12)
 		title = fmt.Sprintf(m.locale.BgTaskLogTitle, task.ID, cmd)
 	}
@@ -313,7 +313,7 @@ func (m *cliModel) viewBgTaskLog() string {
 	sb.WriteString(help)
 	sb.WriteString("\n")
 
-	lines := m.panelBgLogLines
+	lines := m.panelState.bgLogLines
 	if len(lines) == 0 {
 		lines = []string{"(no output yet)"}
 	}

--- a/channel/cli/cli_panel_channel.go
+++ b/channel/cli/cli_panel_channel.go
@@ -20,9 +20,9 @@ var builtinChannelNames = []string{"web", "feishu", "qq", "napcat"}
 
 // openChannelPanel opens the channel configuration panel.
 func (m *cliModel) openChannelPanel() {
-	m.panelMode = "channel"
+	m.panelState.mode = "channel"
 	m.relayoutViewport()
-	m.panelChannelCursor = 0
+	m.panelState.channelCursor = 0
 
 	// Fetch current channel configs (includes plugin channels)
 	if m.channel != nil && m.channel.config.ChannelConfigGetFn != nil {
@@ -31,26 +31,26 @@ func (m *cliModel) openChannelPanel() {
 			m.showSystemMsg("Failed to load channel configs: "+err.Error(), feedbackWarning)
 			cfgs = nil
 		}
-		m.panelChannelCfg = cfgs
+		m.panelState.channelCfg = cfgs
 	}
 
 	// Build channel list: built-in first (in fixed order), then plugin channels
-	items := make([]string, 0, len(builtinChannelNames)+len(m.panelChannelCfg))
+	items := make([]string, 0, len(builtinChannelNames)+len(m.panelState.channelCfg))
 	seen := make(map[string]bool)
 	for _, name := range builtinChannelNames {
 		items = append(items, name)
 		seen[name] = true
 	}
 	// Add plugin channels from config keys
-	if m.panelChannelCfg != nil {
-		for name := range m.panelChannelCfg {
+	if m.panelState.channelCfg != nil {
+		for name := range m.panelState.channelCfg {
 			if !seen[name] {
 				items = append(items, name)
 				seen[name] = true
 			}
 		}
 	}
-	m.panelChannelItems = items
+	m.panelState.channelItems = items
 }
 
 // updateChannelPanel handles key events in the channel config panel.
@@ -59,29 +59,29 @@ func (m *cliModel) updateChannelPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 	case msg.String() == "ctrl+c":
 		return m.closePanelAndResume()
 	case msg.Code == tea.KeyEsc:
-		m.panelChannelItems = nil
-		m.panelChannelCfg = nil
+		m.panelState.channelItems = nil
+		m.panelState.channelCfg = nil
 		if !m.popPanel() {
-			m.panelMode = ""
+			m.panelState.mode = ""
 			m.relayoutViewport()
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyUp:
-		if m.panelChannelCursor > 0 {
-			m.panelChannelCursor--
+		if m.panelState.channelCursor > 0 {
+			m.panelState.channelCursor--
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyDown:
-		if m.panelChannelCursor < len(m.panelChannelItems)-1 {
-			m.panelChannelCursor++
+		if m.panelState.channelCursor < len(m.panelState.channelItems)-1 {
+			m.panelState.channelCursor++
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyEnter:
-		if m.panelChannelCursor >= 0 && m.panelChannelCursor < len(m.panelChannelItems) {
-			ch := m.panelChannelItems[m.panelChannelCursor]
+		if m.panelState.channelCursor >= 0 && m.panelState.channelCursor < len(m.panelState.channelItems) {
+			ch := m.panelState.channelItems[m.panelState.channelCursor]
 			m.openChannelSettingsPanel(ch)
 		}
 		return true, m, nil
@@ -106,9 +106,9 @@ func (m *cliModel) viewChannelPanel() string {
 		contentW = 20
 	}
 
-	for i, ch := range m.panelChannelItems {
+	for i, ch := range m.panelState.channelItems {
 		prefix := "  "
-		if i == m.panelChannelCursor {
+		if i == m.panelState.channelCursor {
 			prefix = s.PanelCursor.Render("▸")
 		}
 
@@ -120,8 +120,8 @@ func (m *cliModel) viewChannelPanel() string {
 		// Show enabled/disabled status
 		status := "◦ disabled"
 		statusStyle := s.TextMutedSt
-		if m.panelChannelCfg != nil {
-			if cfg, ok := m.panelChannelCfg[ch]; ok {
+		if m.panelState.channelCfg != nil {
+			if cfg, ok := m.panelState.channelCfg[ch]; ok {
 				if v, ok2 := cfg["enabled"]; ok2 && v == "true" {
 					status = "● enabled"
 					statusStyle = s.ProgressDone
@@ -143,10 +143,10 @@ func (m *cliModel) viewChannelPanel() string {
 // pluginChannelSchema extracts the settings schema for a plugin channel
 // from the _schema field in panelChannelCfg (populated by getChannelConfigs RPC).
 func (m *cliModel) pluginChannelSchema(channel string) []ch.SettingDefinition {
-	if m.panelChannelCfg == nil {
+	if m.panelState.channelCfg == nil {
 		return nil
 	}
-	cfg, ok := m.panelChannelCfg[channel]
+	cfg, ok := m.panelState.channelCfg[channel]
 	if !ok {
 		return nil
 	}
@@ -232,8 +232,8 @@ func (m *cliModel) openChannelSettingsPanel(channel string) {
 
 	// Get current values from cached config or fetch from backend
 	values := make(map[string]string)
-	if m.panelChannelCfg != nil {
-		if cfg, ok := m.panelChannelCfg[channel]; ok {
+	if m.panelState.channelCfg != nil {
+		if cfg, ok := m.panelState.channelCfg[channel]; ok {
 			for k, v := range cfg {
 				values[k] = v
 			}
@@ -258,7 +258,7 @@ func (m *cliModel) openChannelSettingsPanel(channel string) {
 			// Refresh cached configs
 			if m.channel.config.ChannelConfigGetFn != nil {
 				if cfgs, err := m.channel.config.ChannelConfigGetFn(); err == nil {
-					m.panelChannelCfg = cfgs
+					m.panelState.channelCfg = cfgs
 				}
 			}
 			m.showTempStatus(fmt.Sprintf("✅ %s config saved", channel))

--- a/channel/cli/cli_panel_runner.go
+++ b/channel/cli/cli_panel_runner.go
@@ -13,8 +13,8 @@ import (
 
 // openRunnerPanel 打开 Runner 管理面板
 func (m *cliModel) openRunnerPanel() {
-	m.panelMode = "runner"
-	m.panelScrollY = 0
+	m.panelState.mode = "runner"
+	m.panelState.scrollY = 0
 	m.relayoutViewport()
 
 	// 确保 RunnerBridge 存在（正常 TUI 模式也需要，不只在 --share 时）
@@ -39,12 +39,12 @@ func (m *cliModel) openRunnerPanel() {
 		workspace = v
 	}
 
-	m.panelRunnerServerTI = m.newPanelTextInput(serverURL, m.locale.RunnerServerPlaceholder)
-	m.panelRunnerTokenTI = m.newPanelTextInput(token, m.locale.RunnerTokenPlaceholder)
-	m.panelRunnerTokenTI.EchoMode = 0 // password mode
-	m.panelRunnerTokenTI.EchoCharacter = '•'
-	m.panelRunnerWorkspace = m.newPanelTextInput(workspace, m.locale.RunnerWorkspacePlaceholder)
-	m.panelRunnerEditField = 0
+	m.panelState.runnerServerTI = m.newPanelTextInput(serverURL, m.locale.RunnerServerPlaceholder)
+	m.panelState.runnerTokenTI = m.newPanelTextInput(token, m.locale.RunnerTokenPlaceholder)
+	m.panelState.runnerTokenTI.EchoMode = 0 // password mode
+	m.panelState.runnerTokenTI.EchoCharacter = '•'
+	m.panelState.runnerWS = m.newPanelTextInput(workspace, m.locale.RunnerWorkspacePlaceholder)
+	m.panelState.runnerEditField = 0
 }
 
 // updateRunnerPanel 处理 Runner 面板的键盘事件
@@ -55,10 +55,10 @@ func (m *cliModel) updateRunnerPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.
 	}
 	if msg.Code == tea.KeyEsc {
 		// Clean up runner panel state
-		m.panelRunnerServerTI = textinput.Model{}
-		m.panelRunnerTokenTI = textinput.Model{}
-		m.panelRunnerWorkspace = textinput.Model{}
-		m.panelRunnerEditField = 0
+		m.panelState.runnerServerTI = textinput.Model{}
+		m.panelState.runnerTokenTI = textinput.Model{}
+		m.panelState.runnerWS = textinput.Model{}
+		m.panelState.runnerEditField = 0
 		if !m.popPanel() {
 			m.closePanel()
 		}
@@ -69,13 +69,13 @@ func (m *cliModel) updateRunnerPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.
 	if m.runnerBridge == nil {
 		// 将按键传递给当前编辑的 textinput
 		var cmd tea.Cmd
-		switch m.panelRunnerEditField {
+		switch m.panelState.runnerEditField {
 		case 0:
-			m.panelRunnerServerTI, cmd = m.panelRunnerServerTI.Update(msg)
+			m.panelState.runnerServerTI, cmd = m.panelState.runnerServerTI.Update(msg)
 		case 1:
-			m.panelRunnerTokenTI, cmd = m.panelRunnerTokenTI.Update(msg)
+			m.panelState.runnerTokenTI, cmd = m.panelState.runnerTokenTI.Update(msg)
 		case 2:
-			m.panelRunnerWorkspace, cmd = m.panelRunnerWorkspace.Update(msg)
+			m.panelState.runnerWS, cmd = m.panelState.runnerWS.Update(msg)
 		}
 		return true, m, cmd
 	}
@@ -91,11 +91,11 @@ func (m *cliModel) updateRunnerPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.
 	if status == RunnerConnected {
 		if msg.Code == tea.KeyEnter {
 			m.runnerBridge.Disconnect()
-			m.panelMode = "settings"
-			m.panelRunnerServerTI = textinput.Model{}
-			m.panelRunnerTokenTI = textinput.Model{}
-			m.panelRunnerWorkspace = textinput.Model{}
-			m.panelRunnerEditField = 0
+			m.panelState.mode = "settings"
+			m.panelState.runnerServerTI = textinput.Model{}
+			m.panelState.runnerTokenTI = textinput.Model{}
+			m.panelState.runnerWS = textinput.Model{}
+			m.panelState.runnerEditField = 0
 			m.relayoutViewport()
 			return true, m, nil
 		}
@@ -105,26 +105,26 @@ func (m *cliModel) updateRunnerPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.
 	// 未连接：表单编辑
 	switch msg.Code {
 	case tea.KeyUp:
-		if m.panelRunnerEditField > 0 {
-			m.panelRunnerEditField--
+		if m.panelState.runnerEditField > 0 {
+			m.panelState.runnerEditField--
 		}
 		return true, m, nil
 
 	case tea.KeyDown:
-		if m.panelRunnerEditField < 2 {
-			m.panelRunnerEditField++
+		if m.panelState.runnerEditField < 2 {
+			m.panelState.runnerEditField++
 		}
 		return true, m, nil
 
 	case tea.KeyTab:
-		m.panelRunnerEditField = (m.panelRunnerEditField + 1) % 3
+		m.panelState.runnerEditField = (m.panelState.runnerEditField + 1) % 3
 		return true, m, nil
 
 	case tea.KeyEnter:
 		// 验证并连接
-		serverURL := strings.TrimSpace(m.panelRunnerServerTI.Value())
-		token := strings.TrimSpace(m.panelRunnerTokenTI.Value())
-		workspace := strings.TrimSpace(m.panelRunnerWorkspace.Value())
+		serverURL := strings.TrimSpace(m.panelState.runnerServerTI.Value())
+		token := strings.TrimSpace(m.panelState.runnerTokenTI.Value())
+		workspace := strings.TrimSpace(m.panelState.runnerWS.Value())
 
 		if serverURL == "" {
 			m.showTempStatus(m.locale.RunnerServerRequired)
@@ -143,11 +143,11 @@ func (m *cliModel) updateRunnerPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.
 		})
 
 		// 回到 settings，发起连接
-		m.panelMode = "settings"
-		m.panelRunnerServerTI = textinput.Model{}
-		m.panelRunnerTokenTI = textinput.Model{}
-		m.panelRunnerWorkspace = textinput.Model{}
-		m.panelRunnerEditField = 0
+		m.panelState.mode = "settings"
+		m.panelState.runnerServerTI = textinput.Model{}
+		m.panelState.runnerTokenTI = textinput.Model{}
+		m.panelState.runnerWS = textinput.Model{}
+		m.panelState.runnerEditField = 0
 		m.relayoutViewport()
 
 		// 获取 LLM 客户端
@@ -168,13 +168,13 @@ func (m *cliModel) updateRunnerPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.
 
 	// 将按键传递给当前编辑的 textinput
 	var cmd tea.Cmd
-	switch m.panelRunnerEditField {
+	switch m.panelState.runnerEditField {
 	case 0:
-		m.panelRunnerServerTI, cmd = m.panelRunnerServerTI.Update(msg)
+		m.panelState.runnerServerTI, cmd = m.panelState.runnerServerTI.Update(msg)
 	case 1:
-		m.panelRunnerTokenTI, cmd = m.panelRunnerTokenTI.Update(msg)
+		m.panelState.runnerTokenTI, cmd = m.panelState.runnerTokenTI.Update(msg)
 	case 2:
-		m.panelRunnerWorkspace, cmd = m.panelRunnerWorkspace.Update(msg)
+		m.panelState.runnerWS, cmd = m.panelState.runnerWS.Update(msg)
 	}
 	return true, m, cmd
 }
@@ -238,9 +238,9 @@ func (m *cliModel) viewRunnerPanel() string {
 			input  textinput.Model
 			active bool
 		}{
-			{m.locale.RunnerServerLabel, m.panelRunnerServerTI, m.panelRunnerEditField == 0},
-			{m.locale.RunnerTokenLabel, m.panelRunnerTokenTI, m.panelRunnerEditField == 1},
-			{m.locale.RunnerWorkspaceLabel, m.panelRunnerWorkspace, m.panelRunnerEditField == 2},
+			{m.locale.RunnerServerLabel, m.panelState.runnerServerTI, m.panelState.runnerEditField == 0},
+			{m.locale.RunnerTokenLabel, m.panelState.runnerTokenTI, m.panelState.runnerEditField == 1},
+			{m.locale.RunnerWorkspaceLabel, m.panelState.runnerWS, m.panelState.runnerEditField == 2},
 		}
 
 		for _, f := range fields {

--- a/channel/cli/cli_panel_sessions.go
+++ b/channel/cli/cli_panel_sessions.go
@@ -13,21 +13,21 @@ import (
 )
 
 func (m *cliModel) openSessionsPanel() {
-	m.panelMode = "sessions"
+	m.panelState.mode = "sessions"
 	m.relayoutViewport()
 
 	// sessionsListFn now handles everything (main + local dir + subagents).
 	// Only fall back to local dir sessions when there's no callback.
 	if m.sessionsListFn != nil {
-		m.panelSessionItems = m.sessionsListFn()
+		m.panelState.sessItems = m.sessionsListFn()
 	} else {
-		m.panelSessionItems = m.listLocalDirSessions()
+		m.panelState.sessItems = m.listLocalDirSessions()
 	}
 	// Position cursor on the currently active session
-	m.panelSessionCursor = 0
-	for i, entry := range m.panelSessionItems {
+	m.panelState.sessCursor = 0
+	for i, entry := range m.panelState.sessItems {
 		if entry.Active {
-			m.panelSessionCursor = i
+			m.panelState.sessCursor = i
 			break
 		}
 		// For agent sessions, match by chatID (Active is only set for main sessions)
@@ -37,13 +37,13 @@ func (m *cliModel) openSessionsPanel() {
 				agentChatID += ":" + entry.Instance
 			}
 			if agentChatID == m.chatID {
-				m.panelSessionCursor = i
+				m.panelState.sessCursor = i
 				break
 			}
 		}
 	}
-	m.panelSessionViewing = false
-	m.panelScrollY = 0
+	m.panelState.sessViewing = false
+	m.panelState.scrollY = 0
 	m.ensureSessionCursorVisible()
 }
 
@@ -52,39 +52,39 @@ func (m *cliModel) openSessionsPanel() {
 func (m *cliModel) updateSessionsPanel(msg tea.KeyPressMsg) (bool, *cliModel, tea.Cmd) {
 	switch {
 	case msg.Code == tea.KeyEsc:
-		if m.panelSessionViewing {
-			m.panelSessionViewing = false
-			m.panelScrollY = 0
+		if m.panelState.sessViewing {
+			m.panelState.sessViewing = false
+			m.panelState.scrollY = 0
 			return true, m, nil
 		}
 		if !m.popPanel() {
-			m.panelMode = ""
-			m.panelSessionItems = nil
+			m.panelState.mode = ""
+			m.panelState.sessItems = nil
 			m.relayoutViewport()
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyUp:
-		if !m.panelSessionViewing && m.panelSessionCursor > 0 {
-			m.panelSessionCursor--
+		if !m.panelState.sessViewing && m.panelState.sessCursor > 0 {
+			m.panelState.sessCursor--
 			m.ensureSessionCursorVisible()
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyDown:
-		if !m.panelSessionViewing && m.panelSessionCursor < len(m.panelSessionItems)-1 {
-			m.panelSessionCursor++
+		if !m.panelState.sessViewing && m.panelState.sessCursor < len(m.panelState.sessItems)-1 {
+			m.panelState.sessCursor++
 			m.ensureSessionCursorVisible()
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyEnter:
-		if m.panelSessionViewing {
+		if m.panelState.sessViewing {
 			// Viewing mode: Esc goes back, Enter does nothing
 			return true, m, nil
 		}
-		if m.panelSessionCursor >= 0 && m.panelSessionCursor < len(m.panelSessionItems) {
-			entry := m.panelSessionItems[m.panelSessionCursor]
+		if m.panelState.sessCursor >= 0 && m.panelState.sessCursor < len(m.panelState.sessItems) {
+			entry := m.panelState.sessItems[m.panelState.sessCursor]
 			switch entry.Type {
 			case "main":
 				// Switch to this chatroom + close panel
@@ -113,16 +113,16 @@ func (m *cliModel) updateSessionsPanel(msg tea.KeyPressMsg) (bool, *cliModel, te
 					m.todosDoneCleared = false
 					m.restoreSession() // restore target session state (or reset to idle)
 					cmds := m.postRestoreSessionSetup()
-					m.panelMode = ""
-					m.panelSessionItems = nil
+					m.panelState.mode = ""
+					m.panelState.sessItems = nil
 					if len(cmds) > 0 {
 						return true, m, tea.Batch(cmds...)
 					}
 					m.showSystemMsg(fmt.Sprintf("✅ 已切换到会话: %s", entry.Label), feedbackInfo)
 				} else {
 					// Already on this session, just close panel
-					m.panelMode = ""
-					m.panelSessionItems = nil
+					m.panelState.mode = ""
+					m.panelState.sessItems = nil
 					m.relayoutViewport()
 				}
 			case "agent":
@@ -156,16 +156,16 @@ func (m *cliModel) updateSessionsPanel(msg tea.KeyPressMsg) (bool, *cliModel, te
 					m.todosDoneCleared = false
 					m.restoreSession() // restore target session state (or reset to idle)
 					cmds := m.postRestoreSessionSetup()
-					m.panelMode = ""
-					m.panelSessionItems = nil
+					m.panelState.mode = ""
+					m.panelState.sessItems = nil
 					if len(cmds) > 0 {
 						return true, m, tea.Batch(cmds...)
 					}
 					m.showSystemMsg(fmt.Sprintf("✅ 已切换到 agent 会话: %s/%s", entry.Role, entry.Instance), feedbackInfo)
 				} else {
 					// Already on this session, just close panel
-					m.panelMode = ""
-					m.panelSessionItems = nil
+					m.panelState.mode = ""
+					m.panelState.sessItems = nil
 					m.relayoutViewport()
 				}
 			}
@@ -175,30 +175,30 @@ func (m *cliModel) updateSessionsPanel(msg tea.KeyPressMsg) (bool, *cliModel, te
 	case msg.String() == "r":
 		// Refresh sessions list
 		if m.sessionsListFn != nil {
-			m.panelSessionItems = m.sessionsListFn()
+			m.panelState.sessItems = m.sessionsListFn()
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyHome:
-		if !m.panelSessionViewing && len(m.panelSessionItems) > 0 {
-			m.panelSessionCursor = 0
-			m.panelScrollY = 0
+		if !m.panelState.sessViewing && len(m.panelState.sessItems) > 0 {
+			m.panelState.sessCursor = 0
+			m.panelState.scrollY = 0
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyEnd:
-		if !m.panelSessionViewing && len(m.panelSessionItems) > 0 {
-			m.panelSessionCursor = len(m.panelSessionItems) - 1
+		if !m.panelState.sessViewing && len(m.panelState.sessItems) > 0 {
+			m.panelState.sessCursor = len(m.panelState.sessItems) - 1
 			m.ensureSessionCursorVisible()
 		}
 		return true, m, nil
 
 	case msg.Code == tea.KeyPgUp:
-		if !m.panelSessionViewing {
+		if !m.panelState.sessViewing {
 			visibleH := m.panelVisibleHeight()
-			m.panelSessionCursor -= visibleH
-			if m.panelSessionCursor < 0 {
-				m.panelSessionCursor = 0
+			m.panelState.sessCursor -= visibleH
+			if m.panelState.sessCursor < 0 {
+				m.panelState.sessCursor = 0
 			}
 			m.ensureSessionCursorVisible()
 		}
@@ -206,38 +206,38 @@ func (m *cliModel) updateSessionsPanel(msg tea.KeyPressMsg) (bool, *cliModel, te
 
 	// N: create new session in current directory
 	case msg.String() == "n" || msg.String() == "N":
-		if !m.panelSessionViewing {
+		if !m.panelState.sessViewing {
 			return true, m, m.showSessionCreateDialog()
 		}
 
 	// D: delete selected session (except default) — with confirmation
 	case msg.String() == "d" || msg.String() == "D":
-		if !m.panelSessionViewing && m.panelSessionCursor >= 0 && m.panelSessionCursor < len(m.panelSessionItems) {
-			entry := m.panelSessionItems[m.panelSessionCursor]
+		if !m.panelState.sessViewing && m.panelState.sessCursor >= 0 && m.panelState.sessCursor < len(m.panelState.sessItems) {
+			entry := m.panelState.sessItems[m.panelState.sessCursor]
 			if entry.Type == "main" && entry.Label != defaultSessionName {
-				m.panelSessionConfirmDelete = true
-				m.panelSessionConfirmEntry = entry
+				m.panelState.sessConfirmDelete = true
+				m.panelState.sessConfirmEntry = entry
 			}
 		}
 		return true, m, nil
 
 	// Y: confirm delete (follows D)
-	case (msg.String() == "y" || msg.String() == "Y") && m.panelSessionConfirmDelete:
-		m.panelSessionConfirmDelete = false
-		cmd := m.deleteLocalSession(m.panelSessionConfirmEntry)
+	case (msg.String() == "y" || msg.String() == "Y") && m.panelState.sessConfirmDelete:
+		m.panelState.sessConfirmDelete = false
+		cmd := m.deleteLocalSession(m.panelState.sessConfirmEntry)
 		return true, m, cmd
 
 	// Any other key cancels delete confirmation
-	case m.panelSessionConfirmDelete:
-		m.panelSessionConfirmDelete = false
+	case m.panelState.sessConfirmDelete:
+		m.panelState.sessConfirmDelete = false
 		return true, m, nil
 
 	default:
-		if msg.String() == "pgdown" && !m.panelSessionViewing {
+		if msg.String() == "pgdown" && !m.panelState.sessViewing {
 			visibleH := m.panelVisibleHeight()
-			m.panelSessionCursor += visibleH
-			if m.panelSessionCursor >= len(m.panelSessionItems) {
-				m.panelSessionCursor = len(m.panelSessionItems) - 1
+			m.panelState.sessCursor += visibleH
+			if m.panelState.sessCursor >= len(m.panelState.sessItems) {
+				m.panelState.sessCursor = len(m.panelState.sessItems) - 1
 			}
 			m.ensureSessionCursorVisible()
 			return true, m, nil
@@ -248,7 +248,7 @@ func (m *cliModel) updateSessionsPanel(msg tea.KeyPressMsg) (bool, *cliModel, te
 
 // viewSessionsPanel renders the sessions management panel.
 func (m *cliModel) viewSessionsPanel() string {
-	if m.panelSessionViewing {
+	if m.panelState.sessViewing {
 		return m.viewSessionsDetail()
 	}
 	return m.viewSessionsList()
@@ -260,10 +260,10 @@ func (m *cliModel) viewSessionsList() string {
 	cursorStyle := s.PanelCursor
 	header := s.PanelHeader.Render("Sessions")
 	help := s.PanelDesc.Render("↑↓ Navigate  Enter Switch/View  n New  d Delete  r Refresh  Esc Close")
-	total := len(m.panelSessionItems)
+	total := len(m.panelState.sessItems)
 	scrollHint := ""
 	if total > 1 {
-		scrollHint = s.PanelDesc.Render(fmt.Sprintf(" [%d/%d]", m.panelSessionCursor+1, total))
+		scrollHint = s.PanelDesc.Render(fmt.Sprintf(" [%d/%d]", m.panelState.sessCursor+1, total))
 	}
 
 	var sb strings.Builder
@@ -274,9 +274,9 @@ func (m *cliModel) viewSessionsList() string {
 	sb.WriteString("\n")
 
 	// Show delete confirmation prompt
-	if m.panelSessionConfirmDelete {
+	if m.panelState.sessConfirmDelete {
 		sb.WriteString(s.ErrorMsg.Render(
-			fmt.Sprintf("  ⚠ Delete session %q? [Y]es / [N]o", m.panelSessionConfirmEntry.Label)))
+			fmt.Sprintf("  ⚠ Delete session %q? [Y]es / [N]o", m.panelState.sessConfirmEntry.Label)))
 		sb.WriteString("\n")
 	}
 
@@ -285,14 +285,14 @@ func (m *cliModel) viewSessionsList() string {
 		contentW = 20
 	}
 
-	if len(m.panelSessionItems) == 0 {
+	if len(m.panelState.sessItems) == 0 {
 		sb.WriteString(s.PanelEmpty.Render("(no active sessions)"))
 		return sb.String()
 	}
 
-	for i, entry := range m.panelSessionItems {
+	for i, entry := range m.panelState.sessItems {
 		prefix := "  "
-		if i == m.panelSessionCursor {
+		if i == m.panelState.sessCursor {
 			prefix = cursorStyle.Render("▸")
 		}
 
@@ -305,7 +305,7 @@ func (m *cliModel) viewSessionsList() string {
 				mainBusy = m.typing
 			} else {
 				mainBusy = entry.Busy
-				if ls, ok := m.liveSessionStates[entry.ID]; ok {
+				if ls, ok := m.progressState.liveStates[entry.ID]; ok {
 					mainBusy = ls.busy
 				}
 			}
@@ -316,7 +316,7 @@ func (m *cliModel) viewSessionsList() string {
 			} else if mainBusy {
 				// Non-active busy: spinner.
 				iconChar = m.ticker.viewFrames(sidebarSpinnerFrames, 3)
-			} else if m.unreadSessions[entry.ID] {
+			} else if m.progressState.unread[entry.ID] {
 				// Non-active idle, but has unread results.
 				iconChar = "✦"
 				iconColor = lipgloss.Color("#f59e0b")
@@ -338,13 +338,13 @@ func (m *cliModel) viewSessionsList() string {
 			roleColor := lipgloss.Color(RoleColor(entry.Role))
 			// Use liveSessionStates for running state if available.
 			agentRunning := entry.Running
-			if ls, ok := m.liveSessionStates[entry.ID]; ok {
+			if ls, ok := m.progressState.liveStates[entry.ID]; ok {
 				agentRunning = ls.busy
 			}
 			statusIcon := "●"
 			statusStyle := lipgloss.NewStyle().Foreground(roleColor)
 			if !agentRunning {
-				if m.unreadSessions[entry.ID] {
+				if m.progressState.unread[entry.ID] {
 					statusIcon = "✦"
 					statusStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#f59e0b"))
 				} else {
@@ -389,8 +389,8 @@ func (m *cliModel) viewSessionsDetail() string {
 	s := &m.styles
 
 	var title string
-	if m.panelSessionCursor >= 0 && m.panelSessionCursor < len(m.panelSessionItems) {
-		entry := m.panelSessionItems[m.panelSessionCursor]
+	if m.panelState.sessCursor >= 0 && m.panelState.sessCursor < len(m.panelState.sessItems) {
+		entry := m.panelState.sessItems[m.panelState.sessCursor]
 		switch entry.Type {
 		case "main":
 			title = "👤 " + entry.Label
@@ -408,7 +408,7 @@ func (m *cliModel) viewSessionsDetail() string {
 	sb.WriteString(help)
 	sb.WriteString("\n")
 
-	for _, line := range m.panelBgLogLines {
+	for _, line := range m.panelState.bgLogLines {
 		sb.WriteString(line)
 		sb.WriteString("\n")
 	}
@@ -418,7 +418,7 @@ func (m *cliModel) viewSessionsDetail() string {
 
 // showSessionCreateDialog creates a new session with an auto-generated name.
 func (m *cliModel) showSessionCreateDialog() tea.Cmd {
-	m.panelMode = "" // close sessions panel
+	m.panelState.mode = "" // close sessions panel
 	ds, err := LoadDirSessions(m.workDir)
 	if err != nil {
 		m.showTempStatus(fmt.Sprintf("Failed: %v", err))
@@ -482,7 +482,7 @@ func (m *cliModel) showSessionCreateDialog() tea.Cmd {
 	cmds := m.postRestoreSessionSetup()
 	// Refresh sessions list cache so sidebar/sessions panel shows the new session
 	if m.sessionsListFn != nil {
-		m.panelSessionItems = m.sessionsListFn()
+		m.panelState.sessItems = m.sessionsListFn()
 	}
 	if m.channel != nil && m.channel.config.SessionsListRefresh != nil {
 		m.channel.config.SessionsListRefresh()
@@ -541,7 +541,7 @@ func (m *cliModel) deleteLocalSession(entry SessionPanelEntry) tea.Cmd {
 		cmds := m.postRestoreSessionSetup()
 		// Refresh sessions list so sidebar/sessions panel reflects the deletion
 		if m.sessionsListFn != nil {
-			m.panelSessionItems = m.sessionsListFn()
+			m.panelState.sessItems = m.sessionsListFn()
 		}
 		if m.channel != nil && m.channel.config.SessionsListRefresh != nil {
 			m.channel.config.SessionsListRefresh()
@@ -551,7 +551,7 @@ func (m *cliModel) deleteLocalSession(entry SessionPanelEntry) tea.Cmd {
 	}
 	// Non-active session deleted: refresh sidebar so it disappears immediately.
 	if m.sessionsListFn != nil {
-		m.panelSessionItems = m.sessionsListFn()
+		m.panelState.sessItems = m.sessionsListFn()
 	}
 	if m.channel != nil && m.channel.config.SessionsListRefresh != nil {
 		m.channel.config.SessionsListRefresh()
@@ -567,11 +567,11 @@ func (m *cliModel) switchToSession(entry SessionPanelEntry) (bool, tea.Cmd) {
 	case "main":
 		if entry.ID != m.chatID {
 			// Clear unread flag — user is now viewing this session.
-			delete(m.unreadSessions, entry.ID)
+			delete(m.progressState.unread, entry.ID)
 			// Close AskUser panel if it belongs to a different session
-			if m.panelMode == "askuser" && m.askUserSession != entry.ID {
-				m.panelMode = ""
-				m.panelItems = nil
+			if m.panelState.mode == "askuser" && m.askUserSession != entry.ID {
+				m.panelState.mode = ""
+				m.panelState.askItems = nil
 				m.relayoutViewport()
 			}
 			m.saveCurrentSession()
@@ -609,11 +609,11 @@ func (m *cliModel) switchToSession(entry SessionPanelEntry) (bool, tea.Cmd) {
 		}
 		if agentChatID != m.chatID {
 			// Clear unread flag — user is now viewing this session.
-			delete(m.unreadSessions, entry.ID)
+			delete(m.progressState.unread, entry.ID)
 			// Close AskUser panel if it doesn't belong to the new agent session
-			if m.panelMode == "askuser" && m.askUserSession != agentChatID {
-				m.panelMode = ""
-				m.panelItems = nil
+			if m.panelState.mode == "askuser" && m.askUserSession != agentChatID {
+				m.panelState.mode = ""
+				m.panelState.askItems = nil
 				m.relayoutViewport()
 			}
 			m.saveCurrentSession()

--- a/channel/cli/cli_panel_settings.go
+++ b/channel/cli/cli_panel_settings.go
@@ -34,23 +34,23 @@ type dangerItem struct {
 
 // openSettingsPanel activates the settings panel overlay.
 func (m *cliModel) openSettingsPanel(schema []ch.SettingDefinition, values map[string]string, onSubmit func(map[string]string)) {
-	m.panelMode = "settings"
+	m.panelState.mode = "settings"
 	m.relayoutViewport() // 缩小 viewport 为 panel 腾出空间
-	m.panelCursor = 0
-	m.panelEdit = false
-	m.panelScrollY = 0
-	m.panelSubGeneration = m.subGeneration // capture current subscription generation
+	m.panelState.cursor = 0
+	m.panelState.editing = false
+	m.panelState.scrollY = 0
+	m.panelState.subGeneration = m.subGeneration // capture current subscription generation
 	// Store full schema and pre-process defaults / options on the full copy.
-	m.panelSchemaFull = make([]ch.SettingDefinition, len(schema))
-	copy(m.panelSchemaFull, schema)
-	m.panelValues = make(map[string]string, len(values))
+	m.panelState.schemaFull = make([]ch.SettingDefinition, len(schema))
+	copy(m.panelState.schemaFull, schema)
+	m.panelState.values = make(map[string]string, len(values))
 	for k, v := range values {
-		m.panelValues[k] = v
+		m.panelState.values[k] = v
 	}
 	// Fill defaults and mark global-scoped settings as read-only (admin-only).
-	for i := range m.panelSchemaFull {
-		def := &m.panelSchemaFull[i]
-		cur, ok := m.panelValues[def.Key]
+	for i := range m.panelState.schemaFull {
+		def := &m.panelState.schemaFull[i]
+		cur, ok := m.panelState.values[def.Key]
 		needsDefault := !ok || cur == ""
 		// For number fields, also treat "0" as needing default when the
 		// default value is non-zero (handles stale DB entries from scope migrations).
@@ -60,7 +60,7 @@ func (m *cliModel) openSettingsPanel(schema []ch.SettingDefinition, values map[s
 			}
 		}
 		if needsDefault && def.DefaultValue != "" {
-			m.panelValues[def.Key] = def.DefaultValue
+			m.panelState.values[def.Key] = def.DefaultValue
 		}
 		// Inject cross-subscription model list for tier model selectors.
 		if (def.Key == "vanguard_model" || def.Key == "balance_model" || def.Key == "swift_model") && m.channel.modelLister != nil && len(def.Options) == 0 {
@@ -81,46 +81,46 @@ func (m *cliModel) openSettingsPanel(schema []ch.SettingDefinition, values map[s
 	}
 	// Auto-fill base_url on panel open if provider has a known default
 	// and base_url is currently empty (typical for setup wizard).
-	if provider := m.panelValues["llm_provider"]; provider != "" {
-		if m.panelValues["llm_base_url"] == "" {
+	if provider := m.panelState.values["llm_provider"]; provider != "" {
+		if m.panelState.values["llm_base_url"] == "" {
 			if url, ok := ch.ProviderDefaultURLs[provider]; ok {
-				m.panelValues["llm_base_url"] = url
+				m.panelState.values["llm_base_url"] = url
 			}
 		}
-		if m.panelValues["llm_model"] == "" {
+		if m.panelState.values["llm_model"] == "" {
 			if model, ok := ch.ProviderRecommendedModels[provider]; ok {
-				m.panelValues["llm_model"] = model
+				m.panelState.values["llm_model"] = model
 			}
 		}
-		m.panelPrevProvider = provider
+		m.panelState.prevProvider = provider
 		// Show provider-specific API key guidance on initial open.
 		m.updateAPIKeyHint(provider)
 	}
 	// Build visible schema from full schema (filters DependsOn fields).
 	m.rebuildVisibleSchema()
-	m.panelOnSubmit = onSubmit
-	m.panelOnCancel = nil
+	m.panelState.onSubmit = onSubmit
+	m.panelState.onCancel = nil
 	// Pre-create textarea for editing
 	ta := textarea.New()
 	ta.Placeholder = m.locale.PanelEditPlaceholder
 	ta.SetWidth(m.panelWidth(60))
 	ta.SetHeight(1)
 	ta.CharLimit = 200
-	m.panelEditTA = ta
+	m.panelState.editTA = ta
 }
 
 // rebuildVisibleSchema rebuilds panelSchema from panelSchemaFull,
 // filtering out fields whose DependsOn conditions are not met by current panelValues.
 func (m *cliModel) rebuildVisibleSchema() {
-	m.panelSchema = make([]ch.SettingDefinition, 0, len(m.panelSchemaFull))
-	for _, def := range m.panelSchemaFull {
-		if ch.IsFieldVisible(def, m.panelValues) {
-			m.panelSchema = append(m.panelSchema, def)
+	m.panelState.schema = make([]ch.SettingDefinition, 0, len(m.panelState.schemaFull))
+	for _, def := range m.panelState.schemaFull {
+		if ch.IsFieldVisible(def, m.panelState.values) {
+			m.panelState.schema = append(m.panelState.schema, def)
 		}
 	}
 	// Clamp cursor
-	if m.panelCursor >= len(m.panelSchema) {
-		m.panelCursor = max(0, len(m.panelSchema)-1)
+	if m.panelState.cursor >= len(m.panelState.schema) {
+		m.panelState.cursor = max(0, len(m.panelState.schema)-1)
 	}
 }
 
@@ -133,21 +133,21 @@ func (m *cliModel) autoFillBaseURL(provider string) {
 	if !ok {
 		// Provider has no known default (azure, custom) — clear base_url only
 		// if it currently holds a previous provider's auto-filled URL.
-		cur := m.panelValues["llm_base_url"]
+		cur := m.panelState.values["llm_base_url"]
 		if cur != "" && ch.IsProviderDefaultURL(cur) {
-			m.panelValues["llm_base_url"] = ""
+			m.panelState.values["llm_base_url"] = ""
 		}
 	} else {
-		cur := m.panelValues["llm_base_url"]
+		cur := m.panelState.values["llm_base_url"]
 		if cur == "" || ch.IsProviderDefaultURL(cur) {
-			m.panelValues["llm_base_url"] = defaultURL
+			m.panelState.values["llm_base_url"] = defaultURL
 		}
 	}
 	// Auto-fill recommended model when model is empty or matches a previous provider default.
 	if model, ok := ch.ProviderRecommendedModels[provider]; ok {
-		cur := m.panelValues["llm_model"]
+		cur := m.panelState.values["llm_model"]
 		if cur == "" || isProviderRecommendedModel(cur) {
-			m.panelValues["llm_model"] = model
+			m.panelState.values["llm_model"] = model
 		}
 	}
 	// Dynamically update the API Key field description with provider-specific
@@ -164,16 +164,16 @@ func (m *cliModel) updateAPIKeyHint(provider string) {
 	if hint == "" {
 		return
 	}
-	for i := range m.panelSchemaFull {
-		if m.panelSchemaFull[i].Key == "llm_api_key" {
-			m.panelSchemaFull[i].Description = hint
+	for i := range m.panelState.schemaFull {
+		if m.panelState.schemaFull[i].Key == "llm_api_key" {
+			m.panelState.schemaFull[i].Description = hint
 			break
 		}
 	}
 	// Also update in the visible schema if the field is there.
-	for i := range m.panelSchema {
-		if m.panelSchema[i].Key == "llm_api_key" {
-			m.panelSchema[i].Description = hint
+	for i := range m.panelState.schema {
+		if m.panelState.schema[i].Key == "llm_api_key" {
+			m.panelState.schema[i].Description = hint
 			break
 		}
 	}
@@ -204,33 +204,33 @@ func (m *cliModel) viewDangerPanel() string {
 	sb.WriteString(s.PanelHeader.Render(m.locale.DangerTitle))
 	sb.WriteString("\n")
 
-	if m.panelDangerConfirm && m.panelDangerCursor < len(m.panelDangerItems) {
+	if m.panelState.dangerConfirm && m.panelState.dangerCursor < len(m.panelState.dangerItems) {
 		// Confirmation sub-mode
-		item := m.panelDangerItems[m.panelDangerCursor]
+		item := m.panelState.dangerItems[m.panelState.dangerCursor]
 		confirmStr := dangerConfirmStrings[item.Action]
 		fmt.Fprintf(&sb, "  %s\n", fmt.Sprintf(m.locale.DangerConfirmClear, s.WarningSt.Render(item.Label)))
 		sb.WriteString(s.PanelDesc.Render("  " + m.locale.DangerIrreversible))
 		sb.WriteString("\n\n")
 		fmt.Fprintf(&sb, "  %s\n", fmt.Sprintf(m.locale.DangerTypeConfirm, s.ProgressError.Render(confirmStr)))
 		sb.WriteString("  ")
-		sb.WriteString(m.panelDangerInput.View())
+		sb.WriteString(m.panelState.dangerInput.View())
 		sb.WriteString("\n")
 		sb.WriteString(s.PanelHint.Render("  " + m.locale.DangerNavHint))
 	} else {
 		// Item selection mode
-		for i, item := range m.panelDangerItems {
+		for i, item := range m.panelState.dangerItems {
 			var prefix string
 			statText := ""
 			if item.Stat != "" {
 				statText = fmt.Sprintf("  %s", s.InfoSt.Render(item.Stat))
 			}
-			if i == m.panelDangerCursor {
+			if i == m.panelState.dangerCursor {
 				prefix = s.PanelCursor.Render("▸")
 			} else {
 				prefix = "  "
 			}
 			line := fmt.Sprintf("%s %s%s", prefix, item.Label, statText)
-			if i == m.panelDangerCursor {
+			if i == m.panelState.dangerCursor {
 				line = m.renderSelLine(line, m.panelWidth(60)-4)
 			}
 			sb.WriteString(line)
@@ -245,25 +245,25 @@ func (m *cliModel) viewDangerPanel() string {
 
 // updateDangerPanel handles key events in the danger zone panel.
 func (m *cliModel) updateDangerPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
-	if m.panelDangerConfirm {
+	if m.panelState.dangerConfirm {
 		// Confirmation input mode
 		switch msg.Code {
 		case tea.KeyEsc:
-			m.panelDangerConfirm = false
-			m.panelDangerInput.SetValue("")
+			m.panelState.dangerConfirm = false
+			m.panelState.dangerInput.SetValue("")
 			return true, m, nil
 		case tea.KeyEnter:
-			if m.panelDangerOnExec == nil || m.panelDangerCursor >= len(m.panelDangerItems) {
+			if m.panelState.dangerOnExec == nil || m.panelState.dangerCursor >= len(m.panelState.dangerItems) {
 				return true, m, nil
 			}
-			item := m.panelDangerItems[m.panelDangerCursor]
+			item := m.panelState.dangerItems[m.panelState.dangerCursor]
 			confirmStr := dangerConfirmStrings[item.Action]
-			if m.panelDangerInput.Value() != confirmStr {
+			if m.panelState.dangerInput.Value() != confirmStr {
 				m.showSystemMsg(m.locale.DangerMismatch, feedbackWarning)
 				return true, m, nil
 			}
 			// Execute the clear action
-			if err := m.panelDangerOnExec(item.Action); err != nil {
+			if err := m.panelState.dangerOnExec(item.Action); err != nil {
 				m.showSystemMsg(fmt.Sprintf(m.locale.DangerClearFailed, err), feedbackWarning)
 			} else {
 				m.showSystemMsg(fmt.Sprintf(m.locale.DangerCleared, item.Label), feedbackInfo)
@@ -272,7 +272,7 @@ func (m *cliModel) updateDangerPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.
 			return true, m, nil
 		default:
 			var cmd tea.Cmd
-			m.panelDangerInput, cmd = m.panelDangerInput.Update(msg)
+			m.panelState.dangerInput, cmd = m.panelState.dangerInput.Update(msg)
 			return true, m, cmd
 		}
 	}
@@ -290,21 +290,21 @@ func (m *cliModel) updateDangerPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.
 		return m.closePanelAndResume()
 
 	case msg.Code == tea.KeyUp:
-		if m.panelDangerCursor > 0 {
-			m.panelDangerCursor--
+		if m.panelState.dangerCursor > 0 {
+			m.panelState.dangerCursor--
 		}
 
 	case msg.Code == tea.KeyDown:
-		if m.panelDangerCursor < len(m.panelDangerItems)-1 {
-			m.panelDangerCursor++
+		if m.panelState.dangerCursor < len(m.panelState.dangerItems)-1 {
+			m.panelState.dangerCursor++
 		}
 
 	case msg.Code == tea.KeyEnter:
-		if m.panelDangerCursor < len(m.panelDangerItems) {
-			m.panelDangerConfirm = true
-			m.panelDangerInput.SetValue("")
-			m.panelDangerInput.Focus()
-			return true, m, m.panelDangerInput.Focus()
+		if m.panelState.dangerCursor < len(m.panelState.dangerItems) {
+			m.panelState.dangerConfirm = true
+			m.panelState.dangerInput.SetValue("")
+			m.panelState.dangerInput.Focus()
+			return true, m, m.panelState.dangerInput.Focus()
 		}
 	}
 
@@ -329,13 +329,13 @@ func (m *cliModel) openDangerPanelFromSettings() {
 		{"archival", m.locale.DangerArchival, stats["archival"]},
 	}
 
-	m.panelMode = "danger"
-	m.panelScrollY = 0
+	m.panelState.mode = "danger"
+	m.panelState.scrollY = 0
 	m.relayoutViewport()
-	m.panelDangerItems = items
-	m.panelDangerCursor = 0
-	m.panelDangerConfirm = false
-	m.panelDangerOnExec = func(targetType string) error {
+	m.panelState.dangerItems = items
+	m.panelState.dangerCursor = 0
+	m.panelState.dangerConfirm = false
+	m.panelState.dangerOnExec = func(targetType string) error {
 		if m.channel != nil && m.channel.config.ClearMemory != nil {
 			return m.channel.config.ClearMemory(targetType)
 		}
@@ -352,79 +352,79 @@ func (m *cliModel) openDangerPanelFromSettings() {
 	tiStyles.Focused.Placeholder = m.styles.TIPlaceholder
 	tiStyles.Cursor.Color = m.styles.TICursor.GetForeground()
 	ti.SetStyles(tiStyles)
-	m.panelDangerInput = ti
+	m.panelState.dangerInput = ti
 }
 
 func (m *cliModel) updateSettingsPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
-	if m.panelEdit {
+	if m.panelState.editing {
 		// Editing mode
 		switch msg.Code {
 		case tea.KeyEnter:
 			// Save value
-			newVal := strings.TrimSpace(m.panelEditTA.Value())
-			if m.panelCursor < len(m.panelSchema) {
-				key := m.panelSchema[m.panelCursor].Key
-				m.panelValues[key] = newVal
+			newVal := strings.TrimSpace(m.panelState.editTA.Value())
+			if m.panelState.cursor < len(m.panelState.schema) {
+				key := m.panelState.schema[m.panelState.cursor].Key
+				m.panelState.values[key] = newVal
 			}
-			m.panelEdit = false
+			m.panelState.editing = false
 			return true, m, nil
 		case tea.KeyEsc:
-			m.panelEdit = false
+			m.panelState.editing = false
 			return true, m, nil
 		default:
 			// Delegate to textarea
 			var cmd tea.Cmd
-			m.panelEditTA, cmd = m.panelEditTA.Update(msg)
+			m.panelState.editTA, cmd = m.panelState.editTA.Update(msg)
 			return true, m, cmd
 		}
 	}
 
 	// Combo dropdown mode
-	if m.panelCombo {
-		if m.panelCursor < len(m.panelSchema) {
-			def := m.panelSchema[m.panelCursor]
+	if m.panelState.combo {
+		if m.panelState.cursor < len(m.panelState.schema) {
+			def := m.panelState.schema[m.panelState.cursor]
 			opts := def.Options
 			switch msg.Code {
 			case tea.KeyEsc:
-				m.panelCombo = false
+				m.panelState.combo = false
 				return true, m, nil
 			case tea.KeyUp:
-				if m.panelComboIdx > 0 {
-					m.panelComboIdx--
+				if m.panelState.comboIdx > 0 {
+					m.panelState.comboIdx--
 				}
 				return true, m, nil
 			case tea.KeyDown:
-				if m.panelComboIdx < len(opts)-1 {
-					m.panelComboIdx++
+				if m.panelState.comboIdx < len(opts)-1 {
+					m.panelState.comboIdx++
 				}
 				return true, m, nil
 			case tea.KeyEnter:
-				if m.panelComboIdx < len(opts) {
-					m.panelValues[def.Key] = opts[m.panelComboIdx].Value
+				if m.panelState.comboIdx < len(opts) {
+					m.panelState.values[def.Key] = opts[m.panelState.comboIdx].Value
 				}
-				m.panelCombo = false
+				m.panelState.combo = false
 				// Auto-fill llm_base_url when llm_provider changes via combo
-				if def.Key == "llm_provider" && m.panelValues["llm_provider"] != m.panelPrevProvider {
-					m.autoFillBaseURL(m.panelValues["llm_provider"])
-					m.panelPrevProvider = m.panelValues["llm_provider"]
+				if def.Key == "llm_provider" && m.panelState.values["llm_provider"] != m.panelState.prevProvider {
+					m.autoFillBaseURL(m.panelState.values["llm_provider"])
+					m.panelState.prevProvider = m.panelState.values["llm_provider"]
 				}
 				return true, m, nil
 			case tea.KeySpace:
-				m.panelCombo = false
+				m.panelState.combo = false
 				// Switch to edit mode for custom input
-				m.panelEdit = true
-				ta := m.newPanelTextArea(m.panelValues[def.Key], 50, 1)
+				m.panelState.editing = true
+				ta := m.newPanelTextArea(m.panelState.values[def.Key], 50, 1)
 				var cmd tea.Cmd
-				m.panelEditTA, cmd = ta.Update(msg)
+				m.panelState.editTA, cmd = ta.Update(msg)
 				return true, m, cmd
 			default:
 				// Any printable key: auto-switch to edit mode for custom input
 				if len(msg.Text) > 0 {
-					m.panelCombo = false
-					m.panelEdit = true
-					ta := m.newPanelTextArea(m.panelValues[def.Key], 50, 1)
+					m.panelState.combo = false
+					m.panelState.editing = true
+					ta := m.newPanelTextArea(m.panelState.values[def.Key], 50, 1)
 					var cmd tea.Cmd
-					m.panelEditTA, cmd = ta.Update(msg)
+					m.panelState.editTA, cmd = ta.Update(msg)
 					return true, m, cmd
 				}
 			}
@@ -441,40 +441,40 @@ func (m *cliModel) updateSettingsPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 		return true, m, nil
 	case msg.String() == "ctrl+s":
 		// If currently editing a field, commit the edit before saving.
-		if m.panelEdit && m.panelCursor < len(m.panelSchema) {
-			def := m.panelSchema[m.panelCursor]
+		if m.panelState.editing && m.panelState.cursor < len(m.panelState.schema) {
+			def := m.panelState.schema[m.panelState.cursor]
 			if !def.ReadOnly {
 				key := def.Key
-				m.panelValues[key] = strings.TrimSpace(m.panelEditTA.Value())
+				m.panelState.values[key] = strings.TrimSpace(m.panelState.editTA.Value())
 			}
-			m.panelEdit = false
+			m.panelState.editing = false
 		}
 		// Submit all settings — async to avoid blocking the UI.
 		// Close panel immediately to restore responsiveness, then run
 		// the save callback in a goroutine and send back results.
-		onSubmit := m.panelOnSubmit
-		panelVals := m.panelValues
+		onSubmit := m.panelState.onSubmit
+		panelVals := m.panelState.values
 		m.closePanel()
 		if onSubmit != nil && panelVals != nil {
-			m.settingsSaving = true // block input until cliSettingsSavedMsg arrives
+			m.panelState.settingsSaving = true // block input until cliSettingsSavedMsg arrives
 			return true, m, m.doSaveSettings(onSubmit, panelVals)
 		}
 		return true, m, nil
 	case msg.Code == tea.KeyUp || msg.String() == "shift+tab":
-		if m.panelCursor > 0 {
-			m.panelCursor--
+		if m.panelState.cursor > 0 {
+			m.panelState.cursor--
 			m.ensureSettingsCursorVisible(0)
 		}
 		return true, m, nil
 	case msg.Code == tea.KeyDown || msg.Code == tea.KeyTab:
-		if m.panelCursor < len(m.panelSchema)-1 {
-			m.panelCursor++
+		if m.panelState.cursor < len(m.panelState.schema)-1 {
+			m.panelState.cursor++
 			m.ensureSettingsCursorVisible(0)
 		}
 		return true, m, nil
 	case msg.Code == tea.KeyEnter:
-		if m.panelCursor < len(m.panelSchema) {
-			def := m.panelSchema[m.panelCursor]
+		if m.panelState.cursor < len(m.panelState.schema) {
+			def := m.panelState.schema[m.panelState.cursor]
 			// Read-only items: skip editing (display-only)
 			if def.ReadOnly {
 				return true, m, nil
@@ -494,13 +494,13 @@ func (m *cliModel) updateSettingsPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 			// ch.Subscription management entry — save panel state, open quick switch
 			if def.Key == "subscription_manage" {
 				// Backup current panel state so we can restore after quick switch
-				m.panelValuesBackup = make(map[string]string, len(m.panelValues))
-				for k, v := range m.panelValues {
-					m.panelValuesBackup[k] = v
+				m.panelState.valuesBackup = make(map[string]string, len(m.panelState.values))
+				for k, v := range m.panelState.values {
+					m.panelState.valuesBackup[k] = v
 				}
-				m.panelCursorBackup = m.panelCursor
-				m.panelOnSubmitBackup = m.panelOnSubmit
-				m.panelMode = ""
+				m.panelState.cursorBackup = m.panelState.cursor
+				m.panelState.onSubmitBackup = m.panelState.onSubmit
+				m.panelState.mode = ""
 				m.relayoutViewport()
 				m.quickSwitchReturnToPanel = true
 				m.openQuickSwitch("subscription")
@@ -509,16 +509,16 @@ func (m *cliModel) updateSettingsPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 			switch def.Type {
 			case ch.SettingTypeToggle:
 				// Toggle on Enter
-				cur := m.panelValues[def.Key]
+				cur := m.panelState.values[def.Key]
 				if cur == "true" {
-					m.panelValues[def.Key] = "false"
+					m.panelState.values[def.Key] = "false"
 				} else {
-					m.panelValues[def.Key] = "true"
+					m.panelState.values[def.Key] = "true"
 				}
 				return true, m, nil
 			case ch.SettingTypeSelect:
 				// Cycle through options
-				cur := m.panelValues[def.Key]
+				cur := m.panelState.values[def.Key]
 				if cur == "" && def.DefaultValue != "" {
 					cur = def.DefaultValue
 				}
@@ -526,21 +526,21 @@ func (m *cliModel) updateSettingsPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 					return opt.Value == cur
 				})
 				if idx >= 0 && idx < len(def.Options)-1 {
-					m.panelValues[def.Key] = def.Options[idx+1].Value
+					m.panelState.values[def.Key] = def.Options[idx+1].Value
 				} else if len(def.Options) > 0 {
-					m.panelValues[def.Key] = def.Options[0].Value
+					m.panelState.values[def.Key] = def.Options[0].Value
 				}
 				return true, m, nil
 			case ch.SettingTypeCombo:
 				// Open combo dropdown if options available, otherwise edit
 				if len(def.Options) > 0 {
-					m.panelCombo = true
-					m.panelComboIdx = 0
+					m.panelState.combo = true
+					m.panelState.comboIdx = 0
 					// Pre-select current value if it matches an option
-					cur := m.panelValues[def.Key]
+					cur := m.panelState.values[def.Key]
 					for i, opt := range def.Options {
 						if opt.Value == cur {
-							m.panelComboIdx = i
+							m.panelState.comboIdx = i
 							break
 						}
 					}
@@ -550,8 +550,8 @@ func (m *cliModel) updateSettingsPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 				fallthrough
 			default:
 				// Enter edit mode for text/number/textarea/combo(fallback)
-				m.panelEdit = true
-				m.panelEditTA = m.newPanelTextArea(m.panelValues[def.Key], 50, 1)
+				m.panelState.editing = true
+				m.panelState.editTA = m.newPanelTextArea(m.panelState.values[def.Key], 50, 1)
 				return true, m, nil
 			}
 		}
@@ -579,7 +579,7 @@ func (m *cliModel) viewSettingsPanel() string {
 	// Group by category
 	lastCat := ""
 	ln := 0 // 当前渲染行号
-	for i, def := range m.panelSchema {
+	for i, def := range m.panelState.schema {
 		if def.Category != lastCat {
 			lastCat = def.Category
 			sb.WriteString("\n")
@@ -588,13 +588,13 @@ func (m *cliModel) viewSettingsPanel() string {
 			ln += 2
 		}
 
-		cur := m.panelValues[def.Key]
+		cur := m.panelState.values[def.Key]
 		// If value is empty, fall back to DefaultValue for display
 		if cur == "" && def.DefaultValue != "" {
 			cur = def.DefaultValue
 		}
 		var prefix string
-		if i == m.panelCursor && !m.panelEdit {
+		if i == m.panelState.cursor && !m.panelState.editing {
 			prefix = cursorStyle.Render("▸")
 		} else {
 			prefix = "  "
@@ -621,7 +621,7 @@ func (m *cliModel) viewSettingsPanel() string {
 				}
 			}
 			line := fmt.Sprintf("%s %s%s", prefix, s.ProgressDone.Render(def.Label), statusHint)
-			if i == m.panelCursor && !m.panelEdit {
+			if i == m.panelState.cursor && !m.panelState.editing {
 				line = m.renderSelLine(line, m.width-6)
 			}
 			sb.WriteString(line)
@@ -633,7 +633,7 @@ func (m *cliModel) viewSettingsPanel() string {
 		// Danger zone entry: render with warning style
 		if def.Key == "danger_zone" {
 			line := fmt.Sprintf("%s %s", prefix, s.WarningSt.Render(def.Label))
-			if i == m.panelCursor && !m.panelEdit {
+			if i == m.panelState.cursor && !m.panelState.editing {
 				line = m.renderSelLine(line, m.width-6)
 			}
 			sb.WriteString(line)
@@ -675,7 +675,7 @@ func (m *cliModel) viewSettingsPanel() string {
 				}
 			}
 			line := fmt.Sprintf("%s %s%s", prefix, s.ProgressDone.Render(def.Label), subHint)
-			if i == m.panelCursor && !m.panelEdit {
+			if i == m.panelState.cursor && !m.panelState.editing {
 				line = m.renderSelLine(line, m.width-6)
 			}
 			sb.WriteString(line)
@@ -727,7 +727,7 @@ func (m *cliModel) viewSettingsPanel() string {
 		}
 
 		line := fmt.Sprintf("%s %s: %s", prefix, labelSt.Render(def.Label), displayVal)
-		if i == m.panelCursor && !m.panelEdit && !m.panelCombo {
+		if i == m.panelState.cursor && !m.panelState.editing && !m.panelState.combo {
 			line = m.renderSelLine(line, m.width-6)
 		}
 		sb.WriteString(line)
@@ -735,7 +735,7 @@ func (m *cliModel) viewSettingsPanel() string {
 		ln++
 
 		// Show field description when cursor is on this field (not in edit/combo mode).
-		if i == m.panelCursor && !m.panelEdit && !m.panelCombo && def.Description != "" {
+		if i == m.panelState.cursor && !m.panelState.editing && !m.panelState.combo && def.Description != "" {
 			descLines := strings.Split(def.Description, "\n")
 			for _, dl := range descLines {
 				if strings.Contains(dl, "\x1b]8;;") {
@@ -753,8 +753,8 @@ func (m *cliModel) viewSettingsPanel() string {
 		// API Key field: always show "获取密钥" button below the field.
 		// Clickable via mouse zone (panelOpenURL) — opens browser directly.
 		// Also wrapped in OSC 8 hyperlink for terminals that support it.
-		if def.Key == "llm_api_key" && m.panelValues["llm_provider"] != "" {
-			guide, hasGuide := ch.ProviderSetupGuides[m.panelValues["llm_provider"]]
+		if def.Key == "llm_api_key" && m.panelState.values["llm_provider"] != "" {
+			guide, hasGuide := ch.ProviderSetupGuides[m.panelState.values["llm_provider"]]
 			if hasGuide && guide.URL != "" {
 				btnLabel := "  " + m.locale.PanelBtnGetKey + "  "
 				oscLink := fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", guide.URL, btnLabel)
@@ -777,20 +777,20 @@ func (m *cliModel) viewSettingsPanel() string {
 		}
 
 		// ── Inline edit/combo overlay (Crush-style: render right below the item) ──
-		if i == m.panelCursor {
-			if m.panelEdit {
+		if i == m.panelState.cursor {
+			if m.panelState.editing {
 				sb.WriteString("  ")
 				sb.WriteString(cursorStyle.Render("✎ "))
-				sb.WriteString(m.panelEditTA.View())
+				sb.WriteString(m.panelState.editTA.View())
 				sb.WriteString("\n")
 				sb.WriteString(descStyle.Render("    " + m.locale.PanelEditHint))
 				sb.WriteString("\n")
 				ln += 3
-			} else if m.panelCombo {
+			} else if m.panelState.combo {
 				maxShow := 8
 				start := 0
-				if m.panelComboIdx >= maxShow {
-					start = m.panelComboIdx - maxShow + 1
+				if m.panelState.comboIdx >= maxShow {
+					start = m.panelState.comboIdx - maxShow + 1
 				}
 				end := start + maxShow
 				if end > len(def.Options) {
@@ -803,20 +803,20 @@ func (m *cliModel) viewSettingsPanel() string {
 					if len(runes) > 40 {
 						label = string(runes[:37]) + "..."
 					}
-					if j == m.panelComboIdx {
+					if j == m.panelState.comboIdx {
 						sb.WriteString(cursorStyle.Render("    ▸ " + label))
 					} else {
 						sb.WriteString("      ")
 						sb.WriteString(label)
 					}
 					// Show option description on the selected combo item.
-					if j == m.panelComboIdx && opt.Description != "" {
+					if j == m.panelState.comboIdx && opt.Description != "" {
 						sb.WriteString("\n")
 						sb.WriteString(descStyle.Render("        " + opt.Description))
 					}
 					sb.WriteString("\n")
 					ln++
-					if j == m.panelComboIdx && opt.Description != "" {
+					if j == m.panelState.comboIdx && opt.Description != "" {
 						ln++
 					}
 				}
@@ -829,7 +829,7 @@ func (m *cliModel) viewSettingsPanel() string {
 
 	// Bottom buttons: always show Save and Cancel buttons.
 	// These are clickable mouse zones for users who don't know keyboard shortcuts.
-	if !m.panelEdit && !m.panelCombo {
+	if !m.panelState.editing && !m.panelState.combo {
 		sb.WriteString("\n")
 		// Save button — styled prominently
 		saveBtn := "  " + m.locale.PanelBtnSave + "  "

--- a/channel/cli/cli_panel_test.go
+++ b/channel/cli/cli_panel_test.go
@@ -199,10 +199,10 @@ func TestPanelBoxLeftAlign(t *testing.T) {
 		{Key: "name", Label: "Name", Type: channel.SettingTypeText, Category: "Test"},
 		{Key: "provider", Label: "Provider", Type: channel.SettingTypeText, DefaultValue: "openai", Category: "Test"},
 	}
-	m.panelSchema = schema
-	m.panelValues = map[string]string{"provider": "openai"}
-	m.panelCursor = 0
-	m.panelMode = "settings"
+	m.panelState.schema = schema
+	m.panelState.values = map[string]string{"provider": "openai"}
+	m.panelState.cursor = 0
+	m.panelState.mode = "settings"
 
 	raw := m.viewPanel()
 	// Wrap in PanelBox like cli_view.go does
@@ -232,19 +232,19 @@ func TestPanelBoxLeftAlign(t *testing.T) {
 func TestAskUserQuestionWrapPreservesTextWithScrollbar(t *testing.T) {
 	m := newCLIModel()
 	m.handleResize(80, 12)
-	m.panelMode = "askuser"
+	m.panelState.mode = "askuser"
 
 	// Use the same wrap width that viewAskUserPanel uses internally.
 	// Text at exactly this width must survive applyScrollbar without truncation.
 	qWrapWidth := m.askUserQuestionWrapWidth()
 	question := strings.Repeat("a", qWrapWidth-lipgloss.Width("❓ ")+5) // slightly more than 1 line
-	m.panelItems = []askItem{{
+	m.panelState.askItems = []askItem{{
 		Question: question,
 		Options:  []string{"one", "two", "three", "four", "five", "six"},
 	}}
-	m.panelTab = 0
-	m.panelOptCursor = map[int]int{0: 0}
-	m.panelOptSel = map[int]map[int]bool{0: {}}
+	m.panelState.askTab = 0
+	m.panelState.askOptCursor = map[int]int{0: 0}
+	m.panelState.askOptSel = map[int]map[int]bool{0: {}}
 
 	rendered := m.layoutAskUser("")
 	got := strings.Count(stripANSI(rendered), "a")
@@ -256,7 +256,7 @@ func TestAskUserQuestionWrapPreservesTextWithScrollbar(t *testing.T) {
 func TestAskUserLongOptionWraps(t *testing.T) {
 	m := newCLIModel()
 	m.handleResize(80, 24)
-	m.panelMode = "askuser"
+	m.panelState.mode = "askuser"
 
 	// Create an option that exceeds the panel content width
 	qWrapWidth := m.askUserQuestionWrapWidth()
@@ -264,13 +264,13 @@ func TestAskUserLongOptionWraps(t *testing.T) {
 	prefixW := 4
 	optWrapW := qWrapWidth - prefixW
 	longOpt := strings.Repeat("x", optWrapW+20) // longer than one line
-	m.panelItems = []askItem{{
+	m.panelState.askItems = []askItem{{
 		Question: "Pick one",
 		Options:  []string{longOpt, "short"},
 	}}
-	m.panelTab = 0
-	m.panelOptCursor = map[int]int{0: 0}
-	m.panelOptSel = map[int]map[int]bool{0: {}}
+	m.panelState.askTab = 0
+	m.panelState.askOptCursor = map[int]int{0: 0}
+	m.panelState.askOptSel = map[int]map[int]bool{0: {}}
 
 	raw := m.viewAskUserPanel()
 	lines := strings.Split(raw, "\n")
@@ -321,7 +321,7 @@ func TestSubscriptionGenerationGuard(t *testing.T) {
 	model.subGeneration = 5
 
 	// Simulate: settings panel opens with generation 5
-	model.panelSubGeneration = model.subGeneration
+	model.panelState.subGeneration = model.subGeneration
 
 	// Simulate: user edits some values
 	values := map[string]string{
@@ -340,7 +340,7 @@ func TestSubscriptionGenerationGuard(t *testing.T) {
 
 	// Simulate: the onSubmit callback runs (this is what the guard checks)
 	// After switch, stale subscription-scoped fields should be stripped
-	if model.panelSubGeneration != model.subGeneration {
+	if model.panelState.subGeneration != model.subGeneration {
 		for k := range values {
 			if isSubscriptionScopedSettingKey(k) {
 				delete(values, k)
@@ -369,7 +369,7 @@ func TestSubscriptionGenerationGuard(t *testing.T) {
 func TestSubscriptionGenerationGuardNoSwitch(t *testing.T) {
 	model := newCLIModel()
 	model.subGeneration = 5
-	model.panelSubGeneration = 5 // same generation = no switch
+	model.panelState.subGeneration = 5 // same generation = no switch
 
 	values := map[string]string{
 		"llm_provider":      "openai",
@@ -381,7 +381,7 @@ func TestSubscriptionGenerationGuardNoSwitch(t *testing.T) {
 	}
 
 	// Guard should NOT strip anything
-	if model.panelSubGeneration != model.subGeneration {
+	if model.panelState.subGeneration != model.subGeneration {
 		for k := range values {
 			if isSubscriptionScopedSettingKey(k) {
 				delete(values, k)

--- a/channel/cli/cli_pending_tool_summary_test.go
+++ b/channel/cli/cli_pending_tool_summary_test.go
@@ -21,7 +21,7 @@ func TestPendingToolSummary_NoLeakBetweenTurns(t *testing.T) {
 	turn1 := model.agentTurnID
 
 	// Simulate Turn 1 iterations
-	model.iterationHistory = []cliIterationSnapshot{
+	model.progressState.iterations = []cliIterationSnapshot{
 		{Iteration: 0, Thinking: "turn1-iter0", Tools: []protocol.ToolProgress{
 			{Name: "Read", Label: "file1.go", Status: "done", Elapsed: 100, Iteration: 0},
 		}},
@@ -29,7 +29,7 @@ func TestPendingToolSummary_NoLeakBetweenTurns(t *testing.T) {
 			{Name: "Shell", Label: "go build", Status: "done", Elapsed: 200, Iteration: 1},
 		}},
 	}
-	model.lastSeenIteration = 1
+	model.progressState.lastIter = 1
 
 	// PhaseDone for Turn 1 (populates pendingToolSummary)
 	sendProgress(model, &protocol.ProgressEvent{
@@ -82,7 +82,7 @@ func TestPendingToolSummary_NoLeakBetweenTurns(t *testing.T) {
 	}
 
 	// Simulate Turn 2 iterations
-	model.iterationHistory = []cliIterationSnapshot{
+	model.progressState.iterations = []cliIterationSnapshot{
 		{Iteration: 0, Thinking: "turn2-iter0", Tools: []protocol.ToolProgress{
 			{Name: "Edit", Label: "fix.go", Status: "done", Elapsed: 50, Iteration: 0},
 		}},
@@ -93,7 +93,7 @@ func TestPendingToolSummary_NoLeakBetweenTurns(t *testing.T) {
 			{Name: "Shell", Label: "go test", Status: "done", Elapsed: 150, Iteration: 2},
 		}},
 	}
-	model.lastSeenIteration = 2
+	model.progressState.lastIter = 2
 
 	// PhaseDone for Turn 2
 	sendProgress(model, &protocol.ProgressEvent{
@@ -173,13 +173,13 @@ func TestPendingToolSummary_ClearedOnCancelAck(t *testing.T) {
 	model.cancelTargetTurnID = turn1
 
 	// Populate iterationHistory + pendingToolSummary
-	model.iterationHistory = []cliIterationSnapshot{
+	model.progressState.iterations = []cliIterationSnapshot{
 		{Iteration: 0, Thinking: "cancel-iter0", Tools: []protocol.ToolProgress{
 			{Name: "Read", Label: "file.go", Status: "done", Elapsed: 100, Iteration: 0},
 		}},
 	}
-	model.lastSeenIteration = 0
-	model.pendingToolSummary = &cliMessage{iterations: model.iterationHistory}
+	model.progressState.lastIter = 0
+	model.pendingToolSummary = &cliMessage{iterations: model.progressState.iterations}
 
 	// Cancel ack
 	model.Update(cliOutboundMsg{

--- a/channel/cli/cli_progress_test.go
+++ b/channel/cli/cli_progress_test.go
@@ -532,7 +532,7 @@ func TestCancelMessagePreservesCurrentUnsnappedIteration(t *testing.T) {
 	model := initTestModel()
 	model.startAgentTurn()
 	model.cancelTargetTurnID = model.agentTurnID
-	model.iterationHistory = []cliIterationSnapshot{
+	model.progressState.iterations = []cliIterationSnapshot{
 		{
 			Iteration: 1,
 			Thinking:  "previous iteration",
@@ -541,8 +541,8 @@ func TestCancelMessagePreservesCurrentUnsnappedIteration(t *testing.T) {
 			},
 		},
 	}
-	model.lastSeenIteration = 2
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.lastIter = 2
+	model.progressState.current = &protocol.ProgressEvent{
 		Iteration: 2,
 		Thinking:  "current unsnapped iteration",
 		CompletedTools: []protocol.ToolProgress{
@@ -675,7 +675,7 @@ func TestHistoryReloadPreservesActiveStreamingTurn(t *testing.T) {
 		{role: "user", content: "current user", timestamp: time.Now(), dirty: true},
 	}
 	model.startAgentTurn()
-	model.iterationHistory = []cliIterationSnapshot{
+	model.progressState.iterations = []cliIterationSnapshot{
 		{
 			Iteration: 1,
 			Thinking:  "current turn thinking",
@@ -684,7 +684,7 @@ func TestHistoryReloadPreservesActiveStreamingTurn(t *testing.T) {
 			},
 		},
 	}
-	model.progress = &protocol.ProgressEvent{Phase: "tool_exec", Iteration: 1}
+	model.progressState.current = &protocol.ProgressEvent{Phase: "tool_exec", Iteration: 1}
 	streamingIdx := model.streamingMsgIdx
 
 	model.handleHistoryReload(cliHistoryReloadMsg{
@@ -707,8 +707,8 @@ func TestHistoryReloadPreservesActiveStreamingTurn(t *testing.T) {
 	if streaming.role != "assistant" || !streaming.isPartial {
 		t.Fatalf("active streaming assistant was not preserved: %+v", streaming)
 	}
-	if len(model.iterationHistory) != 1 || model.iterationHistory[0].Thinking != "current turn thinking" {
-		t.Fatalf("iteration history was not preserved: %+v", model.iterationHistory)
+	if len(model.progressState.iterations) != 1 || model.progressState.iterations[0].Thinking != "current turn thinking" {
+		t.Fatalf("iteration history was not preserved: %+v", model.progressState.iterations)
 	}
 	if !strings.Contains(model.viewport.View(), "running command") {
 		t.Fatalf("viewport lost current turn tools after reload:\n%s", stripAnsi(model.viewport.View()))
@@ -803,7 +803,7 @@ func TestProgressNoDuplication(t *testing.T) {
 	})
 
 	// Verify iterationHistory has entries and tools
-	if len(model.iterationHistory) == 0 {
+	if len(model.progressState.iterations) == 0 {
 		t.Error("Expected iterationHistory to have entries after progress events")
 	}
 
@@ -840,7 +840,7 @@ func TestProgressRealisticSequence(t *testing.T) {
 	// Iter 2: empty thinking (no tools)
 	sendProgress(model, &protocol.ProgressEvent{Phase: "thinking", Iteration: 3, Thinking: ""})
 
-	if len(model.iterationHistory) == 0 {
+	if len(model.progressState.iterations) == 0 {
 		t.Error("Expected iterationHistory to have entries")
 	}
 

--- a/channel/cli/cli_search.go
+++ b/channel/cli/cli_search.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (m *cliModel) isSearchMatch(idx int) bool {
-	for _, si := range m.searchResults {
+	for _, si := range m.searchState.results {
 		if si == idx {
 			return true
 		}
@@ -91,40 +91,40 @@ func (m *cliModel) enterSearchMode() {
 		w = 20
 	}
 	ti.SetWidth(w)
-	m.searchTI = ti
-	m.searchMode = true
-	m.searchEditing = true
-	m.searchQuery = ""
-	m.searchResults = nil
-	m.searchIdx = -1
+	m.searchState.ti = ti
+	m.searchState.mode = true
+	m.searchState.editing = true
+	m.searchState.query = ""
+	m.searchState.results = nil
+	m.searchState.idx = -1
 	m.rc.valid = false
 	m.updateViewportContent()
 }
 
 // executeSearch 执行搜索（§21）
 func (m *cliModel) executeSearch() {
-	query := strings.TrimSpace(m.searchTI.Value())
+	query := strings.TrimSpace(m.searchState.ti.Value())
 	if query == "" {
 		m.exitSearch()
 		return
 	}
-	m.searchQuery = query
+	m.searchState.query = query
 	lower := strings.ToLower(query)
-	m.searchResults = nil
+	m.searchState.results = nil
 	for i, msg := range m.messages {
 		if msg.role == "system" {
 			continue
 		}
 		if strings.Contains(strings.ToLower(msg.content), lower) {
-			m.searchResults = append(m.searchResults, i)
+			m.searchState.results = append(m.searchState.results, i)
 		}
 	}
-	m.searchIdx = -1
-	m.searchEditing = false
-	if len(m.searchResults) == 0 {
+	m.searchState.idx = -1
+	m.searchState.editing = false
+	if len(m.searchState.results) == 0 {
 		m.showSystemMsg(m.locale.SearchNoResults, feedbackInfo)
 	} else {
-		m.showSystemMsg(fmt.Sprintf(m.locale.SearchResults, len(m.searchResults)), feedbackInfo)
+		m.showSystemMsg(fmt.Sprintf(m.locale.SearchResults, len(m.searchState.results)), feedbackInfo)
 		m.jumpToSearchResult(0)
 	}
 	m.rc.valid = false
@@ -133,22 +133,22 @@ func (m *cliModel) executeSearch() {
 
 // exitSearch 退出搜索模式（§21）
 func (m *cliModel) exitSearch() {
-	m.searchMode = false
-	m.searchQuery = ""
-	m.searchResults = nil
-	m.searchIdx = -1
-	m.searchEditing = false
+	m.searchState.mode = false
+	m.searchState.query = ""
+	m.searchState.results = nil
+	m.searchState.idx = -1
+	m.searchState.editing = false
 	m.rc.valid = false
 	m.updateViewportContent()
 }
 
 // jumpToSearchResult 跳转到指定搜索结果（§21）
 func (m *cliModel) jumpToSearchResult(idx int) {
-	if idx < 0 || idx >= len(m.searchResults) {
+	if idx < 0 || idx >= len(m.searchState.results) {
 		return
 	}
-	m.searchIdx = idx
-	msgIdx := m.searchResults[idx]
+	m.searchState.idx = idx
+	msgIdx := m.searchState.results[idx]
 	if msgIdx < len(m.msgLineOffsets) {
 		m.viewport.SetYOffset(m.msgLineOffsets[msgIdx])
 	}

--- a/channel/cli/cli_sim_test.go
+++ b/channel/cli/cli_sim_test.go
@@ -363,7 +363,7 @@ func newSimRunner(scenario SimScenario) *simRunner {
 		model.remoteMode = true
 	}
 	model.handleResize(cfg.Width, cfg.Height)
-	model.splashDone = true
+	model.splashState.done = true
 
 	return &simRunner{
 		model:    model,
@@ -1313,7 +1313,7 @@ func (r *simRunner) doSummary(idx int, step SimStep) error {
 
 	// State overview
 	fmt.Fprintf(&sb, "**State**: typing=%v cancelled=%v inputReady=%v msgs=%d iterHist=%d queueLen=%d\n\n",
-		m.typing, m.turnCancelled, m.inputReady, len(m.messages), len(m.iterationHistory), len(m.messageQueue))
+		m.typing, m.turnCancelled, m.inputReady, len(m.messages), len(m.progressState.iterations), len(m.messageQueue))
 
 	// Messages table (max 20 rows, with summary for overflow)
 	if len(m.messages) > 0 {
@@ -1990,16 +1990,16 @@ func (r *simRunner) dumpState() *SimModelSnapshot {
 		InputReady:    m.inputReady,
 		AgentTurnID:   m.agentTurnID,
 		MessageCount:  len(m.messages),
-		IterHistCount: len(m.iterationHistory),
-		LastSeenIter:  m.lastSeenIteration,
+		IterHistCount: len(m.progressState.iterations),
+		LastSeenIter:  m.progressState.lastIter,
 		RemoteMode:    m.remoteMode,
 		QueueLen:      len(m.messageQueue),
 		ViewportAtTop: m.viewport.AtTop(),
 		ViewportAtBot: m.viewport.AtBottom(),
 		TotalLines:    m.viewport.TotalLineCount(),
 	}
-	if m.progress != nil {
-		snap.ProgressPhase = m.progress.Phase
+	if m.progressState.current != nil {
+		snap.ProgressPhase = m.progressState.current.Phase
 	}
 	return snap
 }
@@ -2013,12 +2013,12 @@ func (r *simRunner) dumpVars() map[string]any {
 		"turnCancelled":     m.turnCancelled,
 		"inputReady":        m.inputReady,
 		"agentTurnID":       m.agentTurnID,
-		"lastSeenIteration": m.lastSeenIteration,
+		"lastSeenIteration": m.progressState.lastIter,
 		"messageCount":      len(m.messages),
-		"iterHistCount":     len(m.iterationHistory),
+		"iterHistCount":     len(m.progressState.iterations),
 		"remoteMode":        m.remoteMode,
 		"queueLen":          len(m.messageQueue),
-		"splashDone":        m.splashDone,
+		"splashDone":        m.splashState.done,
 		"ready":             m.ready,
 		"userScrolledUp":    m.userScrolledUp,
 		"newContentHint":    m.newContentHint,

--- a/channel/cli/cli_slash.go
+++ b/channel/cli/cli_slash.go
@@ -65,14 +65,14 @@ func (m *cliModel) handleSlashCommand(cmd string) tea.Cmd {
 						}
 					}
 				}
-				m.panelIsSetup = false // regular settings, not setup wizard
+				m.panelState.isSetup = false // regular settings, not setup wizard
 				m.openSettingsPanel(schema, currentValues, func(values map[string]string) {
 					// --- ch.Subscription generation guard ---
 					// If the active subscription changed since this panel was opened,
 					// the per-subscription LLM fields (provider/key/model/base_url) are STALE
 					// and must NOT be written back — they would overwrite the new subscription.
 					// This is the structural guarantee against subscription data corruption.
-					if m.panelSubGeneration != m.subGeneration {
+					if m.panelState.subGeneration != m.subGeneration {
 						for k := range values {
 							if isSubscriptionScopedSettingKey(k) {
 								delete(values, k)
@@ -304,7 +304,7 @@ func (m *cliModel) handleSlashCommand(cmd string) tea.Cmd {
 			if m.recordVersionHit() {
 				art := fmt.Sprintf(versionAchievementArt, version.Version)
 				_ = m.activateEasterEgg(easterEggVersion)
-				m.easterEggCustom = art
+				m.easterEggState.customArt = art
 				m.updateViewportContent()
 				return nil
 			}

--- a/channel/cli/cli_test.go
+++ b/channel/cli/cli_test.go
@@ -306,7 +306,7 @@ func TestCLIModelHandleResizeMinimum(t *testing.T) {
 
 func TestCLIModelHandleResizeWithProgress(t *testing.T) {
 	model := newCLIModel()
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.current = &protocol.ProgressEvent{
 		Phase: "tool_exec",
 		ActiveTools: []protocol.ToolProgress{
 			{Name: "test", Label: "Testing"},
@@ -334,7 +334,7 @@ func TestCLIModelViewNotReady(t *testing.T) {
 
 func TestCLIModelViewReady(t *testing.T) {
 	model := newCLIModel()
-	model.splashDone = true
+	model.splashState.done = true
 	model.handleResize(80, 24)
 
 	view := model.View()
@@ -345,7 +345,7 @@ func TestCLIModelViewReady(t *testing.T) {
 
 func TestCLIModelViewWithTyping(t *testing.T) {
 	model := newCLIModel()
-	model.splashDone = true
+	model.splashState.done = true
 	model.handleResize(80, 24)
 	model.typing = true
 
@@ -358,7 +358,7 @@ func TestCLIModelViewWithTyping(t *testing.T) {
 func TestCLIModelViewWithProgress(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.current = &protocol.ProgressEvent{
 		Phase:     "thinking",
 		Iteration: 1,
 	}
@@ -371,7 +371,7 @@ func TestCLIModelViewWithProgress(t *testing.T) {
 
 func TestCLIModelViewWithMessages(t *testing.T) {
 	model := newCLIModel()
-	model.splashDone = true
+	model.splashState.done = true
 	model.handleResize(80, 24)
 	model.messages = []cliMessage{
 		{role: "user", content: "Hello", timestamp: time.Now()},
@@ -570,7 +570,7 @@ func TestCLIModelHandleAgentMessageEmptyContent(t *testing.T) {
 	model.handleResize(80, 24)
 
 	// Simulate active progress state
-	model.progress = &protocol.ProgressEvent{Phase: "thinking"}
+	model.progressState.current = &protocol.ProgressEvent{Phase: "thinking"}
 	model.typing = true
 
 	msg := channel.OutboundMsg{
@@ -584,7 +584,7 @@ func TestCLIModelHandleAgentMessageEmptyContent(t *testing.T) {
 	if len(model.messages) != 0 {
 		t.Fatalf("Expected 0 messages, got %d", len(model.messages))
 	}
-	if model.progress != nil {
+	if model.progressState.current != nil {
 		t.Error("Expected progress to be cleared")
 	}
 	if model.typing {
@@ -688,11 +688,11 @@ func TestCLIModelUpdateProgressMsg(t *testing.T) {
 
 	_, _ = model.Update(progMsg)
 
-	if model.progress == nil {
+	if model.progressState.current == nil {
 		t.Error("Progress should be set after cliProgressMsg")
 	}
-	if model.progress.Phase != "thinking" {
-		t.Errorf("Progress phase = %q, want 'thinking'", model.progress.Phase)
+	if model.progressState.current.Phase != "thinking" {
+		t.Errorf("Progress phase = %q, want 'thinking'", model.progressState.current.Phase)
 	}
 }
 
@@ -703,7 +703,7 @@ func TestCLIModelUpdateProgressDone(t *testing.T) {
 	model.chatID = "/test"
 
 	// Set initial progress
-	model.progress = &protocol.ProgressEvent{Phase: "thinking", ChatID: "cli:/test"}
+	model.progressState.current = &protocol.ProgressEvent{Phase: "thinking", ChatID: "cli:/test"}
 
 	// Send done progress
 	progMsg := cliProgressMsg{
@@ -716,7 +716,7 @@ func TestCLIModelUpdateProgressDone(t *testing.T) {
 	_, _ = model.Update(progMsg)
 
 	// Progress should be cleared when phase is "done"
-	if model.progress != nil {
+	if model.progressState.current != nil {
 		t.Error("Progress should be nil after done phase")
 	}
 }
@@ -739,7 +739,7 @@ func TestCLIModelStaleProgressIgnored(t *testing.T) {
 
 	// Scenario 1: After Ctrl+C (typing=false, turnCancelled=true), progress is ignored
 	model.typing = false
-	model.progress = nil
+	model.progressState.current = nil
 	model.turnCancelled = true
 
 	progMsg := cliProgressMsg{
@@ -753,7 +753,7 @@ func TestCLIModelStaleProgressIgnored(t *testing.T) {
 	model.channelName = "cli"
 	model.handleProgressMsg(progMsg)
 
-	if model.progress != nil {
+	if model.progressState.current != nil {
 		t.Error("Progress after Ctrl+C should be ignored when turnCancelled=true")
 	}
 
@@ -772,7 +772,7 @@ func TestCLIModelStaleProgressIgnored(t *testing.T) {
 		},
 	})
 
-	if model2.progress != nil {
+	if model2.progressState.current != nil {
 		t.Error("Progress for a different session should be ignored")
 	}
 
@@ -803,7 +803,7 @@ func TestCLIModelStaleProgressIgnored(t *testing.T) {
 	if !model3.typing {
 		t.Error("Auto-start should fire when turnCancelled=false and typing=false")
 	}
-	if model3.progress == nil {
+	if model3.progressState.current == nil {
 		t.Error("Progress should be set after auto-start")
 	}
 }
@@ -839,7 +839,7 @@ func TestGlobalTickUpdatesSpinnerAndProgress(t *testing.T) {
 
 	// Simulate an active agent turn.
 	model.typing = true
-	model.progress = &protocol.ProgressEvent{Phase: "thinking"}
+	model.progressState.current = &protocol.ProgressEvent{Phase: "thinking"}
 
 	// cliTickMsg from the global goroutine should advance spinner
 	// and NOT panic or return errors.
@@ -854,10 +854,10 @@ func TestGlobalTickAdvancesSplashAnimation(t *testing.T) {
 	model.handleResize(80, 24)
 
 	// Splash not done — tick should advance splashFrame.
-	model.splashDone = false
+	model.splashState.done = false
 	model.Update(cliTickMsg{})
-	if model.splashFrame != 1 {
-		t.Fatalf("expected splashFrame=1, got %d", model.splashFrame)
+	if model.splashState.frame != 1 {
+		t.Fatalf("expected splashFrame=1, got %d", model.splashState.frame)
 	}
 }
 
@@ -969,7 +969,7 @@ func TestCLIModelRenderProgressStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.phase, func(t *testing.T) {
-			model.progress = &protocol.ProgressEvent{Phase: tt.phase}
+			model.progressState.current = &protocol.ProgressEvent{Phase: tt.phase}
 			result := model.renderProgressStatus()
 			if !strings.Contains(result, tt.expected) {
 				t.Errorf("renderProgressStatus(%s) should contain %q, got %q",
@@ -982,7 +982,7 @@ func TestCLIModelRenderProgressStatus(t *testing.T) {
 func TestCLIModelRenderProgressStatusNil(t *testing.T) {
 	model := newCLIModel()
 	model.locale = channel.GetLocale("en")
-	model.progress = nil
+	model.progressState.current = nil
 
 	result := model.renderProgressStatus()
 	if !strings.Contains(result, "Thinking") {
@@ -992,7 +992,7 @@ func TestCLIModelRenderProgressStatusNil(t *testing.T) {
 
 func TestCLIModelRenderProgressStatusWithIteration(t *testing.T) {
 	model := newCLIModel()
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.current = &protocol.ProgressEvent{
 		Phase:     "thinking",
 		Iteration: 5,
 	}
@@ -1006,7 +1006,7 @@ func TestCLIModelRenderProgressStatusWithIteration(t *testing.T) {
 
 func TestCLIModelRenderProgressStatusWithActiveTools(t *testing.T) {
 	model := newCLIModel()
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.current = &protocol.ProgressEvent{
 		Phase:       "tool_exec",
 		Iteration:   1,
 		ActiveTools: []protocol.ToolProgress{{Name: "read", Label: "Reading file", Elapsed: 100}},
@@ -1023,7 +1023,7 @@ func TestCLIModelRenderProgressStatusWithActiveTools(t *testing.T) {
 
 func TestCLIModelRenderProgressStatusToolWithoutLabel(t *testing.T) {
 	model := newCLIModel()
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.current = &protocol.ProgressEvent{
 		Phase:       "tool_exec",
 		Iteration:   1,
 		ActiveTools: []protocol.ToolProgress{{Name: "read", Label: "", Elapsed: 0}},
@@ -1039,7 +1039,7 @@ func TestCLIModelRenderProgressStatusToolWithoutLabel(t *testing.T) {
 
 func TestCLIModelRenderProgressStatusWithElapsed(t *testing.T) {
 	model := newCLIModel()
-	model.progress = &protocol.ProgressEvent{Phase: "thinking"}
+	model.progressState.current = &protocol.ProgressEvent{Phase: "thinking"}
 	model.typingStartTime = time.Now().Add(-5 * time.Second)
 
 	result := model.renderProgressStatus()
@@ -1056,7 +1056,7 @@ func TestCLIModelRenderProgressBlockEmpty(t *testing.T) {
 	model := newCLIModel()
 	model.handleResize(80, 24)
 	model.typing = false
-	model.progress = nil
+	model.progressState.current = nil
 
 	result := model.renderProgressBlock()
 	if result != "" {
@@ -1090,7 +1090,7 @@ func TestCLIModelRenderProgressBlockWithTools(t *testing.T) {
 	model.handleResize(80, 24)
 	model.startAgentTurn()
 	model.typingStartTime = time.Now()
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.current = &protocol.ProgressEvent{
 		Phase:     "tool_exec",
 		Iteration: 1,
 		ActiveTools: []protocol.ToolProgress{
@@ -1110,7 +1110,7 @@ func TestCLIModelRenderProgressBlockWithTools(t *testing.T) {
 	if model.streamingMsgIdx < 0 {
 		t.Error("streamingMsgIdx should be set")
 	}
-	if model.progress == nil {
+	if model.progressState.current == nil {
 		t.Error("progress should be set")
 	}
 }
@@ -1120,7 +1120,7 @@ func TestCLIModelRenderProgressBlockWithIterationHistory(t *testing.T) {
 	model.handleResize(80, 24)
 	model.startAgentTurn()
 	model.typingStartTime = time.Now()
-	model.iterationHistory = []cliIterationSnapshot{
+	model.progressState.iterations = []cliIterationSnapshot{
 		{
 			Iteration: 0,
 			Thinking:  "Analyzing requirements",
@@ -1129,7 +1129,7 @@ func TestCLIModelRenderProgressBlockWithIterationHistory(t *testing.T) {
 			},
 		},
 	}
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.current = &protocol.ProgressEvent{
 		Phase:     "thinking",
 		Iteration: 1,
 	}
@@ -1143,7 +1143,7 @@ func TestCLIModelRenderProgressBlockWithIterationHistory(t *testing.T) {
 	if model.streamingMsgIdx < 0 {
 		t.Error("streamingMsgIdx should be set")
 	}
-	if len(model.iterationHistory) == 0 {
+	if len(model.progressState.iterations) == 0 {
 		t.Error("iterationHistory should have entries")
 	}
 }
@@ -1153,7 +1153,7 @@ func TestCLIModelRenderProgressBlockSubAgents(t *testing.T) {
 	model.handleResize(80, 24)
 	model.startAgentTurn()
 	model.typingStartTime = time.Now()
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.current = &protocol.ProgressEvent{
 		Phase:     "tool_exec",
 		Iteration: 0,
 		SubAgents: []protocol.SubAgentInfo{
@@ -1172,7 +1172,7 @@ func TestCLIModelRenderProgressBlockSubAgents(t *testing.T) {
 	if model.streamingMsgIdx < 0 {
 		t.Error("streamingMsgIdx should be set")
 	}
-	if model.progress == nil || len(model.progress.SubAgents) != 3 {
+	if model.progressState.current == nil || len(model.progressState.current.SubAgents) != 3 {
 		t.Error("progress should have subagent data")
 	}
 }
@@ -1182,7 +1182,7 @@ func TestCLIModelRenderProgressBlockSubAgentChildren(t *testing.T) {
 	model.handleResize(80, 24)
 	model.typing = true
 	model.typingStartTime = time.Now()
-	model.progress = &protocol.ProgressEvent{
+	model.progressState.current = &protocol.ProgressEvent{
 		Phase:     "tool_exec",
 		Iteration: 0,
 		SubAgents: []protocol.SubAgentInfo{
@@ -1610,8 +1610,8 @@ func TestCLIModelIterationAccumulation(t *testing.T) {
 		ChatID:    "cli:/test",
 	}}
 	model.Update(prog0)
-	if len(model.iterationHistory) != 0 {
-		t.Errorf("Expected 0 history entries, got %d", len(model.iterationHistory))
+	if len(model.progressState.iterations) != 0 {
+		t.Errorf("Expected 0 history entries, got %d", len(model.progressState.iterations))
 	}
 
 	// Iteration 0: tool_exec with completed tools
@@ -1632,20 +1632,20 @@ func TestCLIModelIterationAccumulation(t *testing.T) {
 		ChatID:    "cli:/test",
 	}}
 	model.Update(prog1)
-	if len(model.iterationHistory) != 1 {
-		t.Fatalf("Expected 1 history entry after iteration change, got %d", len(model.iterationHistory))
+	if len(model.progressState.iterations) != 1 {
+		t.Fatalf("Expected 1 history entry after iteration change, got %d", len(model.progressState.iterations))
 	}
-	if model.iterationHistory[0].Iteration != 0 {
-		t.Errorf("History[0].Iteration = %d, want 0", model.iterationHistory[0].Iteration)
+	if model.progressState.iterations[0].Iteration != 0 {
+		t.Errorf("History[0].Iteration = %d, want 0", model.progressState.iterations[0].Iteration)
 	}
-	if len(model.iterationHistory[0].Tools) != 1 {
-		t.Errorf("History[0].Tools count = %d, want 1", len(model.iterationHistory[0].Tools))
+	if len(model.progressState.iterations[0].Tools) != 1 {
+		t.Errorf("History[0].Tools count = %d, want 1", len(model.progressState.iterations[0].Tools))
 	}
 }
 
 func TestCLIModelCollectAllTools(t *testing.T) {
 	model := newCLIModel()
-	model.iterationHistory = []cliIterationSnapshot{
+	model.progressState.iterations = []cliIterationSnapshot{
 		{Iteration: 0, Tools: []protocol.ToolProgress{{Name: "a"}, {Name: "b"}}},
 		{Iteration: 1, Tools: []protocol.ToolProgress{{Name: "c"}}},
 	}
@@ -1657,17 +1657,17 @@ func TestCLIModelCollectAllTools(t *testing.T) {
 
 func TestCLIModelResetProgressState(t *testing.T) {
 	model := newCLIModel()
-	model.iterationHistory = []cliIterationSnapshot{{Iteration: 0}}
-	model.lastSeenIteration = 5
+	model.progressState.iterations = []cliIterationSnapshot{{Iteration: 0}}
+	model.progressState.lastIter = 5
 	model.typingStartTime = time.Now().Add(-10 * time.Second)
 
 	model.resetProgressState()
 
-	if model.iterationHistory != nil {
+	if model.progressState.iterations != nil {
 		t.Error("iterationHistory should be nil after reset")
 	}
-	if model.lastSeenIteration != 0 {
-		t.Errorf("lastSeenIteration = %d, want 0", model.lastSeenIteration)
+	if model.progressState.lastIter != 0 {
+		t.Errorf("lastSeenIteration = %d, want 0", model.progressState.lastIter)
 	}
 	if model.typingStartTime.IsZero() {
 		t.Error("typingStartTime should be set after reset")

--- a/channel/cli/cli_turn.go
+++ b/channel/cli/cli_turn.go
@@ -179,8 +179,8 @@ func (m *cliModel) startAgentTurn() {
 
 	// Show initial progress so the user sees immediate feedback (spinner)
 	// without waiting for the first progress_structured event.
-	if m.progress == nil {
-		m.progress = &protocol.ProgressEvent{
+	if m.progressState.current == nil {
+		m.progressState.current = &protocol.ProgressEvent{
 			Phase:     "thinking",
 			Iteration: 0,
 		}
@@ -217,7 +217,7 @@ func (m *cliModel) startAgentTurn() {
 //
 // When the agent turn is active, ch.ConvertMessagesToHistory produces a tool_summary
 // from intermediate assistant messages of the in-progress turn. The progress
-// block (m.progress + m.iterationHistory) owns iteration display for the active
+// block (m.progressState.current + m.progressState.iterations) owns iteration display for the active
 // turn — the static tool_summary from ch.ConvertMessagesToHistory would duplicate
 // content with mismatched (globally-cumulative vs per-turn) iteration numbers.
 //
@@ -230,7 +230,7 @@ func (m *cliModel) startAgentTurn() {
 //
 // When the agent turn is active, ch.ConvertMessagesToHistory produces a tool_summary
 // from intermediate assistant messages of the in-progress turn. The progress
-// block (m.progress + m.iterationHistory) owns iteration display for the active
+// block (m.progressState.current + m.progressState.iterations) owns iteration display for the active
 // turn — the static tool_summary from ch.ConvertMessagesToHistory would duplicate
 // content with mismatched (globally-cumulative vs per-turn) iteration numbers.
 //
@@ -283,22 +283,22 @@ func (m *cliModel) endAgentTurn(turnID uint64) {
 	// a new turn's streaming message when a delayed complete message arrives.
 	m.streamingMsgIdx = -1
 	// Persist token usage for ready-status bar before clearing progress
-	if m.progress != nil {
-		m.cacheTokenUsage(m.progress.TokenUsage)
+	if m.progressState.current != nil {
+		m.cacheTokenUsage(m.progressState.current.TokenUsage)
 	}
 	m.lastCompletedTools = nil
-	m.iterationHistory = nil
+	m.progressState.iterations = nil
 	m.rc.invalidateProgress()
-	m.lastSeenIteration = 0
+	m.progressState.lastIter = 0
 	m.lastReasoning = ""
 	m.reasoningByIter = nil
 	m.lastThinking = ""
 	m.typingStartTime = time.Time{}
-	m.progress = nil
-	m.twVisible = 0
-	m.rwVisible = 0
+	m.progressState.current = nil
+	m.progressState.twVisible = 0
+	m.progressState.rwVisible = 0
 	m.typing = false
-	m.typewriterTickActive = false
+	m.progressState.twActive = false
 	// Clear pending user message: the turn completed, so the user's message
 	// has been persisted to DB. Keeping it set would cause handleHistoryReload
 	// (after /compress) to restore the stale message from a pre-compress turn.

--- a/channel/cli/cli_update.go
+++ b/channel/cli/cli_update.go
@@ -157,7 +157,7 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 
 	// §12 Panel mode: intercept all key events when panel is active
 	// NOTE: Ctrl+C is handled at the top of Update() — never intercept it here.
-	if key, ok := msg.(tea.KeyPressMsg); ok && m.panelMode != "" {
+	if key, ok := msg.(tea.KeyPressMsg); ok && m.panelState.mode != "" {
 		handled, newModel, cmd := m.updatePanel(key)
 		if handled {
 			return newModel, cmd
@@ -166,30 +166,30 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 	// §12b Panel mode: intercept paste events — PasteMsg is not KeyPressMsg,
 	// so it bypasses the above panel interceptor and would be captured by the
 	// main textarea below. Forward it to the panel's internal textarea instead.
-	if paste, ok := msg.(tea.PasteMsg); ok && m.panelMode != "" {
+	if paste, ok := msg.(tea.PasteMsg); ok && m.panelState.mode != "" {
 		var cmd tea.Cmd
-		switch m.panelMode {
+		switch m.panelState.mode {
 		case "askuser":
 			// Check if current tab has options (use textinput) or free input (use textarea)
-			if m.panelTab >= 0 && m.panelTab < len(m.panelItems) && len(m.panelItems[m.panelTab].Options) > 0 {
-				m.panelOtherTI, cmd = m.panelOtherTI.Update(paste)
+			if m.panelState.askTab >= 0 && m.panelState.askTab < len(m.panelState.askItems) && len(m.panelState.askItems[m.panelState.askTab].Options) > 0 {
+				m.panelState.askOtherTI, cmd = m.panelState.askOtherTI.Update(paste)
 			} else {
 				m.autoExpandAskTA()
-				m.panelAnswerTA, cmd = m.panelAnswerTA.Update(paste)
+				m.panelState.askAnswerTA, cmd = m.panelState.askAnswerTA.Update(paste)
 			}
 		case "settings":
-			if m.panelEdit {
-				m.panelEditTA, cmd = m.panelEditTA.Update(paste)
+			if m.panelState.editing {
+				m.panelState.editTA, cmd = m.panelState.editTA.Update(paste)
 			}
 		case "wizard":
-			if m.wizardStep == wizardAPIKey {
-				m.wizardKeyTI, cmd = m.wizardKeyTI.Update(paste)
+			if m.panelState.wizardStep == wizardAPIKey {
+				m.panelState.wizardKeyTI, cmd = m.panelState.wizardKeyTI.Update(paste)
 			}
 		}
 		return m, cmd
 	}
 	// §21 搜索模式拦截
-	if key, ok := msg.(tea.KeyPressMsg); ok && m.searchMode {
+	if key, ok := msg.(tea.KeyPressMsg); ok && m.searchState.mode {
 		model, cmd, handled := m.handleSearchKey(key)
 		if handled {
 			return model, cmd
@@ -248,7 +248,7 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 		// will be forwarded to viewport/textarea at the end of Update().
 
 	case tea.KeyPressMsg:
-		if m.settingsSaving {
+		if m.panelState.settingsSaving {
 			break // block input while settings are being saved
 		}
 		model, keyCmds, handled := m.handleKeyPress(msg, wasTyping)
@@ -280,7 +280,7 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 		// suLoading guard: during session switch, handleSuHistoryLoad
 		// manages typing/progress state. WS session state updates would
 		// conflict with the authoritative RPC snapshot.
-		if !m.suLoading {
+		if !m.splashState.suLoading {
 			if msg.processing && !m.typing {
 				m.startAgentTurn()
 			} else if !msg.processing && m.typing {
@@ -445,7 +445,7 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 
 	case easterEggMatrixTickMsg:
 		// 🥚 Matrix 代码雨动画帧推进
-		if m.easterEgg == easterEggMatrix {
+		if m.easterEggState.mode == easterEggMatrix {
 			m.tickMatrix()
 			cmds = append(cmds, matrixTickCmd())
 		}
@@ -559,8 +559,8 @@ func (m *cliModel) layoutViewportHeight() int {
 	height := m.height
 	fixedLines := 3 // titleBar + status + footer
 
-	if m.panelMode != "" {
-		if m.panelMode == "askuser" {
+	if m.panelState.mode != "" {
+		if m.panelState.mode == "askuser" {
 			// AskUser split layout: viewport stays visible above the panel.
 			// Calculate panel content height, cap it, let viewport take the rest.
 			askContent := m.viewAskUserPanel()
@@ -710,7 +710,7 @@ func (m *cliModel) handleResize(width, height int) {
 	// §20 重建样式缓存
 	m.styles = buildStyles(width)
 	// Invalidate again after style rebuild (sidebar styles may have changed)
-	m.cachedSidebarRenderedWidth = 0
+	m.layoutConfig.cachedSBWidth = 0
 
 	// Refresh widget render function with new styles and re-render all widgets
 	if m.widgetRegistry != nil {

--- a/channel/cli/cli_update_progress.go
+++ b/channel/cli/cli_update_progress.go
@@ -11,7 +11,7 @@ import (
 // restoreIterationHistory converts IterationHistory from a reconnect snapshot
 // into local iteration history, bootstrapping tool StartedAt timestamps.
 func (m *cliModel) restoreIterationHistory(payload *protocol.ProgressEvent) {
-	if payload == nil || len(payload.IterationHistory) == 0 || len(m.iterationHistory) > 0 {
+	if payload == nil || len(payload.IterationHistory) == 0 || len(m.progressState.iterations) > 0 {
 		return
 	}
 	for _, ih := range payload.IterationHistory {
@@ -27,12 +27,12 @@ func (m *cliModel) restoreIterationHistory(payload *protocol.ProgressEvent) {
 				t.StartedAt = time.Now().Add(-time.Duration(t.Elapsed) * time.Millisecond)
 			}
 		}
-		m.iterationHistory = append(m.iterationHistory, snap)
+		m.progressState.iterations = append(m.progressState.iterations, snap)
 	}
-	if len(m.iterationHistory) > 0 {
-		lastIter := m.iterationHistory[len(m.iterationHistory)-1].Iteration
-		if lastIter > m.lastSeenIteration {
-			m.lastSeenIteration = lastIter
+	if len(m.progressState.iterations) > 0 {
+		lastIter := m.progressState.iterations[len(m.progressState.iterations)-1].Iteration
+		if lastIter > m.progressState.lastIter {
+			m.progressState.lastIter = lastIter
 		}
 	}
 }
@@ -40,7 +40,7 @@ func (m *cliModel) restoreIterationHistory(payload *protocol.ProgressEvent) {
 // carryForwardProgressState preserves transient state across progress updates
 // (StartedAt timers, CompletedTools, Reasoning/Thinking content, SubAgent trees).
 func (m *cliModel) carryForwardProgressState(prev *protocol.ProgressEvent) {
-	if m.progress == nil {
+	if m.progressState.current == nil {
 		return
 	}
 
@@ -53,8 +53,8 @@ func (m *cliModel) carryForwardProgressState(prev *protocol.ProgressEvent) {
 			}
 		}
 	}
-	for i := range m.progress.ActiveTools {
-		t := &m.progress.ActiveTools[i]
+	for i := range m.progressState.current.ActiveTools {
+		t := &m.progressState.current.ActiveTools[i]
 		if sa, ok := startedAtMap[t.Name]; ok {
 			t.StartedAt = sa
 		} else if t.StartedAt.IsZero() {
@@ -69,19 +69,19 @@ func (m *cliModel) carryForwardProgressState(prev *protocol.ProgressEvent) {
 	if prev == nil {
 		return
 	}
-	sameIter := m.progress.Iteration == prev.Iteration || m.progress.Iteration == 0
+	sameIter := m.progressState.current.Iteration == prev.Iteration || m.progressState.current.Iteration == 0
 
 	// Carry forward CompletedTools from previous progress within the same iteration.
-	if len(m.progress.CompletedTools) == 0 && len(prev.CompletedTools) > 0 && sameIter {
-		m.progress.CompletedTools = prev.CompletedTools
+	if len(m.progressState.current.CompletedTools) == 0 && len(prev.CompletedTools) > 0 && sameIter {
+		m.progressState.current.CompletedTools = prev.CompletedTools
 	}
 
 	// Carry forward Reasoning/Thinking content.
-	if m.progress.Reasoning == "" && prev.Reasoning != "" && sameIter {
-		m.progress.Reasoning = prev.Reasoning
+	if m.progressState.current.Reasoning == "" && prev.Reasoning != "" && sameIter {
+		m.progressState.current.Reasoning = prev.Reasoning
 	}
-	if m.progress.Thinking == "" && prev.Thinking != "" && sameIter {
-		m.progress.Thinking = prev.Thinking
+	if m.progressState.current.Thinking == "" && prev.Thinking != "" && sameIter {
+		m.progressState.current.Thinking = prev.Thinking
 	}
 
 	// Carry forward StreamContent within the same iteration.
@@ -91,9 +91,9 @@ func (m *cliModel) carryForwardProgressState(prev *protocol.ProgressEvent) {
 	// Skip when Thinking is already set — it contains the same finalized content
 	// and carrying StreamContent forward would cause duplicate rendering
 	// (renderLiveIteration renders both fields separately).
-	if prev.StreamContent != "" && m.progress.StreamContent == "" && sameIter {
-		if m.progress.Thinking == "" {
-			m.progress.StreamContent = prev.StreamContent
+	if prev.StreamContent != "" && m.progressState.current.StreamContent == "" && sameIter {
+		if m.progressState.current.Thinking == "" {
+			m.progressState.current.StreamContent = prev.StreamContent
 		}
 	}
 
@@ -101,9 +101,9 @@ func (m *cliModel) carryForwardProgressState(prev *protocol.ProgressEvent) {
 	// Guard: only when StreamContent is also empty — reasoning stream is the
 	// LLM's internal thinking; once the actual text response (StreamContent)
 	// starts, reasoning stream from the previous progress shouldn't reappear.
-	if m.progress.ReasoningStreamContent == "" && prev.ReasoningStreamContent != "" && sameIter {
-		if m.progress.StreamContent == "" {
-			m.progress.ReasoningStreamContent = prev.ReasoningStreamContent
+	if m.progressState.current.ReasoningStreamContent == "" && prev.ReasoningStreamContent != "" && sameIter {
+		if m.progressState.current.StreamContent == "" {
+			m.progressState.current.ReasoningStreamContent = prev.ReasoningStreamContent
 		}
 	}
 
@@ -117,18 +117,18 @@ func (m *cliModel) carryForwardProgressState(prev *protocol.ProgressEvent) {
 	//   - Completed SubAgents stay completed (don't revert to "running")
 	//   - New SubAgents get added
 	//   - SubAgents no longer in the server's tree get removed
-	iterationChanged := m.progress.Iteration != prev.Iteration && m.progress.Iteration > 0
+	iterationChanged := m.progressState.current.Iteration != prev.Iteration && m.progressState.current.Iteration > 0
 	if iterationChanged {
-		m.progress.SubAgents = nil
-	} else if len(m.progress.SubAgents) > 0 {
+		m.progressState.current.SubAgents = nil
+	} else if len(m.progressState.current.SubAgents) > 0 {
 		// New progress has SubAgent data — merge into previous tree to preserve
 		// completion status for agents no longer reported by the server.
-		m.progress.SubAgents = mergeSubAgentTrees(prev.SubAgents, m.progress.SubAgents)
+		m.progressState.current.SubAgents = mergeSubAgentTrees(prev.SubAgents, m.progressState.current.SubAgents)
 	} else if len(prev.SubAgents) > 0 {
 		// No new SubAgent data — carry forward previous tree, but filter out
 		// agents that were already done in prev. Done agents have already been
 		// displayed to the user and should not linger across subsequent updates.
-		m.progress.SubAgents = pruneDoneSubAgents(prev.SubAgents)
+		m.progressState.current.SubAgents = pruneDoneSubAgents(prev.SubAgents)
 	}
 }
 
@@ -155,15 +155,15 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 	}
 
 	turnID := m.agentTurnID // capture before any mutation
-	prev := m.progress
+	prev := m.progressState.current
 
 	// Seq monotonic check: discard out-of-order or duplicate progress events.
 	// Placed after ChatID filtering, before any state mutation.
 	if msg.payload != nil && msg.payload.Seq > 0 {
-		if msg.payload.Seq <= m.lastProgressSeq {
+		if msg.payload.Seq <= m.progressState.lastSeq {
 			return
 		}
-		m.lastProgressSeq = msg.payload.Seq
+		m.progressState.lastSeq = msg.payload.Seq
 	}
 
 	// New turn's first non-PhaseDone progress clears the cancel flag.
@@ -191,7 +191,7 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 	// turn is paused (not ended). Late progress events from the engine must not
 	// trigger startAgentTurn → resetProgressState, which clears iterationHistory
 	// and makes all previous iterations disappear.
-	if !m.typing && !m.suLoading && !m.compressionReloading && msg.payload != nil && msg.payload.Phase != "done" && m.panelMode != "askuser" {
+	if !m.typing && !m.splashState.suLoading && !m.splashState.compReloading && msg.payload != nil && msg.payload.Phase != "done" && m.panelState.mode != "askuser" {
 		log.WithFields(log.Fields{
 			"phase":     msg.payload.Phase,
 			"iteration": msg.payload.Iteration,
@@ -205,15 +205,15 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 	// non-PhaseDone progress events. Only PhaseDone is allowed through
 	// (to clear stale turn state). All other events are stale — the RPC
 	// (handleSuHistoryLoad) will reconcile with authoritative server data.
-	if m.suLoading && msg.payload != nil && msg.payload.Phase != "done" {
+	if m.splashState.suLoading && msg.payload != nil && msg.payload.Phase != "done" {
 		return
 	}
 	// suLoading + PhaseDone: server confirmed the turn is done.
 	// Record this so handleSuHistoryLoad won't restore stale progress
 	// as active (which would create a stuck spinner — typing=true with
 	// no more progress events coming from the idle server).
-	if m.suLoading && msg.payload != nil && msg.payload.Phase == "done" {
-		m.suPhaseDoneConfirmed = true
+	if m.splashState.suLoading && msg.payload != nil && msg.payload.Phase == "done" {
+		m.splashState.suPhaseConfirmed = true
 	}
 
 	// Stream-only payloads (from StreamContentFunc/StreamReasoningFunc) only carry
@@ -223,47 +223,47 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 		msg.payload.Phase == "" && msg.payload.Iteration == 0 &&
 		(msg.payload.StreamContent != "" || msg.payload.ReasoningStreamContent != "")
 	if isStreamOnly {
-		if m.progress != nil {
+		if m.progressState.current != nil {
 			if msg.payload.StreamContent != "" {
-				m.progress.StreamContent = msg.payload.StreamContent
+				m.progressState.current.StreamContent = msg.payload.StreamContent
 			}
 			if msg.payload.ReasoningStreamContent != "" {
-				m.progress.ReasoningStreamContent = msg.payload.ReasoningStreamContent
+				m.progressState.current.ReasoningStreamContent = msg.payload.ReasoningStreamContent
 			}
 			// Refresh lastTokenUsage from current progress so the context bar
 			// stays visible even when structured events are lost to progressCh
 			// coalescing (stream-only events evicting structured events).
-			m.cacheTokenUsage(m.progress.TokenUsage)
+			m.cacheTokenUsage(m.progressState.current.TokenUsage)
 		} else if m.typing {
 			// Turn started but no structured progress yet — create minimal payload
-			if msg.payload.CWD == "" && m.progress != nil {
-				msg.payload.CWD = m.progress.CWD
+			if msg.payload.CWD == "" && m.progressState.current != nil {
+				msg.payload.CWD = m.progressState.current.CWD
 			}
 			// Preserve CWD from previous progress if new payload doesn't have it.
-			if msg.payload.CWD == "" && m.progress != nil {
-				msg.payload.CWD = m.progress.CWD
+			if msg.payload.CWD == "" && m.progressState.current != nil {
+				msg.payload.CWD = m.progressState.current.CWD
 			}
 			// Preserve CWD from previous progress if new payload doesn't have it.
-			if msg.payload.CWD == "" && m.progress != nil {
-				msg.payload.CWD = m.progress.CWD
+			if msg.payload.CWD == "" && m.progressState.current != nil {
+				msg.payload.CWD = m.progressState.current.CWD
 			}
-			m.progress = msg.payload
+			m.progressState.current = msg.payload
 		}
 		return
 	}
-	// Structured (non-stream-only) payload: replace m.progress.
+	// Structured (non-stream-only) payload: replace m.progressState.current.
 	// Carrying forward stream content (same-iteration only) is handled by
 	// carryForwardProgressState below — the single source of truth for all
 	// carry-forward logic.
 	if msg.payload == nil {
-		m.progress = nil
+		m.progressState.current = nil
 		return
 	}
 	// Preserve CWD from previous progress if new payload doesn't have it.
-	if msg.payload.CWD == "" && m.progress != nil {
-		msg.payload.CWD = m.progress.CWD
+	if msg.payload.CWD == "" && m.progressState.current != nil {
+		msg.payload.CWD = m.progressState.current.CWD
 	}
-	m.progress = msg.payload
+	m.progressState.current = msg.payload
 
 	if m.cachedMaxContextTokens == 0 {
 		m.cachedMaxContextTokens = m.resolveMaxContextTokens()
@@ -276,7 +276,7 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 	}
 
 	// Restore iteration history from reconnect/GetActiveProgress snapshot.
-	m.restoreIterationHistory(m.progress)
+	m.restoreIterationHistory(m.progressState.current)
 
 	m.carryForwardProgressState(prev)
 
@@ -287,8 +287,8 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 	// 1. Progress panel shows fresh iterations (starting from #0)
 	// 2. User message from parent agent appears in message list (from DB)
 	// This must run BEFORE snapshotIterationChange, which skips iterations
-	// that are <= m.lastSeenIteration.
-	if m.progress != nil && prev != nil && m.progress.Iteration < m.lastSeenIteration && m.lastSeenIteration > 0 && m.typing {
+	// that are <= m.progressState.lastIter.
+	if m.progressState.current != nil && prev != nil && m.progressState.current.Iteration < m.progressState.lastIter && m.progressState.lastIter > 0 && m.typing {
 		// Snapshot the old turn's final state before resetting.
 		// Use the current agentTurnID since we're ending the current turn.
 		m.endAgentTurn(m.agentTurnID)
@@ -319,9 +319,9 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 		// event from the pre-compression iteration can arrive after clearing
 		// and re-insert old iterationHistory as a tool_summary message, causing
 		// the TUI to show extra content that doesn't exist after restart.
-		m.iterationHistory = nil
+		m.progressState.iterations = nil
 		m.reasoningByIter = nil
-		m.lastSeenIteration = 0
+		m.progressState.lastIter = 0
 		m.lastReasoning = ""
 		m.lastThinking = ""
 		m.invalidateAllCache(true)
@@ -330,7 +330,7 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 		// events from the post-compression iteration trigger auto-start,
 		// creating a streaming message that gets wiped by handleHistoryReload's
 		// forceFullRebuild path — losing the streaming state and stalling TUI.
-		m.compressionReloading = true
+		m.splashState.compReloading = true
 		// Do NOT GotoBottom here — compression can happen while the user
 		// is scrolled up reading old content. Forcing to bottom would
 		// lose their position. The subsequent reloadMessagesFromSession
@@ -342,8 +342,8 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 	// carries fresh token counts from the agent's updateTokenUsage().
 	// Must run after HistoryCompacted so the compressed estimate overwrites
 	// the nil set above, rather than being cleared by it.
-	if m.progress != nil {
-		m.cacheTokenUsage(m.progress.TokenUsage)
+	if m.progressState.current != nil {
+		m.cacheTokenUsage(m.progressState.current.TokenUsage)
 	}
 
 	if msg.payload != nil {
@@ -353,11 +353,11 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 		m.snapshotIterationChange(msg.payload, prev)
 
 		// Record per-iteration reasoning from structured progress.
-		if m.progress != nil && m.progress.Reasoning != "" && m.progress.Iteration >= 0 {
+		if m.progressState.current != nil && m.progressState.current.Reasoning != "" && m.progressState.current.Iteration >= 0 {
 			if m.reasoningByIter == nil {
 				m.reasoningByIter = make(map[int]string)
 			}
-			m.reasoningByIter[m.progress.Iteration] = m.progress.Reasoning
+			m.reasoningByIter[m.progressState.current.Iteration] = m.progressState.current.Reasoning
 		}
 
 		// §2 工具可视化：快照 CompletedTools 到独立字段
@@ -465,22 +465,22 @@ func (m *cliModel) snapshotIterationChange(payload *protocol.ProgressEvent, prev
 	if payload == nil {
 		return
 	}
-	if payload.Iteration > m.lastSeenIteration && m.lastSeenIteration >= 0 {
+	if payload.Iteration > m.progressState.lastIter && m.progressState.lastIter >= 0 {
 		// Guard: only create snapshot if prev actually belongs to lastSeenIteration.
 		// After session switch, resetProgressState sets lastSeenIteration=0 but
-		// the restored m.progress has Iteration=N. When the next live progress
+		// the restored m.progressState.current has Iteration=N. When the next live progress
 		// arrives, prev (which came from the restore) has Iteration=N, not 0.
 		// Snapshoting "iteration 0" with iteration N's data would cause #0 and #1
 		// to display the same reasoning content.
 		// Also guard against prev being nil (progress cleared by endAgentTurn).
-		if prev != nil && prev.Iteration != m.lastSeenIteration {
+		if prev != nil && prev.Iteration != m.progressState.lastIter {
 			// Data mismatch: prev belongs to a different iteration than what
 			// lastSeenIteration claims. Instead of discarding the snapshot
 			// entirely (which permanently loses iteration data), create a
 			// snapshot tagged with prev.Iteration (the actual iteration number).
 			// Guard against duplicate snapshots for the same iteration.
 			alreadySnapped := false
-			for _, snap := range m.iterationHistory {
+			for _, snap := range m.progressState.iterations {
 				if snap.Iteration == prev.Iteration {
 					alreadySnapped = true
 					break
@@ -503,13 +503,13 @@ func (m *cliModel) snapshotIterationChange(payload *protocol.ProgressEvent, prev
 						Thinking:    prev.Thinking,
 						Reasoning:   prevReasoning,
 						Tools:       prevIterTools,
-						ElapsedWall: time.Since(m.iterationStartTime).Milliseconds(),
+						ElapsedWall: time.Since(m.progressState.iterStart).Milliseconds(),
 					}
-					m.iterationHistory = append(m.iterationHistory, snap)
+					m.progressState.iterations = append(m.progressState.iterations, snap)
 				}
 			}
-			m.lastSeenIteration = payload.Iteration
-			m.iterationStartTime = time.Now()
+			m.progressState.lastIter = payload.Iteration
+			m.progressState.iterStart = time.Now()
 			return
 		}
 		if prev != nil {
@@ -523,25 +523,25 @@ func (m *cliModel) snapshotIterationChange(payload *protocol.ProgressEvent, prev
 			}
 			prevReasoning := prev.Reasoning
 			if prevReasoning == "" {
-				prevReasoning = m.reasoningByIter[m.lastSeenIteration]
+				prevReasoning = m.reasoningByIter[m.progressState.lastIter]
 			}
 			if prevReasoning == "" {
 				prevReasoning = prev.ReasoningStreamContent
 			}
 			if len(prevIterTools) > 0 || prev.Thinking != "" || prevReasoning != "" {
 				snap := cliIterationSnapshot{
-					Iteration:   m.lastSeenIteration,
+					Iteration:   m.progressState.lastIter,
 					Thinking:    prev.Thinking,
 					Reasoning:   prevReasoning,
 					Tools:       prevIterTools,
-					ElapsedWall: time.Since(m.iterationStartTime).Milliseconds(),
+					ElapsedWall: time.Since(m.progressState.iterStart).Milliseconds(),
 				}
-				m.iterationHistory = append(m.iterationHistory, snap)
+				m.progressState.iterations = append(m.progressState.iterations, snap)
 			}
 			m.lastCompletedTools = m.lastCompletedTools[:0]
 		}
-		m.lastSeenIteration = payload.Iteration
-		m.iterationStartTime = time.Now()
+		m.progressState.lastIter = payload.Iteration
+		m.progressState.iterStart = time.Now()
 	}
 }
 
@@ -558,9 +558,9 @@ func (m *cliModel) handleProgressDone(msg cliProgressMsg, prev *protocol.Progres
 		// Snapshot the final iteration (same logic as the non-cancelled path below).
 		// This is needed because snapshotIterationChange only fires on iteration
 		// *changes* (N→N+1), so a single-iteration turn won't have any snapshots yet.
-		if m.lastSeenIteration >= 0 {
-			alreadySnapped := slices.ContainsFunc(m.iterationHistory, func(s cliIterationSnapshot) bool {
-				return s.Iteration == m.lastSeenIteration
+		if m.progressState.lastIter >= 0 {
+			alreadySnapped := slices.ContainsFunc(m.progressState.iterations, func(s cliIterationSnapshot) bool {
+				return s.Iteration == m.progressState.lastIter
 			})
 			if !alreadySnapped {
 				var finalTools []protocol.ToolProgress
@@ -582,13 +582,13 @@ func (m *cliModel) handleProgressDone(msg cliProgressMsg, prev *protocol.Progres
 					}
 				}
 				snap := cliIterationSnapshot{
-					Iteration:   m.lastSeenIteration,
+					Iteration:   m.progressState.lastIter,
 					Thinking:    msg.payload.Thinking,
 					Tools:       finalTools,
-					ElapsedWall: time.Since(m.iterationStartTime).Milliseconds(),
+					ElapsedWall: time.Since(m.progressState.iterStart).Milliseconds(),
 				}
 				if m.reasoningByIter != nil {
-					snap.Reasoning = m.reasoningByIter[m.lastSeenIteration]
+					snap.Reasoning = m.reasoningByIter[m.progressState.lastIter]
 				}
 				if snap.Reasoning == "" {
 					snap.Reasoning = m.lastReasoning
@@ -597,7 +597,7 @@ func (m *cliModel) handleProgressDone(msg cliProgressMsg, prev *protocol.Progres
 					snap.Reasoning = msg.payload.Reasoning
 				}
 				if len(finalTools) > 0 || snap.Thinking != "" || snap.Reasoning != "" {
-					m.iterationHistory = append(m.iterationHistory, snap)
+					m.progressState.iterations = append(m.progressState.iterations, snap)
 				}
 			}
 		}
@@ -608,9 +608,9 @@ func (m *cliModel) handleProgressDone(msg cliProgressMsg, prev *protocol.Progres
 		// content rendered inline and expects it to remain visible.
 		if m.streamingMsgIdx >= 0 && m.streamingMsgIdx < len(m.messages) &&
 			m.messages[m.streamingMsgIdx].turnID == turnID {
-			if len(m.iterationHistory) > 0 {
-				baked := make([]cliIterationSnapshot, len(m.iterationHistory))
-				copy(baked, m.iterationHistory)
+			if len(m.progressState.iterations) > 0 {
+				baked := make([]cliIterationSnapshot, len(m.progressState.iterations))
+				copy(baked, m.progressState.iterations)
 				m.messages[m.streamingMsgIdx].iterations = baked
 				m.messages[m.streamingMsgIdx].dirty = true
 			}
@@ -637,9 +637,9 @@ func (m *cliModel) handleProgressDone(msg cliProgressMsg, prev *protocol.Progres
 	// handleAgentMessage (e.g. agent error/cancel).
 	// Skip if handleAgentMessage already processed (m.typing == false
 	// means the reply arrived and cleaned up iteration state).
-	if m.typing && m.lastSeenIteration >= 0 {
-		alreadySnapped := slices.ContainsFunc(m.iterationHistory, func(s cliIterationSnapshot) bool {
-			return s.Iteration == m.lastSeenIteration
+	if m.typing && m.progressState.lastIter >= 0 {
+		alreadySnapped := slices.ContainsFunc(m.progressState.iterations, func(s cliIterationSnapshot) bool {
+			return s.Iteration == m.progressState.lastIter
 		})
 		if !alreadySnapped {
 			var finalTools []protocol.ToolProgress
@@ -664,16 +664,16 @@ func (m *cliModel) handleProgressDone(msg cliProgressMsg, prev *protocol.Progres
 				}
 			}
 			snap := cliIterationSnapshot{
-				Iteration:   m.lastSeenIteration,
+				Iteration:   m.progressState.lastIter,
 				Thinking:    msg.payload.Thinking,
 				Tools:       finalTools,
-				ElapsedWall: time.Since(m.iterationStartTime).Milliseconds(),
+				ElapsedWall: time.Since(m.progressState.iterStart).Milliseconds(),
 			}
 			// Carry over reasoning: priority is reasoningByIter (per-iteration, authoritative)
 			// > lastReasoning (captured before progress clear)
 			// > prev progress Reasoning (server-authoritative, from ReasoningContent)
 			// > PhaseDone payload Reasoning
-			reasoning := m.reasoningByIter[m.lastSeenIteration]
+			reasoning := m.reasoningByIter[m.progressState.lastIter]
 			if reasoning == "" {
 				reasoning = m.lastReasoning
 			}
@@ -685,13 +685,13 @@ func (m *cliModel) handleProgressDone(msg cliProgressMsg, prev *protocol.Progres
 			}
 			snap.Reasoning = reasoning
 			if len(finalTools) > 0 || snap.Thinking != "" || snap.Reasoning != "" {
-				m.iterationHistory = append(m.iterationHistory, snap)
+				m.progressState.iterations = append(m.progressState.iterations, snap)
 			}
 		}
 		// Store iterations in pendingToolSummary for handleAgentMessage
 		// to bake into the assistant message. Accumulate (not replace) to
 		// handle multiple PhaseDone events per logical turn (simulation tests).
-		if len(m.iterationHistory) > 0 {
+		if len(m.progressState.iterations) > 0 {
 			if m.pendingToolSummary == nil {
 				m.pendingToolSummary = &cliMessage{}
 			}
@@ -700,7 +700,7 @@ func (m *cliModel) handleProgressDone(msg cliProgressMsg, prev *protocol.Progres
 			for _, it := range m.pendingToolSummary.iterations {
 				existingIters[it.Iteration] = true
 			}
-			for _, it := range m.iterationHistory {
+			for _, it := range m.progressState.iterations {
 				if !existingIters[it.Iteration] {
 					m.pendingToolSummary.iterations = append(m.pendingToolSummary.iterations, it)
 				}

--- a/channel/cli/cli_update_session.go
+++ b/channel/cli/cli_update_session.go
@@ -25,16 +25,16 @@ func (m *cliModel) handleSessionStateMsg(msg cliSessionStateMsg) {
 	switch ev.Action {
 	case "busy":
 		// Main session started processing.
-		m.liveSessionStates[ev.ChatID] = &liveSessionState{busy: true}
+		m.progressState.liveStates[ev.ChatID] = &liveSessionState{busy: true}
 	case "idle":
 		// Main session finished processing.
 		// Explicitly mark as idle (not delete) — the 30s safety-net poll
 		// may return stale Busy=true from cache, so we need the override.
-		m.liveSessionStates[ev.ChatID] = &liveSessionState{busy: false}
+		m.progressState.liveStates[ev.ChatID] = &liveSessionState{busy: false}
 	case "subagent_started":
 		// SubAgent interactive session created.
 		key := "agent:" + ev.Role + "/" + ev.Instance
-		m.liveSessionStates[key] = &liveSessionState{
+		m.progressState.liveStates[key] = &liveSessionState{
 			busy:     true,
 			role:     ev.Role,
 			instance: ev.Instance,
@@ -46,7 +46,7 @@ func (m *cliModel) handleSessionStateMsg(msg cliSessionStateMsg) {
 		// SubAgent interactive session destroyed.
 		key := "agent:" + ev.Role + "/" + ev.Instance
 		// Explicitly mark as idle (not delete) — same reason as main session idle.
-		m.liveSessionStates[key] = &liveSessionState{
+		m.progressState.liveStates[key] = &liveSessionState{
 			busy:     false,
 			role:     ev.Role,
 			instance: ev.Instance,
@@ -80,7 +80,7 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 	}
 
 	// Only clear suLoading for the matching session.
-	m.suLoading = false
+	m.splashState.suLoading = false
 
 	if msg.err != nil {
 		m.showSystemMsg(fmt.Sprintf(m.locale.SuLoadFailed, msg.err), feedbackWarning)
@@ -94,7 +94,7 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 		// confirmation we cannot know the real turn state. Assuming idle is the
 		// safe fallback (prevents perpetual spinner from stuck typing=true).
 		m.typing = false
-		m.progress = nil
+		m.progressState.current = nil
 		m.inputReady = true
 	} else {
 		// Build a dedup set from existing messages.
@@ -157,7 +157,7 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 	// is stale. Skip acceptProgress to avoid restoring a stuck spinner.
 	var cmds []tea.Cmd
 	var acceptProgress bool
-	if !m.suPhaseDoneConfirmed && msg.activeProgress != nil && msg.activeProgress.Phase != "done" {
+	if !m.splashState.suPhaseConfirmed && msg.activeProgress != nil && msg.activeProgress.Phase != "done" {
 		acceptProgress = true
 		// Cross-session guard: activeProgress from GetActiveProgress RPC
 		// should match the current session. If ChatID is set and doesn't
@@ -182,9 +182,9 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 		// from creating a spurious "iteration 0" snapshot on the next live
 		// progress event (symptom: #0 and #1 both show the same reasoning).
 		if msg.activeProgress.Iteration > 0 {
-			m.lastSeenIteration = msg.activeProgress.Iteration
+			m.progressState.lastIter = msg.activeProgress.Iteration
 		}
-		m.progress = msg.activeProgress
+		m.progressState.current = msg.activeProgress
 
 		// When an active turn is restored from the server snapshot, the
 		// last assistant message in DB history corresponds to the in-flight
@@ -257,15 +257,15 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 		}
 
 		// Restore StartedAt for active tools so live elapsed timers work.
-		for i := range m.progress.ActiveTools {
-			t := &m.progress.ActiveTools[i]
+		for i := range m.progressState.current.ActiveTools {
+			t := &m.progressState.current.ActiveTools[i]
 			if t.StartedAt.IsZero() && t.Elapsed > 0 {
 				t.StartedAt = time.Now().Add(-time.Duration(t.Elapsed) * time.Millisecond)
 			}
 		}
 
 		// Rebuild iteration history from server snapshot (authoritative).
-		m.iterationHistory = nil
+		m.progressState.iterations = nil
 		m.rc.invalidateProgress()
 		if len(msg.activeProgress.IterationHistory) > 0 {
 			for _, ih := range msg.activeProgress.IterationHistory {
@@ -281,12 +281,12 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 						t.StartedAt = time.Now().Add(-time.Duration(t.Elapsed) * time.Millisecond)
 					}
 				}
-				m.iterationHistory = append(m.iterationHistory, snap)
+				m.progressState.iterations = append(m.progressState.iterations, snap)
 			}
-			if len(m.iterationHistory) > 0 {
-				lastIter := m.iterationHistory[len(m.iterationHistory)-1].Iteration
-				if lastIter > m.lastSeenIteration {
-					m.lastSeenIteration = lastIter
+			if len(m.progressState.iterations) > 0 {
+				lastIter := m.progressState.iterations[len(m.progressState.iterations)-1].Iteration
+				if lastIter > m.progressState.lastIter {
+					m.progressState.lastIter = lastIter
 				}
 			}
 		}
@@ -296,8 +296,8 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 		// is 0 but IterationHistory is populated during SubAgent session
 		// switches (symptom: progress shows #0 while history shows
 		// correct #1, #2, ...).
-		if m.progress != nil && m.progress.Iteration <= 0 && len(m.iterationHistory) > 0 {
-			m.progress.Iteration = m.iterationHistory[len(m.iterationHistory)-1].Iteration
+		if m.progressState.current != nil && m.progressState.current.Iteration <= 0 && len(m.progressState.iterations) > 0 {
+			m.progressState.current.Iteration = m.progressState.iterations[len(m.progressState.iterations)-1].Iteration
 		}
 
 		// Emit a tickCmd to guarantee the fast tick chain is running.
@@ -305,10 +305,10 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 		// If the restored progress has stream or reasoning content, start the
 		// typewriter tick immediately. Without this, the cursor won't blink and
 		// streaming content won't animate until the next handleTickMsg cycle.
-		hasStream := m.progress != nil && m.progress.StreamContent != "" && m.twVisible < len([]rune(m.progress.StreamContent))
-		hasReasoning := m.progress != nil && m.progress.ReasoningStreamContent != "" && m.rwVisible < len([]rune(m.progress.ReasoningStreamContent))
-		if !m.typewriterTickActive && (hasStream || hasReasoning) {
-			m.typewriterTickActive = true
+		hasStream := m.progressState.current != nil && m.progressState.current.StreamContent != "" && m.progressState.twVisible < len([]rune(m.progressState.current.StreamContent))
+		hasReasoning := m.progressState.current != nil && m.progressState.current.ReasoningStreamContent != "" && m.progressState.rwVisible < len([]rune(m.progressState.current.ReasoningStreamContent))
+		if !m.progressState.twActive && (hasStream || hasReasoning) {
+			m.progressState.twActive = true
 			cmds = append(cmds, typewriterTickCmd())
 		}
 
@@ -323,8 +323,8 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 		// before this async handler runs, so endAgentTurn's typing guard above may
 		// not fire. But progress can still be non-nil → renderProgressBlock would
 		// show a phantom progress block.
-		if m.progress != nil {
-			m.progress = nil
+		if m.progressState.current != nil {
+			m.progressState.current = nil
 			m.rc.valid = false
 		}
 		// Server says session is idle — enable input.
@@ -465,7 +465,7 @@ func (m *cliModel) handleHistoryReload(msg cliHistoryReloadMsg) {
 	// of iterations where full rebuild would take seconds.
 	m.streamingMsgIdx = restoredStreamingIdx
 	// Compression reload complete — allow auto-start turn again.
-	m.compressionReloading = false
+	m.splashState.compReloading = false
 	if msg.forceFullRebuild {
 		m.messages = newMessages
 		m.invalidateAllCache(false)
@@ -473,7 +473,7 @@ func (m *cliModel) handleHistoryReload(msg cliHistoryReloadMsg) {
 		// iterations get a streaming message. Without this, progress
 		// updates only appear in the progress panel — new iteration
 		// tools never render in the message area, making TUI look frozen.
-		if !m.typing && m.progress != nil && m.progress.Phase != "done" && m.panelMode != "askuser" {
+		if !m.typing && m.progressState.current != nil && m.progressState.current.Phase != "done" && m.panelState.mode != "askuser" {
 			m.startAgentTurn()
 		}
 		m.updateViewportContent()
@@ -499,7 +499,7 @@ func (m *cliModel) handleHistoryReload(msg cliHistoryReloadMsg) {
 
 	// NOTE: do NOT call refreshTokenStateAfterReload() here.
 	// The HistoryCompacted handler in handleProgressMsg already calls
-	// cacheTokenUsage(m.progress.TokenUsage) synchronously, which sets
+	// cacheTokenUsage(m.progressState.current.TokenUsage) synchronously, which sets
 	// the compressed token count from the engine's progress event.
 	// refreshTokenStateAfterReload was an async DB read that could race:
 	// it reads the compressed value (e.g. 20k) from DB and sends

--- a/channel/cli/cli_update_turn.go
+++ b/channel/cli/cli_update_turn.go
@@ -17,12 +17,12 @@ import (
 func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Model, []tea.Cmd, bool) {
 
 	// 🥚 彩蛋覆盖层激活时，按任意键退出（Ctrl+C 除外，已在上面处理）
-	if m.easterEgg != easterEggNone {
+	if m.easterEggState.mode != easterEggNone {
 		return m, []tea.Cmd{func() tea.Msg { return easterEggDoneMsg{} }}, true
 	}
 
 	// 🥚 Konami Code 彩蛋：监听方向键和字母键
-	if m.easterEgg == easterEggNone {
+	if m.easterEggState.mode == easterEggNone {
 		konamiKey := ""
 		switch msg.Code {
 		case tea.KeyUp:
@@ -84,22 +84,22 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 
 	case msg.String() == "ctrl+p":
 		// Ctrl+P: Quick switch subscription
-		if m.panelMode == "" && m.subscriptionMgr != nil && !m.typing {
+		if m.panelState.mode == "" && m.subscriptionMgr != nil && !m.typing {
 			m.openQuickSwitch("subscription")
 			return m, nil, true
 		}
 
 	case msg.String() == "ctrl+t":
 		// Ctrl+T: Open Sessions panel (T = Tabs/Sessions)
-		if m.panelMode == "" {
+		if m.panelState.mode == "" {
 			m.openSessionsPanel()
 			return m, nil, true
 		}
 
 	case msg.String() == "ctrl+b":
 		// Ctrl+B: Toggle sidebar (only in wide mode)
-		if m.panelMode == "" && m.isWide() && m.sidebarEnabled {
-			m.sidebarVisible = !m.sidebarVisible
+		if m.panelState.mode == "" && m.isWide() && m.layoutConfig.sidebarEnabled {
+			m.layoutConfig.sidebarVisible = !m.layoutConfig.sidebarVisible
 			m.invalidateLayoutCache()
 			m.relayoutViewport()
 			return m, nil, true
@@ -109,7 +109,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 		// Cycle model (next in list)
 		// Uses Ctrl+N instead of Ctrl+M because Ctrl+M is indistinguishable
 		// from Enter on Windows VT Input Mode (Char=\r in both cases).
-		if m.panelMode == "" && !m.typing && m.channel != nil {
+		if m.panelState.mode == "" && !m.typing && m.channel != nil {
 			m.cycleModel()
 			// Drain pending cmds (e.g. showTempStatus timer) immediately
 			// to avoid an extra Update→View cycle on the next frame.
@@ -124,7 +124,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 	case msg.Text == "^":
 		// ^ opens bg tasks panel only when input is empty AND there are running tasks.
 		// Gate prevents intercepting the ^ character during normal typing.
-		if m.panelMode == "" && m.inputHistoryIdx == -1 && m.bgTaskCount > 0 {
+		if m.panelState.mode == "" && m.inputHistoryIdx == -1 && m.bgTaskCount > 0 {
 			m.openBgTasksPanel()
 			return m, nil, true
 		}
@@ -138,7 +138,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 	case msg.Code == tea.KeyUp:
 		// Plain ArrowUp: only viewport scroll (no queue recall / history).
 		// If textarea has content, let textarea own multiline vertical cursor movement.
-		if m.panelMode == "" && m.textarea.Value() != "" {
+		if m.panelState.mode == "" && m.textarea.Value() != "" {
 			break
 		}
 		// Viewport 不在底部时，方向键滚动 viewport
@@ -156,7 +156,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 
 	case msg.Code == tea.KeyDown:
 		// Plain ArrowDown: only viewport scroll.
-		if m.panelMode == "" && m.textarea.Value() != "" {
+		if m.panelState.mode == "" && m.textarea.Value() != "" {
 			break
 		}
 		if !m.viewport.AtBottom() {
@@ -186,10 +186,10 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 
 	case msg.String() == "ctrl+e":
 		// §19 Ctrl+E 切换长消息折叠（搜索导航模式下拦截）
-		if m.searchMode && !m.searchEditing {
+		if m.searchState.mode && !m.searchState.editing {
 			return m, nil, true
 		}
-		if !m.typing && !m.searchMode && len(m.messages) > 0 {
+		if !m.typing && !m.searchState.mode && len(m.messages) > 0 {
 			m.toggleMessageFold()
 		}
 		return m, nil, true
@@ -204,7 +204,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 func (m *cliModel) handleInjectedUserMsg(msg cliInjectedUserMsg) []tea.Cmd {
 	// suLoading guard: during session switch in remote mode, discard injected messages.
 	// They belong to the previous session's context; the RPC will handle state.
-	if m.suLoading {
+	if m.splashState.suLoading {
 		log.WithFields(log.Fields{"msg_chat_id": msg.chatID}).Debug("handleInjectedUserMsg: suLoading, discarding (session switch in progress)")
 		return nil
 	}
@@ -279,7 +279,7 @@ func (m *cliModel) handleUpdateCheck(msg cliUpdateCheckMsg) {
 	// The notice would corrupt the progress panel layout and distract from
 	// the active iteration history the user needs to see.
 	// The notice is still stored in m.updateNotice for manual /update check.
-	if m.typing || (m.progress != nil && m.progress.Phase != "done" && m.progress.Phase != "") {
+	if m.typing || (m.progressState.current != nil && m.progressState.current.Phase != "done" && m.progressState.current.Phase != "") {
 		return
 	}
 	if msg.info.HasUpdate {
@@ -298,12 +298,12 @@ func (m *cliModel) handleUpdateCheck(msg cliUpdateCheckMsg) {
 // handleToastMsg enqueues a toast notification.
 func (m *cliModel) handleToastMsg(msg cliToastMsg) []tea.Cmd {
 	// §16 Toast 通知入队（最多保留 5 条，显示前 3 条）
-	if len(m.toasts) >= 5 {
-		m.toasts = m.toasts[len(m.toasts)-4:]
+	if len(m.toastState.queue) >= 5 {
+		m.toastState.queue = m.toastState.queue[len(m.toastState.queue)-4:]
 	}
-	m.toasts = append(m.toasts, cliToastItem(msg))
-	if !m.toastTimer {
-		m.toastTimer = true
+	m.toastState.queue = append(m.toastState.queue, cliToastItem(msg))
+	if !m.toastState.timerActive {
+		m.toastState.timerActive = true
 		return []tea.Cmd{tea.Tick(3*time.Second, func(time.Time) tea.Msg {
 			return cliToastClearMsg{}
 		})}
@@ -313,15 +313,15 @@ func (m *cliModel) handleToastMsg(msg cliToastMsg) []tea.Cmd {
 
 // handleToastClear removes the oldest toast notification.
 func (m *cliModel) handleToastClear(msg cliToastClearMsg) []tea.Cmd {
-	if len(m.toasts) > 0 {
-		m.toasts = m.toasts[1:]
+	if len(m.toastState.queue) > 0 {
+		m.toastState.queue = m.toastState.queue[1:]
 	}
-	if len(m.toasts) > 0 {
+	if len(m.toastState.queue) > 0 {
 		return []tea.Cmd{tea.Tick(3*time.Second, func(time.Time) tea.Msg {
 			return cliToastClearMsg{}
 		})}
 	}
-	m.toastTimer = false
+	m.toastState.timerActive = false
 	return nil
 }
 
@@ -338,10 +338,10 @@ func (m *cliModel) handleCtrlC() (tea.Model, tea.Cmd, bool) {
 	if m.rewindMode {
 		m.closeRewindPanel()
 	}
-	if m.panelMode != "" {
+	if m.panelState.mode != "" {
 		m.closePanel()
 	}
-	if m.searchMode {
+	if m.searchState.mode {
 		m.exitSearch()
 	}
 	// 2. 取消正在编辑的排队消息
@@ -399,16 +399,16 @@ func (m *cliModel) handleTickMsg() []tea.Cmd {
 	var cmds []tea.Cmd
 
 	// Splash / suLoading animation — data-ready driven, no artificial delay.
-	if !m.splashDone || m.suLoading {
-		m.splashFrame++
+	if !m.splashState.done || m.splashState.suLoading {
+		m.splashState.frame++
 		// End splash as soon as model is ready and RPC loading is done.
-		if !m.suLoading && m.ready {
-			m.splashDone = true
+		if !m.splashState.suLoading && m.ready {
+			m.splashState.done = true
 		}
 		// Hard limit: ~3s (30 frames × 100ms) UNCONDITIONAL — safety net
 		// if RPC hangs. User sees the UI instead of staring at splash forever.
-		if m.splashFrame >= 30 {
-			m.splashDone = true
+		if m.splashState.frame >= 30 {
+			m.splashState.done = true
 		}
 	}
 
@@ -419,9 +419,9 @@ func (m *cliModel) handleTickMsg() []tea.Cmd {
 	}
 
 	// Spinner / progress update
-	sessionActive := m.progress != nil && m.progress.Phase != "done"
+	sessionActive := m.progressState.current != nil && m.progressState.current.Phase != "done"
 	busy := m.typing || sessionActive
-	needsSpinnerTick := busy || m.sidebarHasBusySessions
+	needsSpinnerTick := busy || m.progressState.busySessions
 
 	// Refresh bg task / agent counts every tick so the infobar and sidebar
 	// stay accurate even when the agent is idle (no progress messages flowing).
@@ -437,24 +437,24 @@ func (m *cliModel) handleTickMsg() []tea.Cmd {
 
 	if (m.bgTaskCount > 0) || (m.agentCount > 0) || needsSpinnerTick {
 		m.ticker.tick()
-		hasStreamContent := m.progress != nil && m.progress.StreamContent != "" && m.twVisible < len([]rune(m.progress.StreamContent))
-		hasReasoningContent := m.progress != nil && m.progress.ReasoningStreamContent != "" && m.rwVisible < len([]rune(m.progress.ReasoningStreamContent))
+		hasStreamContent := m.progressState.current != nil && m.progressState.current.StreamContent != "" && m.progressState.twVisible < len([]rune(m.progressState.current.StreamContent))
+		hasReasoningContent := m.progressState.current != nil && m.progressState.current.ReasoningStreamContent != "" && m.progressState.rwVisible < len([]rune(m.progressState.current.ReasoningStreamContent))
 		if hasStreamContent || hasReasoningContent {
-			if !m.typewriterTickActive {
-				m.typewriterTickActive = true
+			if !m.progressState.twActive {
+				m.progressState.twActive = true
 				cmds = append(cmds, typewriterTickCmd())
 			}
 		}
 		m.updateViewportContent()
 	} else {
-		m.typewriterTickActive = false
+		m.progressState.twActive = false
 		if !m.rc.valid || countsChanged {
 			m.updateViewportContent()
 		}
 	}
 
 	// Queue flush
-	if m.needFlushQueue && !m.typing && !m.suLoading && len(m.messageQueue) > 0 {
+	if m.needFlushQueue && !m.typing && !m.splashState.suLoading && len(m.messageQueue) > 0 {
 		prevTurnID := m.agentTurnID
 		canFlush := m.isTurnReplyReceived(prevTurnID)
 		if !canFlush && m.isTurnDoneProcessed(prevTurnID) && m.turnCancelled {
@@ -476,7 +476,7 @@ func (m *cliModel) handleTickMsg() []tea.Cmd {
 	}
 
 	// Idle: placeholder rotation (every 30 ticks = ~3s)
-	if !busy && !needsSpinnerTick && m.splashDone {
+	if !busy && !needsSpinnerTick && m.splashState.done {
 		m.idleTickCounter++
 		if m.idleTickCounter >= 30 {
 			m.idleTickCounter = 0
@@ -498,12 +498,12 @@ func (m *cliModel) handleTypewriterTick() []tea.Cmd {
 	m.advanceTypewriter()
 	m.updateViewportContent()
 	// Continue chain if still behind on either stream or reasoning content
-	streamBehind := m.progress != nil && m.progress.StreamContent != "" && m.twVisible < len([]rune(m.progress.StreamContent))
-	reasoningBehind := m.progress != nil && m.progress.ReasoningStreamContent != "" && m.rwVisible < len([]rune(m.progress.ReasoningStreamContent))
-	if m.typewriterTickActive && (streamBehind || reasoningBehind) {
+	streamBehind := m.progressState.current != nil && m.progressState.current.StreamContent != "" && m.progressState.twVisible < len([]rune(m.progressState.current.StreamContent))
+	reasoningBehind := m.progressState.current != nil && m.progressState.current.ReasoningStreamContent != "" && m.progressState.rwVisible < len([]rune(m.progressState.current.ReasoningStreamContent))
+	if m.progressState.twActive && (streamBehind || reasoningBehind) {
 		cmds = append(cmds, typewriterTickCmd())
 	} else {
-		m.typewriterTickActive = false
+		m.progressState.twActive = false
 	}
 	return cmds
 }
@@ -512,28 +512,28 @@ func (m *cliModel) handleTypewriterTick() []tea.Cmd {
 func (m *cliModel) handleSplashDone() []tea.Cmd {
 	var cmds []tea.Cmd
 	// §14 启动画面结束确认
-	m.splashDone = true
+	m.splashState.done = true
 	// Remote mode: retry model name fetch — the initial call in cli.go:76
 	// may have failed if the WS RPC wasn't fully ready yet.
 	if m.cachedModelName == "" && m.remoteMode {
 		m.refreshCachedModelName()
 	}
-	_ = m.progress // sessionActive computed for future use
+	_ = m.progressState.current // sessionActive computed for future use
 	return cmds
 }
 
 // handleApprovalRequest shows the approval dialog for a permission request.
 func (m *cliModel) handleApprovalRequest(msg approvalRequestMsg) (tea.Model, tea.Cmd) {
 	// Permission control: show approval dialog
-	m.approvalRequest = &msg.request
-	m.approvalResultCh = msg.resultCh
-	m.approvalCursor = 0 // default to Approve
-	m.approvalEnteringDeny = false
-	m.approvalDenyInput = textinput.New()
-	m.approvalDenyInput.Placeholder = "Optional deny reason for LLM"
-	m.approvalDenyInput.CharLimit = 200
-	m.approvalDenyInput.SetWidth(60)
-	m.panelMode = "approval"
+	m.panelState.approvalReq = &msg.request
+	m.panelState.approvalCh = msg.resultCh
+	m.panelState.approvalCursor = 0 // default to Approve
+	m.panelState.approvalDenyMode = false
+	m.panelState.approvalDenyTA = textinput.New()
+	m.panelState.approvalDenyTA.Placeholder = "Optional deny reason for LLM"
+	m.panelState.approvalDenyTA.CharLimit = 200
+	m.panelState.approvalDenyTA.SetWidth(60)
+	m.panelState.mode = "approval"
 	m.rc.valid = false
 	return m, nil
 }
@@ -542,7 +542,7 @@ func (m *cliModel) handleApprovalRequest(msg approvalRequestMsg) (tea.Model, tea
 // Returns (model, cmd, handled). If handled is true, Update() returns immediately.
 func (m *cliModel) handleSearchKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {
 	switch {
-	case m.searchEditing:
+	case m.searchState.editing:
 		switch key.String() {
 		case "enter":
 			m.executeSearch()
@@ -552,14 +552,14 @@ func (m *cliModel) handleSearchKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd, boo
 			return m, nil, true
 		}
 		var cmd tea.Cmd
-		m.searchTI, cmd = m.searchTI.Update(key)
+		m.searchState.ti, cmd = m.searchState.ti.Update(key)
 		return m, cmd, true
 	default:
 		switch key.String() {
 		case "n":
-			if len(m.searchResults) > 0 {
-				next := m.searchIdx + 1
-				if next >= len(m.searchResults) {
+			if len(m.searchState.results) > 0 {
+				next := m.searchState.idx + 1
+				if next >= len(m.searchState.results) {
 					next = 0
 				}
 				m.jumpToSearchResult(next)
@@ -568,10 +568,10 @@ func (m *cliModel) handleSearchKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd, boo
 			}
 			return m, nil, true
 		case "N":
-			if len(m.searchResults) > 0 {
-				prev := m.searchIdx - 1
+			if len(m.searchState.results) > 0 {
+				prev := m.searchState.idx - 1
 				if prev < 0 {
-					prev = len(m.searchResults) - 1
+					prev = len(m.searchState.results) - 1
 				}
 				m.jumpToSearchResult(prev)
 				m.rc.valid = false
@@ -681,14 +681,14 @@ func (m *cliModel) handleShiftUp() (tea.Model, []tea.Cmd, bool) {
 	// Shift+Up: recall queued message for editing / browse input history.
 	// When actively browsing history (inputHistoryIdx >= 0), allow continued
 	// scrolling even though textarea has content (from the previous history entry).
-	if m.panelMode == "" && m.textarea.Value() != "" && m.inputHistoryIdx < 0 {
+	if m.panelState.mode == "" && m.textarea.Value() != "" && m.inputHistoryIdx < 0 {
 		return m, nil, true
 	}
 	if !m.viewport.AtBottom() {
 		return m, nil, true
 	}
 	// §Q 消息队列：typing 时 Shift+↑ 追回最后一条排队消息编辑
-	if m.panelMode == "" && m.typing && !m.inputReady && len(m.messageQueue) > 0 {
+	if m.panelState.mode == "" && m.typing && !m.inputReady && len(m.messageQueue) > 0 {
 		if !m.queueEditing && m.textarea.Value() == "" {
 			// 追回最后一条排队消息
 			m.queueEditing = true
@@ -698,7 +698,7 @@ func (m *cliModel) handleShiftUp() (tea.Model, []tea.Cmd, bool) {
 			return m, nil, true
 		}
 	}
-	if m.panelMode == "" && !m.typing {
+	if m.panelState.mode == "" && !m.typing {
 		// 空输入时浏览历史
 		if (m.textarea.Value() == "" || m.inputHistoryIdx >= 0) && len(m.inputHistory) > 0 {
 			if m.inputHistoryIdx == -1 {
@@ -719,13 +719,13 @@ func (m *cliModel) handleShiftUp() (tea.Model, []tea.Cmd, bool) {
 func (m *cliModel) handleShiftDown() (tea.Model, []tea.Cmd, bool) {
 	// Shift+Down: browse input history backwards.
 	// Only block when NOT in history browsing mode AND textarea has content.
-	if m.panelMode == "" && m.textarea.Value() != "" && m.inputHistoryIdx < 0 {
+	if m.panelState.mode == "" && m.textarea.Value() != "" && m.inputHistoryIdx < 0 {
 		return m, nil, true
 	}
 	if !m.viewport.AtBottom() {
 		return m, nil, true
 	}
-	if m.panelMode == "" && !m.typing && m.inputHistoryIdx >= 0 {
+	if m.panelState.mode == "" && !m.typing && m.inputHistoryIdx >= 0 {
 		if m.inputHistoryIdx > 0 {
 			m.inputHistoryIdx--
 			m.textarea.SetValue(m.inputHistory[m.inputHistoryIdx])

--- a/channel/cli/cli_view.go
+++ b/channel/cli/cli_view.go
@@ -25,11 +25,11 @@ import (
 // uses uniseg.StringWidth), then adds the screen layout offsets.
 func (m *cliModel) computeInputCursorScreenPos() (x, y int, ok bool) {
 	// Only compute for main layout where textarea is visible
-	if m.panelMode != "" || m.paletteOpen || m.quickSwitchMode != "" || m.rewindMode || m.searchMode {
+	if m.panelState.mode != "" || m.paletteOpen || m.quickSwitchMode != "" || m.rewindMode || m.searchState.mode {
 		return 0, 0, false
 	}
 	// Textarea is not rendered when settings are being saved
-	if m.settingsSaving {
+	if m.panelState.settingsSaving {
 		return 0, 0, false
 	}
 
@@ -68,7 +68,7 @@ func (m *cliModel) computeInputCursorScreenPos() (x, y int, ok bool) {
 	// --- Compute X (screen column) ---
 	// textarea.Cursor().X already includes: CharOffset + prompt + lineNumber + base border/padding.
 	// We need to add: xShift (sidebar) + InputBox border-left + InputBox padding-left.
-	x = m.xShift
+	x = m.layoutConfig.xShift
 	x += inputBox.GetBorderLeftSize() + inputBox.GetPaddingLeft()
 	x += taCur.X
 
@@ -96,41 +96,43 @@ func (m *cliModel) isNarrow() bool { return m.width < 60 }
 func (m *cliModel) isWide() bool { return m.width >= 120 }
 
 // sidebarShown returns true when the sidebar is currently rendered on screen.
-func (m *cliModel) sidebarShown() bool { return m.isWide() && m.sidebarEnabled && m.sidebarVisible }
+func (m *cliModel) sidebarShown() bool {
+	return m.isWide() && m.layoutConfig.sidebarEnabled && m.layoutConfig.sidebarVisible
+}
 
 // invalidateLayoutCache resets cached sidebar/chat width metrics.
 // Must be called on resize, sidebar toggle, sidebarWidth change, or theme change.
 func (m *cliModel) invalidateLayoutCache() {
-	m.cachedSidebarRenderedWidth = 0
-	m.cachedSidebarWidthKey = 0
-	m.cachedChatWidth = 0
-	m.cachedChatWidthKey = 0
+	m.layoutConfig.cachedSBWidth = 0
+	m.layoutConfig.cachedSBKey = 0
+	m.layoutConfig.cachedChatW = 0
+	m.layoutConfig.cachedChatKey = 0
 }
 
 // sidebarRenderedWidth returns the actual visual width of the sidebar after rendering.
 // This depends on character widths (e.g. RUNEWIDTH_EASTASIAN makes │ width=2),
 // so we measure it dynamically — but cache the result until layout changes.
 func (m *cliModel) sidebarRenderedWidth() int {
-	sw := m.sidebarWidth
+	sw := m.layoutConfig.sidebarWidth
 	if sw < 12 {
 		sw = 12
 	}
-	if m.cachedSidebarRenderedWidth > 0 && m.cachedSidebarWidthKey == sw {
-		return m.cachedSidebarRenderedWidth
+	if m.layoutConfig.cachedSBWidth > 0 && m.layoutConfig.cachedSBKey == sw {
+		return m.layoutConfig.cachedSBWidth
 	}
 	rendered := m.styles.SidebarBg.Width(sw).Height(1).Render("")
 	line := strings.Split(rendered, "\n")[0]
 	w := lipgloss.Width(line)
-	m.cachedSidebarRenderedWidth = w
-	m.cachedSidebarWidthKey = sw
+	m.layoutConfig.cachedSBWidth = w
+	m.layoutConfig.cachedSBKey = sw
 	return w
 }
 
 // chatWidth returns the effective width for the chat viewport, accounting for sidebar.
 // Result is cached until invalidateLayoutCache() is called.
 func (m *cliModel) chatWidth() int {
-	if m.cachedChatWidth > 0 && m.cachedChatWidthKey == m.width {
-		return m.cachedChatWidth
+	if m.layoutConfig.cachedChatW > 0 && m.layoutConfig.cachedChatKey == m.width {
+		return m.layoutConfig.cachedChatW
 	}
 	var w int
 	if m.sidebarShown() {
@@ -141,8 +143,8 @@ func (m *cliModel) chatWidth() int {
 	} else {
 		w = m.width
 	}
-	m.cachedChatWidth = w
-	m.cachedChatWidthKey = m.width
+	m.layoutConfig.cachedChatW = w
+	m.layoutConfig.cachedChatKey = m.width
 	return w
 }
 
@@ -167,7 +169,7 @@ func (m *cliModel) renderTitleBar() string {
 	titleLeft := m.titleText()
 	titleRight := m.locale.TitleHint
 	// Askuser panel: override titleRight with panel-specific hints (always visible)
-	if m.panelMode == "askuser" {
+	if m.panelState.mode == "askuser" {
 		titleRight = m.askUserTitleHints()
 	} else if m.updateNotice != nil && m.updateNotice.HasUpdate {
 		titleRight = fmt.Sprintf("%s→%s · /update · /help", m.updateNotice.Current, m.updateNotice.Latest)
@@ -208,7 +210,7 @@ func (m *cliModel) renderTitleBar() string {
 // which triggers CJK rendering bugs on Windows Terminal).
 func (m *cliModel) renderInputArea(borderColor color.Color) string {
 	// Show saving overlay instead of textarea while settings are being saved
-	if m.settingsSaving {
+	if m.panelState.settingsSaving {
 		w := m.chatWidth()
 		inputBoxStyle := m.styles.InputBox.BorderForeground(borderColor).Width(w - 4)
 		return inputBoxStyle.Render(lipgloss.NewStyle().Faint(true).Render("  ⏳ Saving settings..."))
@@ -321,11 +323,11 @@ func (m *cliModel) renderReadyStatus() string {
 // and input box.
 func (m *cliModel) layoutSearch(titleBar, input string) string {
 	var searchBar string
-	if m.searchEditing {
-		searchBar = m.styles.SearchBar.Render(m.searchTI.View())
+	if m.searchState.editing {
+		searchBar = m.styles.SearchBar.Render(m.searchState.ti.View())
 	} else {
 		searchBar = m.styles.SearchBar.Render(
-			fmt.Sprintf(m.locale.SearchNavFormat, m.searchQuery, m.searchIdx+1, len(m.searchResults)))
+			fmt.Sprintf(m.locale.SearchNavFormat, m.searchState.query, m.searchState.idx+1, len(m.searchState.results)))
 	}
 	return fmt.Sprintf("%s\n%s\n%s\n%s",
 		titleBar, m.viewport.View(), searchBar, input)
@@ -345,14 +347,14 @@ func (m *cliModel) layoutAskUser(titleBar string) string {
 		askVisibleH = 3
 	}
 	totalAskLines := len(askLines)
-	if m.askPanelScrollY+askVisibleH > totalAskLines {
-		m.askPanelScrollY = max(0, totalAskLines-askVisibleH)
+	if m.panelState.askScrollY+askVisibleH > totalAskLines {
+		m.panelState.askScrollY = max(0, totalAskLines-askVisibleH)
 	}
-	end := m.askPanelScrollY + askVisibleH
+	end := m.panelState.askScrollY + askVisibleH
 	if end > totalAskLines {
 		end = totalAskLines
 	}
-	visibleAsk := askLines[m.askPanelScrollY:end]
+	visibleAsk := askLines[m.panelState.askScrollY:end]
 	askContent := strings.Join(visibleAsk, "\n")
 	// Append scrollbar when content overflows
 	cw := m.chatWidth()
@@ -366,7 +368,7 @@ func (m *cliModel) layoutAskUser(titleBar string) string {
 		if contentWidth < 10 {
 			contentWidth = 10
 		}
-		askContent = m.applyScrollbar(askContent, contentWidth, totalAskLines, m.askPanelScrollY)
+		askContent = m.applyScrollbar(askContent, contentWidth, totalAskLines, m.panelState.askScrollY)
 	}
 	// Width(cw-2): text_area = cw-6. Without scrollbar, lines ≤ qWrapWidth(cw-7)
 	// fit (cw-7 < cw-6). With scrollbar, total = contentWidth(cw-7)+1 = cw-6 = text_area.
@@ -374,7 +376,7 @@ func (m *cliModel) layoutAskUser(titleBar string) string {
 	// Scroll indicator — mouse wheel or ↑↓ at edges scrolls content
 	scrollHint := ""
 	if totalAskLines > askVisibleH {
-		pct := (m.askPanelScrollY + askVisibleH) * 100 / totalAskLines
+		pct := (m.panelState.askScrollY + askVisibleH) * 100 / totalAskLines
 		scrollHint = m.styles.PanelDesc.Render(fmt.Sprintf(" [%d%%] ↕ scroll", pct))
 	}
 
@@ -396,7 +398,7 @@ func (m *cliModel) layoutAskUser(titleBar string) string {
 	if showSidebar {
 		availableH := m.height - 1 // minus titleBar
 		sidebar := m.renderSidebarForBlock(middleBlock, availableH)
-		if m.sidebarPosition == "right" {
+		if m.layoutConfig.sidebarPos == "right" {
 			return titleBar + "\n" + lipgloss.JoinHorizontal(lipgloss.Top, middleBlock, sidebar)
 		}
 		return titleBar + "\n" + lipgloss.JoinHorizontal(lipgloss.Top, sidebar, middleBlock)
@@ -414,14 +416,14 @@ func (m *cliModel) layoutPanel(titleBar string) string {
 	rawLines := strings.Split(rawContent, "\n")
 	visibleH := m.panelVisibleHeight()
 	totalLines := len(rawLines)
-	if m.panelScrollY+visibleH > totalLines {
-		m.panelScrollY = max(0, totalLines-visibleH)
+	if m.panelState.scrollY+visibleH > totalLines {
+		m.panelState.scrollY = max(0, totalLines-visibleH)
 	}
-	end := m.panelScrollY + visibleH
+	end := m.panelState.scrollY + visibleH
 	if end > totalLines {
 		end = totalLines
 	}
-	visible := rawLines[m.panelScrollY:end]
+	visible := rawLines[m.panelState.scrollY:end]
 	panelContent := strings.Join(visible, "\n")
 	// Append scrollbar when content overflows
 	if totalLines > visibleH && visibleH > 0 {
@@ -430,7 +432,7 @@ func (m *cliModel) layoutPanel(titleBar string) string {
 		if contentWidth < 10 {
 			contentWidth = 10
 		}
-		panelContent = m.applyScrollbar(panelContent, contentWidth, totalLines, m.panelScrollY)
+		panelContent = m.applyScrollbar(panelContent, contentWidth, totalLines, m.panelState.scrollY)
 	}
 	boxedContent := m.styles.PanelBox.Render(panelContent)
 	return fmt.Sprintf("%s\n%s%s",
@@ -443,7 +445,7 @@ func (m *cliModel) layoutPanel(titleBar string) string {
 func (m *cliModel) layoutMain(titleBar, input, completionsHint string) string {
 	// Render status bar
 	var status string
-	if m.typing || m.progress != nil {
+	if m.typing || m.progressState.current != nil {
 		thinkingStatusStyle := m.styles.ThinkingSt
 		status = thinkingStatusStyle.Render(m.renderProgressStatus())
 	} else if m.checkingUpdate {
@@ -521,7 +523,7 @@ func (m *cliModel) layoutMain(titleBar, input, completionsHint string) string {
 	// Sidebar: spans the full height of the middle section (viewport → infoBar)
 	if showSidebar {
 		sidebar := m.renderSidebarForBlock(middleBlock, m.height-len(topLines))
-		if m.sidebarPosition == "right" {
+		if m.layoutConfig.sidebarPos == "right" {
 			return strings.Join(topLines, "\n") + "\n" +
 				lipgloss.JoinHorizontal(lipgloss.Top, middleBlock, sidebar)
 		}
@@ -536,7 +538,7 @@ func (m *cliModel) layoutMain(titleBar, input, completionsHint string) string {
 // middle content block (viewport + status + footer + input).
 // The block string is used only to measure height via line counting.
 func (m *cliModel) renderSidebarForBlock(block string, availableH int) string {
-	sw := m.sidebarWidth
+	sw := m.layoutConfig.sidebarWidth
 	if sw < 12 {
 		sw = 12
 	}
@@ -560,14 +562,14 @@ func (m *cliModel) renderSidebarForBlock(block string, availableH int) string {
 
 	// --- Sessions (always shown, clickable) ---
 	sidebarSectionHeaders["sessions"] = 0
-	if m.sidebarCollapsedSections["sessions"] {
+	if m.layoutConfig.collapsedSects["sessions"] {
 		// Must reset tracking vars even when collapsed, otherwise stale
 		// zone data from the previous frame causes wrong click targets.
 		sidebarSessionLines = nil
 		sidebarDeleteXStart = nil
 		sidebarDeleteXEnd = nil
 		sidebarNewSessionY = -1
-		m.sidebarHasBusySessions = false
+		m.progressState.busySessions = false
 		blocks = append(blocks, m.renderSidebarSectionHeader("Sessions", true))
 	} else {
 		blocks = append(blocks, m.renderSidebarSessions(contentW))
@@ -575,7 +577,7 @@ func (m *cliModel) renderSidebarForBlock(block string, availableH int) string {
 
 	// --- Todo (when sidebar is visible, todo moves here from main view) ---
 	if len(m.todos) > 0 {
-		if m.sidebarCollapsedSections["todo"] {
+		if m.layoutConfig.collapsedSects["todo"] {
 			sidebarSectionHeaders["todo"] = nextBlockOffset(blocks)
 			blocks = append(blocks, m.renderSidebarSectionHeader("Todo", true))
 		} else {
@@ -588,7 +590,7 @@ func (m *cliModel) renderSidebarForBlock(block string, availableH int) string {
 
 	// --- Active tasks (only when something is running) ---
 	if m.bgTaskCount > 0 || m.agentCount > 0 {
-		if m.sidebarCollapsedSections["tasks"] {
+		if m.layoutConfig.collapsedSects["tasks"] {
 			sidebarSectionHeaders["tasks"] = nextBlockOffset(blocks)
 			blocks = append(blocks, m.renderSidebarSectionHeader("Tasks", true))
 			sidebarActiveSectionOffset = -1
@@ -645,7 +647,7 @@ func nextBlockOffset(blocks []string) int {
 
 func (m *cliModel) renderSidebarSessions(w int) string {
 	// Reset tracking
-	m.sidebarHasBusySessions = false
+	m.progressState.busySessions = false
 	sidebarSessionLines = nil
 	sidebarDeleteXStart = nil
 	sidebarDeleteXEnd = nil
@@ -706,13 +708,13 @@ func (m *cliModel) renderSidebarSessions(w int) string {
 			} else if s.Type == "agent" {
 				isBusy = s.Running
 				// Check live state for agent sessions
-				if ls, ok := m.liveSessionStates[s.ID]; ok {
+				if ls, ok := m.progressState.liveStates[s.ID]; ok {
 					isBusy = ls.busy
 				}
 			} else {
 				isBusy = s.Busy
 				// Live state takes priority for non-active main sessions
-				if ls, ok := m.liveSessionStates[s.ID]; ok {
+				if ls, ok := m.progressState.liveStates[s.ID]; ok {
 					isBusy = ls.busy
 				}
 			}
@@ -724,10 +726,10 @@ func (m *cliModel) renderSidebarSessions(w int) string {
 				icon = "●"
 				itemStyle = m.styles.SidebarActive
 				// Clear unread flag when user is viewing this session.
-				delete(m.unreadSessions, s.ID)
+				delete(m.progressState.unread, s.ID)
 			} else if isBusy {
 				// Non-active but busy: animated spinner.
-				m.sidebarHasBusySessions = true
+				m.progressState.busySessions = true
 				icon = m.ticker.viewFrames(sidebarSpinnerFrames, 3)
 				itemStyle = m.styles.SidebarBusy
 				// Clear unread when busy — a running session shows a spinner,
@@ -735,18 +737,18 @@ func (m *cliModel) renderSidebarSessions(w int) string {
 				// that briefly returns Running=false can set unread=true via
 				// the busy→idle transition below, and the flag persists even
 				// after the sessions list catches up and shows Running=true again.
-				delete(m.unreadSessions, s.ID)
-			} else if m.unreadSessions[s.ID] {
+				delete(m.progressState.unread, s.ID)
+			} else if m.progressState.unread[s.ID] {
 				// Non-active, idle, but has unread results.
 				icon = "✦"
 				itemStyle = m.styles.SidebarBusy
 			}
 			// Track busy→idle transitions to mark unread.
-			wasBusy := m.lastBusyStates[s.ID]
+			wasBusy := m.progressState.busyStates[s.ID]
 			if wasBusy && !isBusy && !isActive {
-				m.unreadSessions[s.ID] = true
+				m.progressState.unread[s.ID] = true
 			}
-			m.lastBusyStates[s.ID] = isBusy
+			m.progressState.busyStates[s.ID] = isBusy
 
 			labelPart := indent + " " + icon + " " + label
 			labelVisW := lipgloss.Width(labelPart)
@@ -1059,7 +1061,7 @@ func (m *cliModel) View() (v tea.View) {
 	m.mouseZones.reset()
 
 	// Splash screen
-	if !m.splashDone {
+	if !m.splashState.done {
 		v := tea.NewView(m.renderSplash())
 		v.AltScreen = true
 		return v
@@ -1071,14 +1073,14 @@ func (m *cliModel) View() (v tea.View) {
 	}
 
 	// Easter egg overlay
-	if m.easterEgg != easterEggNone {
+	if m.easterEggState.mode != easterEggNone {
 		v := tea.NewView(m.renderEasterEggOverlay())
 		v.AltScreen = true
 		return v
 	}
 
 	// /su loading
-	if m.suLoading {
+	if m.splashState.suLoading {
 		v := tea.NewView(m.renderSuLoading())
 		v.AltScreen = true
 		return v
@@ -1106,13 +1108,13 @@ func (m *cliModel) View() (v tea.View) {
 	// Layout selection + zone tracking
 	var content string
 	switch {
-	case m.searchMode:
+	case m.searchState.mode:
 		content = m.layoutSearch(titleBar, input)
 		m.trackMainLayoutZones(&m.mouseZones)
-	case m.panelMode == "askuser":
+	case m.panelState.mode == "askuser":
 		content = m.layoutAskUser(titleBar)
 		m.trackAskUserZones(&m.mouseZones)
-	case m.panelMode != "":
+	case m.panelState.mode != "":
 		content = m.layoutPanel(titleBar)
 		m.trackPanelZones(&m.mouseZones)
 	default:
@@ -1236,8 +1238,8 @@ func (m *cliModel) renderInfoBar() string {
 // "🏠 main workspace" for main workspace, "🌿 <name>" for worktree sessions.
 func (m *cliModel) renderWorkspaceIndicator() string {
 	cwd := ""
-	if m.progress != nil {
-		cwd = m.progress.CWD
+	if m.progressState.current != nil {
+		cwd = m.progressState.current.CWD
 	}
 
 	if cwd != "" && strings.Contains(cwd, ".xbot-worktrees") {
@@ -1396,7 +1398,7 @@ func (m *cliModel) titleText() string {
 // Keep it short — header width is limited and line wrap looks terrible.
 func (m *cliModel) askUserTitleHints() string {
 	hints := []string{"↑↓ select", "Space check", "Enter submit", "Esc cancel"}
-	if len(m.panelItems) > 1 {
+	if len(m.panelState.askItems) > 1 {
 		hints = append([]string{"←→ switch"}, hints...)
 	}
 	return strings.Join(hints, " · ")
@@ -1490,7 +1492,7 @@ func (m *cliModel) renderSplash() string {
 	lines = append(lines, "")
 
 	// 加载动画
-	frame := splashFrames[m.splashFrame%len(splashFrames)]
+	frame := splashFrames[m.splashState.frame%len(splashFrames)]
 	loadingText := loadingStyle.Render(fmt.Sprintf(m.locale.SplashLoading, frame))
 	lW := lipgloss.Width(loadingText)
 	lPad := (screenW - lW) / 2
@@ -1533,7 +1535,7 @@ func (m *cliModel) renderSuLoading() string {
 
 	// 居中内容
 	var lines []string
-	frame := splashFrames[m.splashFrame%len(splashFrames)]
+	frame := splashFrames[m.splashState.frame%len(splashFrames)]
 
 	// 切换目标提示
 	suText := descStyle.Render(fmt.Sprintf(m.locale.SuSwitching, m.senderID))
@@ -1724,15 +1726,15 @@ func init() {
 func (m *cliModel) renderFooter() string {
 	var hints []footerHint
 
-	if m.panelMode != "" {
+	if m.panelState.mode != "" {
 		// 面板打开时：显示面板相关快捷键
 		escLabel := m.locale.FooterClose
-		if len(m.panelStack) > 0 {
+		if len(m.panelState.stack) > 0 {
 			escLabel = m.locale.FooterBack
 		}
-		switch m.panelMode {
+		switch m.panelState.mode {
 		case "bgtasks":
-			if m.panelBgViewing {
+			if m.panelState.bgViewing {
 				hints = append(hints,
 					m.footerHintItem("PgUp/PgDn", m.locale.FooterScroll, "scroll"),
 					m.footerHintItem("Esc", m.locale.FooterBack, "esc"),
@@ -1759,7 +1761,7 @@ func (m *cliModel) renderFooter() string {
 				m.footerHintItem("Esc", escLabel, "esc"),
 			)
 		case "wizard":
-			switch m.wizardStep {
+			switch m.panelState.wizardStep {
 			case wizardAPIKey:
 				hints = append(hints,
 					m.footerHintItem("Enter/Ctrl+s", m.locale.WizardNextBtn, "enter"),
@@ -1911,11 +1913,11 @@ func (m *cliModel) renderProgressStatus() string {
 		sb.WriteString(" · ")
 	}
 
-	if m.progress != nil {
-		fmt.Fprintf(&sb, "#%d", m.progress.Iteration)
+	if m.progressState.current != nil {
+		fmt.Fprintf(&sb, "#%d", m.progressState.current.Iteration)
 
 		// Phase hint
-		switch m.progress.Phase {
+		switch m.progressState.current.Phase {
 		case "thinking":
 			sb.WriteString(" · " + m.pickVerb(m.ticker.ticks))
 		case "compressing":
@@ -1925,7 +1927,7 @@ func (m *cliModel) renderProgressStatus() string {
 		case "retrying":
 			sb.WriteString(" · " + m.locale.StatusRetrying)
 		default:
-			if len(m.progress.CompletedTools) > 0 {
+			if len(m.progressState.current.CompletedTools) > 0 {
 				sb.WriteString(" · " + m.locale.StatusDone)
 			}
 		}

--- a/channel/cli/cli_viewport.go
+++ b/channel/cli/cli_viewport.go
@@ -280,7 +280,7 @@ func (m *cliModel) updateViewportContent() {
 
 	// 快速路径：缓存有效 + 仅追加了新消息（无流式、无搜索）
 	// 只渲染新增的 dirty 消息并追加到 cachedHistory，跳过全量重建。
-	if m.rc.valid && m.streamingMsgIdx < 0 && !m.searchMode &&
+	if m.rc.valid && m.streamingMsgIdx < 0 && !m.searchState.mode &&
 		len(m.messages) > m.rc.msgCount {
 		m.appendNewMessagesToCache()
 		return
@@ -338,7 +338,7 @@ func (m *cliModel) updateStreamingOnly() {
 	// When there's no iteration data yet (turn just started, no progress arrived),
 	// fall back to the full renderMessage path. This is a brief transitional state
 	// that resolves within the first progress event.
-	hasIterData := len(m.iterationHistory) > 0 || m.progress != nil
+	hasIterData := len(m.progressState.iterations) > 0 || m.progressState.current != nil
 	if !hasIterData && len(msg.iterations) == 0 {
 		var sb strings.Builder
 		sb.WriteString(m.rc.history)
@@ -366,7 +366,7 @@ func (m *cliModel) updateStreamingOnly() {
 	// --- Render completed iterations (cached) ---
 	// Uses renderTurnBody(iterations, nil, ...) to get the exact same output
 	// as the full render path. Only re-renders when iteration count changes.
-	numCompleted := len(m.iterationHistory)
+	numCompleted := len(m.progressState.iterations)
 	var completedLines []string
 	completedMaxW := 0
 
@@ -377,7 +377,7 @@ func (m *cliModel) updateStreamingOnly() {
 	} else {
 		// Cache miss: render completed iterations and cache the result
 		if numCompleted > 0 {
-			bodyContent := m.renderTurnBody(m.iterationHistory, nil, contentWidth, "")
+			bodyContent := m.renderTurnBody(m.progressState.iterations, nil, contentWidth, "")
 			bodyContent = strings.TrimRight(bodyContent, "\n")
 			if bodyContent != "" {
 				for _, l := range strings.Split(bodyContent, "\n") {
@@ -402,13 +402,13 @@ func (m *cliModel) updateStreamingOnly() {
 	// only have tools (running tools should be continuous with completed tools).
 	var liveLines []string
 	liveMaxW := 0
-	if m.progress != nil {
-		liveBlocks := m.liveIterationBlocks(m.progress, contentWidth, msg.content)
+	if m.progressState.current != nil {
+		liveBlocks := m.liveIterationBlocks(m.progressState.current, contentWidth, msg.content)
 		liveContent := renderTurnBlocks(liveBlocks)
 		liveContent = strings.TrimRight(liveContent, "\n")
 		if liveContent != "" {
 			if len(completedLines) > 0 {
-				prevKind, hasPrev := lastIterationBlockKind(m.iterationHistory)
+				prevKind, hasPrev := lastIterationBlockKind(m.progressState.iterations)
 				nextKind, hasNext := firstTurnBlockKind(liveBlocks)
 				if hasPrev && hasNext && needsTurnBlockSeparator(prevKind, nextKind) {
 					liveLines = append(liveLines, guidePrefix) // blank guide line as separator

--- a/channel/cli/cli_wizard.go
+++ b/channel/cli/cli_wizard.go
@@ -41,7 +41,7 @@ func (m *cliModel) wizardProviderList() []ch.SettingOption {
 // --- Rendering ---
 
 func (m *cliModel) renderWizard() string {
-	switch m.wizardStep {
+	switch m.panelState.wizardStep {
 	case wizardLang:
 		return m.renderWizardLang()
 	case wizardProvider:
@@ -64,7 +64,7 @@ func (m *cliModel) renderWizardLang() string {
 	sb.WriteString("\n\n")
 
 	for i, opt := range wizardLangOptions {
-		if i == m.wizardLangSel {
+		if i == m.panelState.wizardLangSel {
 			sb.WriteString(m.wizardSelLine(opt.Label, w))
 		} else {
 			sb.WriteString(m.wizardUnselLine(opt.Label, w))
@@ -91,7 +91,7 @@ func (m *cliModel) renderWizardProvider() string {
 
 	opts := m.wizardProviderList()
 	for i, opt := range opts {
-		if i == m.wizardProvSel {
+		if i == m.panelState.wizardProvSel {
 			sb.WriteString(m.wizardSelLine(opt.Label, w))
 			if opt.Description != "" {
 				sb.WriteString("\n")
@@ -116,7 +116,7 @@ func (m *cliModel) renderWizardProvider() string {
 }
 
 func (m *cliModel) renderWizardAPIKey() string {
-	provider := m.panelValues["llm_provider"]
+	provider := m.panelState.values["llm_provider"]
 	providerLabel := provider
 	for _, opt := range m.wizardProviderList() {
 		if opt.Value == provider {
@@ -151,7 +151,7 @@ func (m *cliModel) renderWizardAPIKey() string {
 	// Single input for API key
 	sb.WriteString("  " + m.locale.WizardKeyLabel)
 	sb.WriteString("\n  ")
-	sb.WriteString(m.wizardKeyTI.View())
+	sb.WriteString(m.panelState.wizardKeyTI.View())
 	sb.WriteString("\n\n")
 
 	// Save + Back buttons
@@ -204,7 +204,7 @@ func (m *cliModel) wizardTitle(text string) string {
 		w = 80
 	}
 	stepLabels := []string{"1/3", "2/3", "3/3", "✓"}
-	step := stepLabels[min(m.wizardStep, 3)]
+	step := stepLabels[min(m.panelState.wizardStep, 3)]
 	return m.styles.PanelHeader.Width(w).Render(fmt.Sprintf(" %s  %s", step, text))
 }
 
@@ -224,7 +224,7 @@ func (m *cliModel) wizardHint(text string) string {
 // --- Keyboard ---
 
 func (m *cliModel) handleWizardKey(msg tea.KeyMsg) (bool, tea.Cmd) {
-	switch m.wizardStep {
+	switch m.panelState.wizardStep {
 	case wizardLang:
 		return m.wizardLangKey(msg)
 	case wizardProvider:
@@ -240,15 +240,15 @@ func (m *cliModel) handleWizardKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 func (m *cliModel) wizardLangKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 	switch msg.String() {
 	case "up", "k":
-		if m.wizardLangSel > 0 {
-			m.wizardLangSel--
+		if m.panelState.wizardLangSel > 0 {
+			m.panelState.wizardLangSel--
 		}
 	case "down", "j":
-		if m.wizardLangSel < len(wizardLangOptions)-1 {
-			m.wizardLangSel++
+		if m.panelState.wizardLangSel < len(wizardLangOptions)-1 {
+			m.panelState.wizardLangSel++
 		}
 	case "enter":
-		m.wizardConfirmLang(m.wizardLangSel)
+		m.wizardConfirmLang(m.panelState.wizardLangSel)
 	case "esc":
 		m.closePanel()
 	}
@@ -259,17 +259,17 @@ func (m *cliModel) wizardProvKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 	opts := m.wizardProviderList()
 	switch msg.String() {
 	case "up", "k":
-		if m.wizardProvSel > 0 {
-			m.wizardProvSel--
+		if m.panelState.wizardProvSel > 0 {
+			m.panelState.wizardProvSel--
 		}
 	case "down", "j":
-		if m.wizardProvSel < len(opts)-1 {
-			m.wizardProvSel++
+		if m.panelState.wizardProvSel < len(opts)-1 {
+			m.panelState.wizardProvSel++
 		}
 	case "enter":
-		m.wizardConfirmProvider(m.wizardProvSel)
+		m.wizardConfirmProvider(m.panelState.wizardProvSel)
 	case "esc":
-		m.wizardStep = wizardLang
+		m.panelState.wizardStep = wizardLang
 	}
 	return true, nil
 }
@@ -277,15 +277,15 @@ func (m *cliModel) wizardProvKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 func (m *cliModel) wizardKeyInput(msg tea.KeyMsg) (bool, tea.Cmd) {
 	switch msg.String() {
 	case "ctrl+s", "enter":
-		m.panelValues["llm_api_key"] = m.wizardKeyTI.Value()
-		m.wizardStep = wizardDone
+		m.panelState.values["llm_api_key"] = m.panelState.wizardKeyTI.Value()
+		m.panelState.wizardStep = wizardDone
 		return true, nil
 	case "esc":
-		m.wizardStep = wizardProvider
+		m.panelState.wizardStep = wizardProvider
 		return true, nil
 	default:
 		var cmd tea.Cmd
-		m.wizardKeyTI, cmd = m.wizardKeyTI.Update(msg)
+		m.panelState.wizardKeyTI, cmd = m.panelState.wizardKeyTI.Update(msg)
 		return true, cmd
 	}
 }
@@ -295,13 +295,13 @@ func (m *cliModel) wizardDoneKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 	case "enter":
 		return true, m.wizardFinish()
 	case "esc":
-		provider := m.panelValues["llm_provider"]
+		provider := m.panelState.values["llm_provider"]
 		if provider == "ollama" {
-			m.wizardStep = wizardProvider
+			m.panelState.wizardStep = wizardProvider
 		} else {
-			m.wizardStep = wizardAPIKey
-			m.wizardKeyTI.SetValue(m.panelValues["llm_api_key"])
-			m.wizardKeyTI.Focus()
+			m.panelState.wizardStep = wizardAPIKey
+			m.panelState.wizardKeyTI.SetValue(m.panelState.values["llm_api_key"])
+			m.panelState.wizardKeyTI.Focus()
 		}
 	}
 	return true, nil
@@ -315,9 +315,9 @@ func (m *cliModel) wizardConfirmLang(idx int) {
 	}
 	code := wizardLangOptions[idx].Code
 	m.locale = ch.GetLocale(code)
-	m.panelValues["language"] = code
-	m.wizardStep = wizardProvider
-	m.wizardProvSel = 0
+	m.panelState.values["language"] = code
+	m.panelState.wizardStep = wizardProvider
+	m.panelState.wizardProvSel = 0
 }
 
 func (m *cliModel) wizardConfirmProvider(idx int) {
@@ -326,31 +326,31 @@ func (m *cliModel) wizardConfirmProvider(idx int) {
 		return
 	}
 	provider := opts[idx].Value
-	m.panelValues["llm_provider"] = provider
+	m.panelState.values["llm_provider"] = provider
 	if url, ok := ch.ProviderDefaultURLs[provider]; ok {
-		m.panelValues["llm_base_url"] = url
+		m.panelState.values["llm_base_url"] = url
 	}
 	if model, ok := ch.ProviderRecommendedModels[provider]; ok {
-		m.panelValues["llm_model"] = model
+		m.panelState.values["llm_model"] = model
 	}
 	m.updateAPIKeyHint(provider)
 	m.rebuildVisibleSchema()
 
 	if provider == "ollama" {
-		m.wizardStep = wizardDone
+		m.panelState.wizardStep = wizardDone
 	} else {
-		m.wizardStep = wizardAPIKey
-		m.wizardKeyTI.SetValue("")
-		m.wizardKeyTI.Focus()
+		m.panelState.wizardStep = wizardAPIKey
+		m.panelState.wizardKeyTI.SetValue("")
+		m.panelState.wizardKeyTI.Focus()
 	}
 }
 
 func (m *cliModel) wizardFinish() tea.Cmd {
-	onSubmit := m.panelOnSubmit
-	panelVals := m.panelValues
+	onSubmit := m.panelState.onSubmit
+	panelVals := m.panelState.values
 	m.closePanel()
 	if onSubmit != nil && panelVals != nil {
-		m.settingsSaving = true
+		m.panelState.settingsSaving = true
 		return m.doSaveSettings(onSubmit, panelVals)
 	}
 	return nil
@@ -359,7 +359,7 @@ func (m *cliModel) wizardFinish() tea.Cmd {
 // --- Mouse zone tracking ---
 
 func (m *cliModel) trackWizardZones(zb *mouseZoneBuilder, contentStartY, visibleH int) {
-	scrollY := m.panelScrollY
+	scrollY := m.panelState.scrollY
 
 	type wLine struct {
 		zoneID  string
@@ -367,7 +367,7 @@ func (m *cliModel) trackWizardZones(zb *mouseZoneBuilder, contentStartY, visible
 	}
 	var lines []wLine
 
-	switch m.wizardStep {
+	switch m.panelState.wizardStep {
 	case wizardLang:
 		lines = append(lines, wLine{}) // title
 		lines = append(lines, wLine{}) // blank
@@ -397,7 +397,7 @@ func (m *cliModel) trackWizardZones(zb *mouseZoneBuilder, contentStartY, visible
 	case wizardAPIKey:
 		lines = append(lines, wLine{}) // title
 		lines = append(lines, wLine{}) // blank
-		provider := m.panelValues["llm_provider"]
+		provider := m.panelState.values["llm_provider"]
 		guide, hasGuide := ch.ProviderSetupGuides[provider]
 		if hasGuide && guide.URL != "" {
 			lines = append(lines, wLine{zoneID: "panelOpenURL"}) // button
@@ -459,25 +459,25 @@ func (m *cliModel) handleWizardClick(zone mouseZone) (bool, tea.Model, tea.Cmd) 
 		m.wizardConfirmProvider(zone.Index)
 		return true, m, nil
 	case "wizardSave":
-		m.panelValues["llm_api_key"] = m.wizardKeyTI.Value()
-		m.wizardStep = wizardDone
+		m.panelState.values["llm_api_key"] = m.panelState.wizardKeyTI.Value()
+		m.panelState.wizardStep = wizardDone
 		return true, m, nil
 	case "wizardBack":
-		switch m.wizardStep {
+		switch m.panelState.wizardStep {
 		case wizardLang:
 			m.closePanel()
 		case wizardProvider:
-			m.wizardStep = wizardLang
+			m.panelState.wizardStep = wizardLang
 		case wizardAPIKey:
-			m.wizardStep = wizardProvider
+			m.panelState.wizardStep = wizardProvider
 		case wizardDone:
-			provider := m.panelValues["llm_provider"]
+			provider := m.panelState.values["llm_provider"]
 			if provider == "ollama" {
-				m.wizardStep = wizardProvider
+				m.panelState.wizardStep = wizardProvider
 			} else {
-				m.wizardStep = wizardAPIKey
-				m.wizardKeyTI.SetValue(m.panelValues["llm_api_key"])
-				m.wizardKeyTI.Focus()
+				m.panelState.wizardStep = wizardAPIKey
+				m.panelState.wizardKeyTI.SetValue(m.panelState.values["llm_api_key"])
+				m.panelState.wizardKeyTI.Focus()
 			}
 		}
 		return true, m, nil
@@ -495,23 +495,23 @@ func (m *cliModel) updateWizardPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.
 
 // openWizardPanel opens the step-by-step setup wizard.
 func (m *cliModel) openWizardPanel() {
-	m.panelMode = "wizard"
+	m.panelState.mode = "wizard"
 	m.relayoutViewport()
-	m.wizardStep = wizardLang
-	m.wizardLangSel = 0
-	m.wizardProvSel = 0
-	m.panelValues = make(map[string]string)
-	m.panelSchemaFull = make([]ch.SettingDefinition, len(m.locale.SetupSchema))
-	copy(m.panelSchemaFull, m.locale.SetupSchema)
-	for _, def := range m.panelSchemaFull {
+	m.panelState.wizardStep = wizardLang
+	m.panelState.wizardLangSel = 0
+	m.panelState.wizardProvSel = 0
+	m.panelState.values = make(map[string]string)
+	m.panelState.schemaFull = make([]ch.SettingDefinition, len(m.locale.SetupSchema))
+	copy(m.panelState.schemaFull, m.locale.SetupSchema)
+	for _, def := range m.panelState.schemaFull {
 		if def.DefaultValue != "" {
-			m.panelValues[def.Key] = def.DefaultValue
+			m.panelState.values[def.Key] = def.DefaultValue
 		}
 	}
-	m.panelOnSubmit = func(vals map[string]string) {
+	m.panelState.onSubmit = func(vals map[string]string) {
 		m.persistCLISettingsValues(vals)
 	}
-	m.panelIsSetup = true
+	m.panelState.isSetup = true
 	ti := textinput.New()
 	ti.Placeholder = "sk-..."
 	ti.Prompt = "  "
@@ -524,5 +524,5 @@ func (m *cliModel) openWizardPanel() {
 	tiStyles.Focused.Placeholder = m.styles.TIPlaceholder
 	tiStyles.Cursor.Color = m.styles.TICursor.GetForeground()
 	ti.SetStyles(tiStyles)
-	m.wizardKeyTI = ti
+	m.panelState.wizardKeyTI = ti
 }

--- a/channel/cli/easter_egg.go
+++ b/channel/cli/easter_egg.go
@@ -57,26 +57,26 @@ var konamiASCII = strings.TrimLeft(`
 
 // checkKonami 检查按键是否匹配 Konami Code 序列
 func (m *cliModel) checkKonami(keyName string) bool {
-	if m.konamiBuffer == nil {
-		m.konamiBuffer = make([]string, 0, len(konamiSequence))
+	if m.easterEggState.konamiBuf == nil {
+		m.easterEggState.konamiBuf = make([]string, 0, len(konamiSequence))
 	}
-	m.konamiBuffer = append(m.konamiBuffer, keyName)
+	m.easterEggState.konamiBuf = append(m.easterEggState.konamiBuf, keyName)
 
-	if len(m.konamiBuffer) > len(konamiSequence) {
-		m.konamiBuffer = m.konamiBuffer[len(m.konamiBuffer)-len(konamiSequence):]
+	if len(m.easterEggState.konamiBuf) > len(konamiSequence) {
+		m.easterEggState.konamiBuf = m.easterEggState.konamiBuf[len(m.easterEggState.konamiBuf)-len(konamiSequence):]
 	}
 
-	if len(m.konamiBuffer) >= len(konamiSequence) {
-		offset := len(m.konamiBuffer) - len(konamiSequence)
+	if len(m.easterEggState.konamiBuf) >= len(konamiSequence) {
+		offset := len(m.easterEggState.konamiBuf) - len(konamiSequence)
 		match := true
 		for i := 0; i < len(konamiSequence); i++ {
-			if m.konamiBuffer[offset+i] != konamiSequence[i] {
+			if m.easterEggState.konamiBuf[offset+i] != konamiSequence[i] {
 				match = false
 				break
 			}
 		}
 		if match {
-			m.konamiBuffer = nil
+			m.easterEggState.konamiBuf = nil
 			return true
 		}
 	}
@@ -106,64 +106,64 @@ func (m *cliModel) initMatrixColumns() {
 	if rows < 5 {
 		rows = 5
 	}
-	m.matrixCols = cols
-	m.matrixRows = rows
-	m.matrixDrops = make([]int, cols)
-	m.matrixSpeeds = make([]int, cols)
-	m.matrixTrailLen = make([]int, cols)
+	m.easterEggState.matrixCols = cols
+	m.easterEggState.matrixRows = rows
+	m.easterEggState.matrixDrops = make([]int, cols)
+	m.easterEggState.matrixSpeeds = make([]int, cols)
+	m.easterEggState.matrixTrailLen = make([]int, cols)
 	for i := 0; i < cols; i++ {
-		m.matrixDrops[i] = -rand.Intn(rows) // 负数 = 还在画面外
-		m.matrixSpeeds[i] = 1 + rand.Intn(2)
-		m.matrixTrailLen[i] = 5 + rand.Intn(15)
+		m.easterEggState.matrixDrops[i] = -rand.Intn(rows) // 负数 = 还在画面外
+		m.easterEggState.matrixSpeeds[i] = 1 + rand.Intn(2)
+		m.easterEggState.matrixTrailLen[i] = 5 + rand.Intn(15)
 	}
 	// 用空格初始化矩阵缓冲区
-	m.matrixBuffer = make([][]rune, rows)
+	m.easterEggState.matrixBuf = make([][]rune, rows)
 	for r := 0; r < rows; r++ {
-		m.matrixBuffer[r] = make([]rune, cols)
+		m.easterEggState.matrixBuf[r] = make([]rune, cols)
 		for c := 0; c < cols; c++ {
-			m.matrixBuffer[r][c] = ' '
+			m.easterEggState.matrixBuf[r][c] = ' '
 		}
 	}
 }
 
 // tickMatrix 推进一帧代码雨动画
 func (m *cliModel) tickMatrix() {
-	if m.matrixDrops == nil {
+	if m.easterEggState.matrixDrops == nil {
 		m.initMatrixColumns()
 	}
 
-	cols := m.matrixCols
-	rows := m.matrixRows
+	cols := m.easterEggState.matrixCols
+	rows := m.easterEggState.matrixRows
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// 随机更新已有字符产生闪烁效果
 	for r := 0; r < rows; r++ {
 		for c := 0; c < cols; c++ {
-			if m.matrixBuffer[r][c] != ' ' && rng.Intn(10) == 0 {
-				m.matrixBuffer[r][c] = matrixChars[rng.Intn(len(matrixChars))]
+			if m.easterEggState.matrixBuf[r][c] != ' ' && rng.Intn(10) == 0 {
+				m.easterEggState.matrixBuf[r][c] = matrixChars[rng.Intn(len(matrixChars))]
 			}
 		}
 	}
 
 	// 推进每列下落
 	for c := 0; c < cols; c++ {
-		m.matrixDrops[c] += m.matrixSpeeds[c]
-		head := m.matrixDrops[c]
-		tail := head - m.matrixTrailLen[c]
+		m.easterEggState.matrixDrops[c] += m.easterEggState.matrixSpeeds[c]
+		head := m.easterEggState.matrixDrops[c]
+		tail := head - m.easterEggState.matrixTrailLen[c]
 
 		// 头部写入新字符
 		if head >= 0 && head < rows {
-			m.matrixBuffer[head][c] = matrixChars[rng.Intn(len(matrixChars))]
+			m.easterEggState.matrixBuf[head][c] = matrixChars[rng.Intn(len(matrixChars))]
 		}
 		// 尾部擦除
 		if tail >= 0 && tail < rows {
-			m.matrixBuffer[tail][c] = ' '
+			m.easterEggState.matrixBuf[tail][c] = ' '
 		}
 		// 超出画面：重置
 		if tail > rows+5 {
-			m.matrixDrops[c] = -rng.Intn(rows / 2)
-			m.matrixSpeeds[c] = 1 + rng.Intn(2)
-			m.matrixTrailLen[c] = 5 + rng.Intn(15)
+			m.easterEggState.matrixDrops[c] = -rng.Intn(rows / 2)
+			m.easterEggState.matrixSpeeds[c] = 1 + rng.Intn(2)
+			m.easterEggState.matrixTrailLen[c] = 5 + rng.Intn(15)
 		}
 	}
 }
@@ -332,14 +332,14 @@ var versionAchievementArt = strings.TrimLeft(`
 // recordVersionHit 记录 /version 调用，返回 true 表示触发了彩蛋
 func (m *cliModel) recordVersionHit() bool {
 	now := time.Now()
-	m.versionHitTimes = append(m.versionHitTimes, now)
-	if len(m.versionHitTimes) > 3 {
-		m.versionHitTimes = m.versionHitTimes[len(m.versionHitTimes)-3:]
+	m.easterEggState.versionHits = append(m.easterEggState.versionHits, now)
+	if len(m.easterEggState.versionHits) > 3 {
+		m.easterEggState.versionHits = m.easterEggState.versionHits[len(m.easterEggState.versionHits)-3:]
 	}
-	if len(m.versionHitTimes) >= 3 {
-		elapsed := m.versionHitTimes[len(m.versionHitTimes)-1].Sub(m.versionHitTimes[len(m.versionHitTimes)-3])
+	if len(m.easterEggState.versionHits) >= 3 {
+		elapsed := m.easterEggState.versionHits[len(m.easterEggState.versionHits)-1].Sub(m.easterEggState.versionHits[len(m.easterEggState.versionHits)-3])
 		if elapsed <= 10*time.Second {
-			m.versionHitTimes = nil
+			m.easterEggState.versionHits = nil
 			return true
 		}
 	}
@@ -376,7 +376,7 @@ func randomZen() (string, string) {
 // activateEasterEgg 激活指定彩蛋（按任意键退出）。
 // 返回 tea.Cmd 用于 Matrix 动画的初始 tick。
 func (m *cliModel) activateEasterEgg(mode easterEggMode) tea.Cmd {
-	m.easterEgg = mode
+	m.easterEggState.mode = mode
 	if mode == easterEggMatrix {
 		m.initMatrixColumns()
 		// 生成第一帧并启动动画循环
@@ -388,10 +388,10 @@ func (m *cliModel) activateEasterEgg(mode easterEggMode) tea.Cmd {
 
 // dismissEasterEgg 关闭当前彩蛋
 func (m *cliModel) dismissEasterEgg() {
-	m.easterEgg = easterEggNone
-	m.matrixBuffer = nil
-	m.matrixDrops = nil
-	m.easterEggCustom = ""
+	m.easterEggState.mode = easterEggNone
+	m.easterEggState.matrixBuf = nil
+	m.easterEggState.matrixDrops = nil
+	m.easterEggState.customArt = ""
 }
 
 // handleEasterEggCommand 处理隐藏的彩蛋斜杠命令。
@@ -438,7 +438,7 @@ func (m *cliModel) handleEasterEggCommand(cmd string) (bool, tea.Cmd) {
 
 // renderEasterEggOverlay 渲染彩蛋覆盖层。返回空字符串表示无彩蛋。
 func (m *cliModel) renderEasterEggOverlay() string {
-	switch m.easterEgg {
+	switch m.easterEggState.mode {
 	case easterEggKonami:
 		return m.renderKonamiOverlay()
 	case easterEggMatrix:
@@ -461,7 +461,7 @@ func (m *cliModel) renderKonamiOverlay() string {
 
 // renderMatrixOverlay 渲染 Matrix 代码雨画面
 func (m *cliModel) renderMatrixOverlay() string {
-	if m.matrixBuffer == nil {
+	if m.easterEggState.matrixBuf == nil {
 		return ""
 	}
 
@@ -470,24 +470,24 @@ func (m *cliModel) renderMatrixOverlay() string {
 	dimGreen := lipgloss.NewStyle().Foreground(lipgloss.Color("#003300"))
 
 	var sb strings.Builder
-	for r := 0; r < m.matrixRows; r++ {
-		for c := 0; c < m.matrixCols; c++ {
-			ch := m.matrixBuffer[r][c]
+	for r := 0; r < m.easterEggState.matrixRows; r++ {
+		for c := 0; c < m.easterEggState.matrixCols; c++ {
+			ch := m.easterEggState.matrixBuf[r][c]
 			if ch == ' ' {
 				sb.WriteString(" ")
 				continue
 			}
 			// 判断是否是列头部
 			isHead := false
-			if m.matrixDrops != nil && c < len(m.matrixDrops) && m.matrixDrops[c] == r {
+			if m.easterEggState.matrixDrops != nil && c < len(m.easterEggState.matrixDrops) && m.easterEggState.matrixDrops[c] == r {
 				isHead = true
 			}
 			if isHead {
 				sb.WriteString(brightWhite.Render(string(ch)))
 			} else {
 				distance := 0
-				if m.matrixDrops != nil && c < len(m.matrixDrops) {
-					distance = m.matrixDrops[c] - r
+				if m.easterEggState.matrixDrops != nil && c < len(m.easterEggState.matrixDrops) {
+					distance = m.easterEggState.matrixDrops[c] - r
 					if distance < 0 {
 						distance = 0
 					}
@@ -499,7 +499,7 @@ func (m *cliModel) renderMatrixOverlay() string {
 				}
 			}
 		}
-		if r < m.matrixRows-1 {
+		if r < m.easterEggState.matrixRows-1 {
 			sb.WriteString("\n")
 		}
 	}
@@ -522,7 +522,7 @@ func (m *cliModel) renderAnswer42Overlay() string {
 // renderVersionOverlay 渲染版本强迫症成就画面
 func (m *cliModel) renderVersionOverlay() string {
 	gold := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD700")).Bold(true)
-	content := gold.Render(m.easterEggCustom)
+	content := gold.Render(m.easterEggState.customArt)
 	return centerOverlay(content, m.width, m.height)
 }
 


### PR DESCRIPTION
## Summary

将 `cliModel` 的 240 个字段提取为 7 个内聚子结构体，使状态域一目了然。

## Extracted Sub-structs

| Sub-struct | Fields | Domain |
|-----------|--------|--------|
| `panelState` | 61 | 所有面板 UI（settings, askuser, sessions, bgtasks, rewind, runner, channel, wizard, approval） |
| `progressState` | 14 | 进度事件、迭代快照、SubAgent 渲染、打字机/动画 |
| `layoutConfig` | 13 | 宽度、居中、侧边栏布局、缓存 |
| `easterEggState` | 10 | Konami、Matrix 雨、版本彩蛋 |
| `searchState` | 6 | 搜索模式、查询、结果 |
| `splashState` | 5 | 启动 splash、加载、压缩重载 |
| `toastState` | 2 | Toast 队列和计时器 |

## Impact

| 指标 | 前 | 后 |
|------|-----|-----|
| cliModel 直接字段数 | ~240 | ~129 |
| 提取的子结构体 | 0 | 7 |
| 移动的字段总数 | — | 111 |

## Design

每个子结构体包含一组**紧密耦合**的字段——它们在业务逻辑中总是一起修改/读取。子结构体字段名适当缩短（如 `panelMode` → `panelState.mode`），因为结构体名已提供上下文。

## Verification
- ✅ `go build ./...`
- ✅ `go test ./...` (0 FAIL)
- ✅ `go vet ./channel/cli/`
- 零逻辑变更