### PR TITLE
fix: wizard model name not refreshing after setup

### DIFF
--- a/channel/cli/cli_helpers.go
+++ b/channel/cli/cli_helpers.go
@@ -251,9 +251,10 @@ func (m *cliModel) handleSettingsSavedMsg(msg cliSettingsSavedMsg) tea.Cmd {
 		visualChanged = true
 	}
 	m.reloadSettingsCaches()
-	// If model name is still empty after refresh (e.g. GetDefault RPC race on
-	// first setup), use the model name directly from the saved values.
-	if m.cachedModelName == "" && msg.savedModel != "" {
+	// msg.savedModel comes from the user's explicit choice in the wizard/settings
+	// panel. It is authoritative — refreshCachedModelName may fail due to RPC
+	// timing (subscription just created, not yet visible to GetDefault).
+	if msg.savedModel != "" {
 		m.cachedModelName = msg.savedModel
 	}
 	if msg.feedbackMsg != "" {


### PR DESCRIPTION
## Problem
第一次 setup wizard 完成后，TUI 状态栏不刷新模型名（仍显示旧的），需要重启 TUI 才正常。

## Root Cause
`handleSettingsSavedMsg` 中 `msg.savedModel`（用户明确选择的模型）仅在 `cachedModelName == ""` 时才生效。但 `refreshCachedModelName()` 可能因 RPC 时序返回非空的 stale 值（subscription 刚创建，`GetDefault` 还没传播），阻断了 fallback。

## Fix
`msg.savedModel` 来自用户的显式选择（wizard/settings panel），始终优先于 `refreshCachedModelName` 的 RPC 查询结果。

## Test
- `go build ./...` ✅
- `go test ./...` ✅
- `golangci-lint` ✅
