### PR TITLE
fix(cron): 重启后 delay_seconds 任务丢失 & every_seconds 累积漂移

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,11 @@
 
 - **SQLite `datetime()` comparison with RFC3339 strings is a silent trap.** `created_at` stores `2026-05-24T14:00:00+08:00` (RFC3339 with timezone). `datetime(?, '-2 seconds')` returns `2026-05-24 05:59:58` (UTC, no timezone). Raw string comparison: `'T'` (0x54) > `' '` (0x20) at position 10, so `created_at > datetime(?)` is **always TRUE**, breaking any time-window dedup/filter. Always wrap both sides in `datetime()`: `datetime(created_at) > datetime(?, '-2 seconds')`.
 
+### Cron Scheduler
+- **`cleanupExpiredJobs` must NOT delete `delay_seconds` one-shot jobs.** `delay_seconds` represents relative time ("N seconds from creation"). If the job expired during downtime, deleting it silently drops the user's scheduled reminder. Keep expired `delay_seconds` jobs so `checkAndFire` triggers them on the first tick. Only `at`-based one-shot jobs (absolute time point) should be removed when expired — the scheduled moment has passed.
+- **`every_seconds` next_run must be based on `job.NextRun`, NOT `now`.** The old code used `nextRun = now.Add(interval)`, where `now` is the actual fire time (delayed by 0–5s due to the 5s ticker). Each fire accumulates drift, causing the schedule to slide later and later. Fix: `nextRun = job.NextRun.Add(interval)` anchored to the planned schedule, with a forward-advance loop for missed intervals.
+- **Recurring jobs skip missed executions on restart (by design).** `cleanupExpiredJobs` recalculates `next_run` from `now` for recurring jobs. This matches traditional cron semantics — no catch-up execution.
+
 ### Startup
 - `NewOpenAILLM` loads model list asynchronously. `ListModels()` returns fallback immediately.
 - Settings save is synchronous — all local I/O, no network calls.

