### PR TITLE
fix(cli): prevent reasoning block flicker during tool execution

### DIFF
--- a/channel/cli/cli_flicker_test.go
+++ b/channel/cli/cli_flicker_test.go
@@ -137,6 +137,112 @@ func TestReasoningStructuredPriority(t *testing.T) {
 	}
 }
 
+// TestReasoningBoxVisibleDuringToolExec verifies that the reasoning box
+// remains visible in the live iteration when structured progress events
+// (sent during tool execution) carry Reasoning but NOT ReasoningStreamContent.
+//
+// Root cause: liveIterationBlocks only checked ReasoningStreamContent,
+// ignoring the structured Reasoning field. During tool execution, every
+// notifyProgress sends structured events without ReasoningStreamContent.
+// The reasoning box would disappear until carryForwardProgressState
+// restored ReasoningStreamContent (if it could), causing a visible flicker.
+//
+// Fix: fall back to structured Reasoning when ReasoningStreamContent is empty.
+func TestReasoningBoxVisibleDuringToolExec(t *testing.T) {
+	model := initTestModel()
+	model.startAgentTurn()
+
+	// Simulate reasoning streaming (DeepSeek-style reasoning_content)
+	sendProgress(model, &protocol.ProgressEvent{
+		ReasoningStreamContent: "I need to search for the file first.",
+		ChatID:                 "cli:/test",
+	})
+
+	// Verify reasoning box is visible during streaming
+	blocks := model.liveIterationBlocks(model.progressState.current, 80, "")
+	found := false
+	for _, b := range blocks {
+		if b.kind == turnBlockReasoning && strings.Contains(b.text, "search for the file") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("reasoning box should be visible during streaming (ReasoningStreamContent)")
+	}
+
+	// Structured event after LLM completes: has Reasoning, no ReasoningStreamContent.
+	// This is exactly what notifyProgress sends during tool execution.
+	sendProgress(model, &protocol.ProgressEvent{
+		Phase:     "tool_exec",
+		Iteration: 1,
+		Reasoning: "I need to search for the file first.",
+		ActiveTools: []protocol.ToolProgress{
+			{Name: "Shell", Label: "find . -name '*.go'", Status: "running"},
+		},
+		ChatID: "cli:/test",
+	})
+
+	// Verify reasoning box is STILL visible via structured Reasoning fallback
+	blocks = model.liveIterationBlocks(model.progressState.current, 80, "")
+	found = false
+	for _, b := range blocks {
+		if b.kind == turnBlockReasoning && strings.Contains(b.text, "search for the file") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("BUG: reasoning box disappeared during tool execution — " +
+			"liveIterationBlocks should fall back to structured Reasoning " +
+			"when ReasoningStreamContent is empty")
+	} else {
+		t.Log("FIXED: reasoning box remains visible via structured Reasoning fallback")
+	}
+}
+
+// TestReasoningBoxVisibleAcrossMultipleToolProgress verifies the reasoning
+// box stays visible across multiple structured progress events (each tool
+// execution step sends a notifyProgress).
+func TestReasoningBoxVisibleAcrossMultipleToolProgress(t *testing.T) {
+	model := initTestModel()
+	model.startAgentTurn()
+
+	// Reasoning streaming
+	sendProgress(model, &protocol.ProgressEvent{
+		ReasoningStreamContent: "Step 1: read the config. Step 2: validate.",
+		ChatID:                 "cli:/test",
+	})
+
+	reasoning := "Step 1: read the config. Step 2: validate."
+
+	// Multiple structured events during tool execution (each carries Reasoning)
+	for _, tools := range [][]protocol.ToolProgress{
+		{{Name: "Read", Label: "config.yaml", Status: "running"}},
+		{{Name: "Read", Label: "config.yaml", Status: "done"}},
+		{{Name: "Shell", Label: "validate", Status: "running"}},
+	} {
+		sendProgress(model, &protocol.ProgressEvent{
+			Phase:       "tool_exec",
+			Iteration:   1,
+			Reasoning:   reasoning,
+			ActiveTools: tools,
+			ChatID:      "cli:/test",
+		})
+
+		blocks := model.liveIterationBlocks(model.progressState.current, 80, "")
+		found := false
+		for _, b := range blocks {
+			if b.kind == turnBlockReasoning && strings.Contains(b.text, "Step 1") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("reasoning box should stay visible across all tool progress events; "+
+				"missing after tools=%v", tools)
+		}
+	}
+	t.Log("FIXED: reasoning box stays visible across all tool execution progress events")
+}
+
 // TestReasoningPhaseDoneNoContamination verifies the PhaseDone path is also
 // free from ReasoningStreamContent contamination.
 func TestReasoningPhaseDoneNoContamination(t *testing.T) {

--- a/channel/cli/cli_helpers_test.go
+++ b/channel/cli/cli_helpers_test.go
@@ -1206,6 +1206,174 @@ func TestSuHistoryLoad_TypingReconcile_AcceptProgress(t *testing.T) {
 	}
 }
 
