### PR TITLE
fix: context indicator not updating after config tool sets max_context_tokens

### DIFF
--- a/channel/cli/cli_settings.go
+++ b/channel/cli/cli_settings.go
@@ -331,6 +331,16 @@ func (m *cliModel) activeSubscription() *ch.Subscription {
 // resolveMaxContext reads max_context from subscription.PerModelConfigs[model].
 // Returns 0 if not set (caller uses schema default 200000).
 func (m *cliModel) resolveMaxContext() int {
+	// Check user settings first — config tool writes max_context_tokens
+	// to SettingsSvc (user_settings DB), not to subscription PerModelConfigs.
+	// Same pattern as resolveMaxOutputTokens and resolveCompressRatio.
+	if m.channel != nil && m.channel.config.GetCurrentValues != nil {
+		if v, ok := m.channel.config.GetCurrentValues()["max_context_tokens"]; ok && v != "" {
+			if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+				return n
+			}
+		}
+	}
 	sub := m.activeSubscription()
 	if sub == nil {
 		return 0


### PR DESCRIPTION
## Problem
config 工具修改 `max_context_tokens` 后，TUI 的 context 指示器不更新。

## Root Cause
`resolveMaxContext()` 只从 `subscription.PerModelConfigs` 读，但 config tool 写的是 `SettingsSvc`（user_settings DB），两个数据源不通。

## Fix
`resolveMaxContext()` 增加 `GetCurrentValues()["max_context_tokens"]` 优先检查，与 `resolveMaxOutputTokens` 和 `resolveCompressRatio` 保持相同模式。

## Test
- `go build ./...` ✅
- `go test ./...` ✅
- `golangci-lint` ✅