--- a/cron/scheduler.go
+++ b/cron/scheduler.go
@@ -109,7 +109,19 @@ func (s *Scheduler) cleanupExpiredJobs() {
 	cleaned := 0
 	for _, job := range jobs {
 		if job.OneShot && job.NextRun.Before(now) {
-			// Remove expired one-shot jobs
+			if job.DelaySeconds > 0 {
+				// delay_seconds one-shot jobs represent relative time ("N seconds from
+				// creation"). If expired during downtime, keep them so checkAndFire
+				// triggers immediately on the first tick — the user expected them to
+				// fire eventually, not be silently dropped.
+				log.WithFields(log.Fields{
+					"job_id":   job.ID,
+					"next_run": job.NextRun,
+				}).Info("Preserving expired delay_seconds one-shot job for immediate fire")
+				continue
+			}
+			// At-based one-shot jobs: the scheduled moment has passed.
+			// Remove them (matching traditional cron catch-up semantics).
 			if err := s.cronSvc.RemoveJob(job.ID); err != nil {
 				log.WithError(err).WithField("job_id", job.ID).Warn("Failed to remove expired one-shot job")
 			} else {
@@ -247,8 +259,16 @@ func (s *Scheduler) checkAndFire(now time.Time) {
 				log.WithError(err).WithField("job_id", job.ID).Error("Failed to remove one-shot job")
 			}
 		} else if job.EverySeconds > 0 {
-			// Update next run for interval jobs
-			nextRun := now.Add(time.Duration(job.EverySeconds) * time.Second)
+			// Update next run for interval jobs.
+			// Base next_run on the scheduled time (job.NextRun), not the actual
+			// fire time (now), to prevent accumulated drift when the 5s ticker
+			// fires slightly late. If multiple intervals were missed, advance
+			// forward until we reach a future time.
+			interval := time.Duration(job.EverySeconds) * time.Second
+			nextRun := job.NextRun.Add(interval)
+			for !nextRun.After(now) {
+				nextRun = nextRun.Add(interval)
+			}
 			if err := s.cronSvc.UpdateNextRun(job.ID, nextRun); err != nil {
 				log.WithError(err).WithField("job_id", job.ID).Error("Failed to update interval job")
 			}

--- a/cron/scheduler_restart_test.go
+++ b/cron/scheduler_restart_test.go
@@ -1,0 +1,235 @@
+package cron
+
+import (
+	"testing"
+	"time"
+
+	"xbot/storage/sqlite"
+)
+
+// helperOpenDB creates a fresh SQLite DB for testing.
+func helperOpenDB(t *testing.T) *sqlite.DB {
+	t.Helper()
+	dbPath := t.TempDir() + "/test_cron.db"
+	db, err := sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// --- Fix 1: OneShot delay_seconds job preserved after restart (not deleted) ---
+
+func TestCleanupExpiredJobs_OneShotDelayPreservedAfterRestart(t *testing.T) {
+	db := helperOpenDB(t)
+	cronSvc := sqlite.NewCronService(db)
+	s := NewScheduler(cronSvc)
+
+	// Simulate a delay_seconds one-shot job created 60s ago,
+	// with next_run = created + 30s (already expired by 30s).
+	created := time.Now().Add(-60 * time.Second)
+	nextRun := created.Add(30 * time.Second) // 30s ago → expired
+
+	job := &sqlite.CronJob{
+		ID:           "job_delay_test",
+		Message:      "test delay",
+		DelaySeconds: 30,
+		CreatedAt:    created,
+		NextRun:      nextRun,
+		OneShot:      true,
+	}
+	if err := cronSvc.AddJob(job); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	// cleanupExpiredJobs simulates what happens on restart
+	s.cleanupExpiredJobs()
+
+	// FIXED: the job should be preserved so checkAndFire triggers it immediately
+	got, err := cronSvc.GetJob("job_delay_test")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if got == nil {
+		t.Fatal("BUG: delay_seconds one-shot job was deleted by cleanupExpiredJobs — should be preserved for immediate fire")
+	}
+	t.Logf("FIXED: delay_seconds one-shot job preserved, next_run=%v (will fire on first tick)", got.NextRun)
+}
+
+// --- Fix 1b: At-based one-shot job still removed after restart (correct behavior) ---
+
+func TestCleanupExpiredJobs_AtOneShotRemovedAfterRestart(t *testing.T) {
+	db := helperOpenDB(t)
+	cronSvc := sqlite.NewCronService(db)
+	s := NewScheduler(cronSvc)
+
+	// An At-based one-shot job scheduled for the past
+	job := &sqlite.CronJob{
+		ID:        "job_at_test",
+		Message:   "test at",
+		At:        "2026-06-15T08:00:00",
+		CreatedAt: time.Now().Add(-4 * time.Hour),
+		NextRun:   time.Now().Add(-2 * time.Hour), // 2h ago → expired
+		OneShot:   true,
+	}
+	if err := cronSvc.AddJob(job); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	s.cleanupExpiredJobs()
+
+	got, err := cronSvc.GetJob("job_at_test")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if got != nil {
+		t.Errorf("At-based one-shot job should be removed after expiry, but still exists")
+	}
+	t.Logf("CORRECT: At-based one-shot job removed (scheduled moment passed)")
+}
+
+// --- Fix 2: every_seconds eliminates accumulated drift ---
+
+func TestEverySecondsNoDrift(t *testing.T) {
+	db := helperOpenDB(t)
+	cronSvc := sqlite.NewCronService(db)
+
+	var firedCount int
+	s := NewScheduler(cronSvc)
+	s.SetInjectFunc(func(channel, chatID, senderID, content string) {
+		firedCount++
+	})
+
+	// Create an every-10-second job starting at 10:00:10
+	baseTime := time.Date(2026, 6, 15, 10, 0, 0, 0, time.Local)
+	job := &sqlite.CronJob{
+		ID:           "job_drift_test",
+		Message:      "tick",
+		EverySeconds: 10,
+		CreatedAt:    baseTime,
+		NextRun:      baseTime.Add(10 * time.Second),
+		OneShot:      false,
+	}
+	if err := cronSvc.AddJob(job); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	// Simulate ticks where tick4 is 2s late (system busy).
+	// With the fix, next_run should be based on job.NextRun, not fire time.
+	ticks := []time.Time{
+		baseTime.Add(5 * time.Second),  // 10:00:05 → not yet
+		baseTime.Add(10 * time.Second), // 10:00:10 → fire! next should be 10:00:20
+		baseTime.Add(15 * time.Second), // 10:00:15 → not yet
+		baseTime.Add(22 * time.Second), // 10:00:22 → fire (2s late), next should still be 10:00:30 (no drift!)
+		baseTime.Add(27 * time.Second), // 10:00:27 → not yet
+		baseTime.Add(30 * time.Second), // 10:00:30 → fire! on schedule
+	}
+
+	for _, tick := range ticks {
+		s.checkAndFire(tick)
+	}
+
+	if firedCount != 3 {
+		t.Errorf("expected 3 fires, got %d", firedCount)
+	}
+
+	got, _ := cronSvc.GetJob("job_drift_test")
+	// With the fix: next_run = 10:00:30 + 10 = 10:00:40 (NO drift)
+	// Without the fix: next_run would be 10:00:30 + 10 = 10:00:40 only if tick6 was on time
+	// But tick4=10:00:22 → old code: next=10:00:32, then tick at 10:00:32 would fire → next=10:00:42
+	expectedNext := baseTime.Add(40 * time.Second)
+	if !got.NextRun.Equal(expectedNext) {
+		t.Errorf("next_run should be %v (no drift), got %v", expectedNext, got.NextRun)
+	}
+	t.Logf("FIXED: next_run=%v — no accumulated drift", got.NextRun)
+}
+
+// --- Recurring job skips missed executions after restart (expected behavior) ---
+
+func TestCleanupExpiredJobs_RecurringSkipsMissedRuns(t *testing.T) {
+	db := helperOpenDB(t)
+	cronSvc := sqlite.NewCronService(db)
+	s := NewScheduler(cronSvc)
+
+	// Simulate an every-5-min job that was supposed to run 12 min ago.
+	pastRun := time.Now().Add(-12 * time.Minute)
+
+	job := &sqlite.CronJob{
+		ID:           "job_recurring_test",
+		Message:      "test recurring",
+		EverySeconds: 300, // 5 minutes
+		CreatedAt:    time.Now().Add(-20 * time.Minute),
+		NextRun:      pastRun,
+		OneShot:      false,
+	}
+	if err := cronSvc.AddJob(job); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	s.cleanupExpiredJobs()
+
+	got, err := cronSvc.GetJob("job_recurring_test")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if got == nil {
+		t.Fatal("job should not be deleted, but it's gone")
+	}
+
+	// next_run should be ~5 min from now (missed executions skipped —
+	// this is expected behavior matching traditional cron semantics)
+	if got.NextRun.Before(time.Now().Add(4 * time.Minute)) {
+		t.Errorf("expected next_run ~5min in future, got %v", got.NextRun)
+	}
+	t.Logf("CORRECT: recurring next_run=%v (missed executions skipped, matches cron semantics)",
+		got.NextRun)
+}
+
+// --- Integration: delay_seconds job fires immediately after restart ---
+
+func TestDelaySecondsFiresOnFirstTickAfterRestart(t *testing.T) {
+	db := helperOpenDB(t)
+	cronSvc := sqlite.NewCronService(db)
+
+	var firedMessages []string
+	s := NewScheduler(cronSvc)
+	s.SetInjectFunc(func(channel, chatID, senderID, content string) {
+		firedMessages = append(firedMessages, content)
+	})
+
+	// Create a delay_seconds job that's already expired
+	job := &sqlite.CronJob{
+		ID:           "job_fire_test",
+		Message:      "fire me!",
+		DelaySeconds: 30,
+		CreatedAt:    time.Now().Add(-60 * time.Second),
+		NextRun:      time.Now().Add(-30 * time.Second), // 30s ago
+		OneShot:      true,
+	}
+	if err := cronSvc.AddJob(job); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	// Step 1: cleanupExpiredJobs (should preserve, not delete)
+	s.cleanupExpiredJobs()
+
+	got, _ := cronSvc.GetJob("job_fire_test")
+	if got == nil {
+		t.Fatal("job should be preserved by cleanupExpiredJobs")
+	}
+
+	// Step 2: first checkAndFire tick (simulates first runLoop iteration)
+	s.checkAndFire(time.Now())
+
+	if len(firedMessages) != 1 {
+		t.Errorf("expected 1 fire on first tick, got %d", len(firedMessages))
+	}
+
+	// Job should now be removed (one-shot after firing)
+	got, _ = cronSvc.GetJob("job_fire_test")
+	if got != nil {
+		t.Errorf("one-shot job should be removed after firing")
+	}
+	t.Logf("FIXED: delay_seconds job fired immediately on first tick after restart")
+}


### PR DESCRIPTION
## 问题

重启后 cron 调度存在 2 个 bug：

### 🔴 Bug 1：`delay_seconds` 一次性任务重启后被静默删除

**根因**：`cleanupExpiredJobs` 对所有过期的 OneShot 任务一刀切删除，不区分 `delay_seconds` 和 `at`。

**场景**：用户设置 "60秒后提醒我" → 30秒后 xbot 重启 → next_run 已过期 → 任务被**删除**，永远不会触发。

### 🔴 Bug 2：`every_seconds` 任务累积漂移（越来越晚触发）

**根因**：`checkAndFire` 用触发时间 `now` 计算下次运行，每次触发都比预期晚 0~5 秒（5秒 ticker 粒度），且不断累积。

## 修复

| 问题 | 修复方案 |
|------|----------|
| delay_seconds 被删除 | `cleanupExpiredJobs` 保留过期 delay_seconds 任务，首轮 checkAndFire 立即触发 |
| every_seconds 漂移 | next_run 基于 `job.NextRun` 计算，锚定计划时间网格，消除累积漂移 |

### 正常行为（非 Bug，无需修改）

- Recurring 任务重启后跳过错过的执行（符合传统 cron 语义）
- 最多 5 秒触发延迟（5 秒 ticker 设计精度）

## 测试

新增 `cron/scheduler_restart_test.go`，5 个测试覆盖：
- ✅ delay_seconds 任务重启后保留并立即触发
- ✅ at-based 任务过期仍正确删除
- ✅ every_seconds 无累积漂移
- ✅ recurring 任务跳过错过的执行（正常行为）
- ✅ 端到端：delay_seconds 任务重启后首轮触发

## 变更文件

- `cron/scheduler.go` — 2 处修复
- `cron/scheduler_restart_test.go` — 新增测试文件
- `AGENTS.md` — Gotchas 新增 Cron Scheduler 章节