+// TestSuHistoryLoad_CompressingPhase_NoContentMerge verifies that when the
+// server snapshot has Phase=="compressing", the last assistant message from
+// history is NOT merged into the streaming message. The compression indicator
+// must render as a standalone message, not inside the previous assistant content.
+//
+// Regression: handleSuHistoryLoad used to unconditionally replace the empty
+// streaming message's content with the last history assistant's content.
+// For Phase=="compressing", this caused "◇◇◇◇◇ 压缩中" to render between
+// the previous assistant's header and its content after a TUI restart.
+func TestSuHistoryLoad_CompressingPhase_NoContentMerge(t *testing.T) {
+	m := newCLIModel()
+	m.channelName = "cli"
+	m.chatID = "/test"
+	m.handleResize(120, 40)
+	setupTestRemoteChannel(m)
+
+	// Simulate restored session: typing=false (fresh restart).
+	m.typing = false
+	m.splashState.suLoading = true
+
+	// History with an assistant message that must NOT be merged.
+	history := []channel.HistoryMessage{
+		{Role: "user", Content: "hello", Timestamp: time.Now()},
+		{Role: "assistant", Content: "已 commit，磁盘已清理。", Timestamp: time.Now()},
+	}
+
+	payload := &protocol.ProgressEvent{
+		ChatID:    "cli:/test",
+		Phase:     "compressing",
+		Iteration: 1,
+	}
+	msg := suHistoryLoadMsg{
+		channelName:    "cli",
+		chatID:         "/test",
+		history:        history,
+		activeProgress: payload,
+	}
+
+	_ = m.handleSuHistoryLoad(msg)
+
+	if m.streamingMsgIdx < 0 {
+		t.Fatal("expected streamingMsgIdx >= 0 for compressing phase")
+	}
+
+	streamingMsg := m.messages[m.streamingMsgIdx]
+	if streamingMsg.content != "" {
+		t.Fatalf("streaming message content should be empty for compressing phase, got %q",
+			streamingMsg.content)
+	}
+	if !streamingMsg.isPartial {
+		t.Fatal("streaming message should be isPartial=true")
+	}
+
+	// The history assistant message should still be in messages (not deleted/merged).
+	foundHistoryAssistant := false
+	for i, msg := range m.messages {
+		if i == m.streamingMsgIdx {
+			continue
+		}
+		if msg.role == "assistant" && strings.Contains(msg.content, "已 commit") {
+			foundHistoryAssistant = true
+			break
+		}
+	}
+	if !foundHistoryAssistant {
+		t.Fatal("history assistant message should still exist, not be merged into streaming slot")
+	}
+}
+
+// TestSuHistoryLoad_CompressingPhase_TypingRestored verifies that when
+// typing was already true (from restoreSession) and Phase=="compressing",
+// a new empty streaming message is created rather than reusing the last
+// history assistant as the streaming slot.
+func TestSuHistoryLoad_CompressingPhase_TypingRestored(t *testing.T) {
+	m := newCLIModel()
+	m.channelName = "cli"
+	m.chatID = "/test"
+	m.handleResize(120, 40)
+	setupTestRemoteChannel(m)
+
+	// Simulate restored session: typing=true, streamingMsgIdx=-1 (cleared by
+	// HistoryCompacted handler before session switch).
+	m.typing = true
+	m.streamingMsgIdx = -1
+	m.splashState.suLoading = true
+
+	history := []channel.HistoryMessage{
+		{Role: "user", Content: "hello", Timestamp: time.Now()},
+		{Role: "assistant", Content: "previous reply", Timestamp: time.Now()},
+	}
+
+	payload := &protocol.ProgressEvent{
+		ChatID:    "cli:/test",
+		Phase:     "compressing",
+		Iteration: 1,
+	}
+	msg := suHistoryLoadMsg{
+		channelName:    "cli",
+		chatID:         "/test",
+		history:        history,
+		activeProgress: payload,
+	}
+
+	_ = m.handleSuHistoryLoad(msg)
+
+	if m.streamingMsgIdx < 0 {
+		t.Fatal("expected streamingMsgIdx >= 0 for compressing phase even when typing was restored")
+	}
+
+	streamingMsg := m.messages[m.streamingMsgIdx]
+	if streamingMsg.content != "" {
+		t.Fatalf("streaming message content should be empty, got %q", streamingMsg.content)
+	}
+
+	// The history assistant should NOT be marked as isPartial.
+	for i, msg := range m.messages {
+		if i == m.streamingMsgIdx {
+			continue
+		}
+		if msg.role == "assistant" && msg.isPartial {
+			t.Fatal("history assistant should not be marked isPartial for compressing phase")
+		}
+	}
+}
+
+// TestSuHistoryLoad_NonCompressingPhase_ContentMerge verifies the ORIGINAL
+// behavior is preserved for non-compressing phases: the last history assistant
+// IS merged into the streaming slot.
+func TestSuHistoryLoad_NonCompressingPhase_ContentMerge(t *testing.T) {
+	m := newCLIModel()
+	m.channelName = "cli"
+	m.chatID = "/test"
+	m.handleResize(120, 40)
+	setupTestRemoteChannel(m)
+
+	m.typing = false
+	m.splashState.suLoading = true
+
+	history := []channel.HistoryMessage{
+		{Role: "user", Content: "hello", Timestamp: time.Now()},
+		{Role: "assistant", Content: "in-flight reply", Timestamp: time.Now()},
+	}
+
+	payload := &protocol.ProgressEvent{
+		ChatID:    "cli:/test",
+		Phase:     "executing",
+		Iteration: 2,
+	}
+	msg := suHistoryLoadMsg{
+		channelName:    "cli",
+		chatID:         "/test",
+		history:        history,
+		activeProgress: payload,
+	}
+
+	_ = m.handleSuHistoryLoad(msg)
+
+	if m.streamingMsgIdx < 0 {
+		t.Fatal("expected streamingMsgIdx >= 0 for executing phase")
+	}
+
+	streamingMsg := m.messages[m.streamingMsgIdx]
+	if streamingMsg.content != "in-flight reply" {
+		t.Fatalf("expected streaming message content to be merged with history assistant, got %q",
+			streamingMsg.content)
+	}
+}
+
 // TestSuHistoryLoad_TypingReconcile_Default verifies that
 // handleSuHistoryLoad sets typing=false when the server has no active
 // turn (default path — turn completed while user was away).

--- a/channel/cli/cli_render_turn.go
+++ b/channel/cli/cli_render_turn.go
@@ -268,11 +268,23 @@ func (m *cliModel) liveIterationBlocks(p *protocol.ProgressEvent, width int, fal
 		})
 	}
 
-	if p.ReasoningStreamContent != "" {
+	// Prefer ReasoningStreamContent (streaming, real-time) but fall back to
+	// structured Reasoning (final, set by recordAssistantMsg). Structured
+	// progress events sent during tool execution do NOT carry
+	// ReasoningStreamContent — only Reasoning. Without this fallback, the
+	// reasoning box flickers: visible during streaming, disappears when the
+	// first structured event replaces m.progressState.current (losing
+	// ReasoningStreamContent), then reappears when carryForwardProgressState
+	// restores it or when the iteration is snapshotted.
+	reasoningContent := p.ReasoningStreamContent
+	if reasoningContent == "" {
+		reasoningContent = p.Reasoning
+	}
+	if reasoningContent != "" {
 		hasSpinner = true
 		blocks = append(blocks, turnBlock{
 			kind: turnBlockReasoning,
-			text: m.renderReasoningBox(p.ReasoningStreamContent, width, s),
+			text: m.renderReasoningBox(reasoningContent, width, s),
 		})
 	}
 

--- a/channel/cli/cli_update_session.go
+++ b/channel/cli/cli_update_session.go
@@ -196,7 +196,12 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 		// If history already has an assistant message, we must replace
 		// startAgentTurn's empty message with the history one to avoid showing
 		// two assistant messages (the history version + the empty streaming version).
-		{
+		//
+		// EXCEPTION: Phase=="compressing" — compression is a transient operation.
+		// The last assistant message in DB is NOT the in-flight streaming message;
+		// merging its content into the streaming slot causes the compression
+		// indicator to render inside the previous assistant's content.
+		if msg.activeProgress.Phase != "compressing" {
 			// Find the last non-streaming assistant message from history
 			// (before the empty one created by startAgentTurn).
 			historyAssistantIdx := -1
@@ -234,6 +239,20 @@ func (m *cliModel) handleSuHistoryLoad(msg suHistoryLoadMsg) []tea.Cmd {
 					}
 				}
 			}
+		} else if m.streamingMsgIdx < 0 {
+			// Phase=="compressing" with no streaming slot: create a fresh empty
+			// streaming message so the compression indicator renders standalone.
+			// Do NOT reuse the last history assistant — that would merge the
+			// compression indicator into the previous message's content.
+			m.messages = append(m.messages, cliMessage{
+				role:      "assistant",
+				content:   "",
+				timestamp: time.Now(),
+				isPartial: true,
+				dirty:     true,
+				turnID:    m.agentTurnID,
+			})
+			m.streamingMsgIdx = len(m.messages) - 1
 		}
 
 		// Sync todos from server snapshot so the todo bar shows them


### PR DESCRIPTION
## Problem

When the TUI executes tools, the reasoning block (思考链 / `reasoning_content`) would momentarily disappear and reappear, causing visible screen flicker.

## Root Cause

`liveIterationBlocks` only checked `ReasoningStreamContent` (the streaming field updated in real-time by `StreamReasoningFunc`), completely ignoring the structured `Reasoning` field.

During tool execution, every `notifyProgress` sends **structured** events that carry `Reasoning` but **NOT** `ReasoningStreamContent`. When such an event replaces `m.progressState.current`, the streaming content is lost and the reasoning box vanishes. It reappears once `carryForwardProgressState` restores `ReasoningStreamContent` or the iteration gets snapshotted — producing the flicker.

## Fix

Fall back to structured `Reasoning` when `ReasoningStreamContent` is empty:

```go
reasoningContent := p.ReasoningStreamContent
if reasoningContent == "" {
    reasoningContent = p.Reasoning
}
```

This is consistent with `renderTurnBody` (the completed-iteration render path), which already uses the `Reasoning` field.

## Test

Added two tests in `cli_flicker_test.go`:
- `TestReasoningBoxVisibleDuringToolExec` — verifies reasoning box stays visible when structured events (no `ReasoningStreamContent`) arrive during tool execution
- `TestReasoningBoxVisibleAcrossMultipleToolProgress` — verifies across multiple tool progress events
