### PR TITLE
fix(docs): resolve internal link 404s on GitHub Pages

### DIFF
--- a/docs-site/content/en/_index.md
+++ b/docs-site/content/en/_index.md
@@ -14,9 +14,9 @@ browser** — it uses tools to get real work done.
 
 <--->
 
-{{< button href="/getting-started" >}}Quick Start{{< /button >}}
+{{< button relref="getting-started.md" >}}Quick Start{{< /button >}}
 &nbsp;
-{{< button href="/installation" >}}Installation{{< /button >}}
+{{< button relref="installation.md" >}}Installation{{< /button >}}
 
 {{< /columns >}}
 

--- a/docs-site/content/zh-cn/_index.md
+++ b/docs-site/content/zh-cn/_index.md
@@ -13,9 +13,9 @@ geekdocHidden: true
 
 <--->
 
-{{< button href="/zh-cn/getting-started" >}}快速开始{{< /button >}}
+{{< button relref="getting-started.md" >}}快速开始{{< /button >}}
 &nbsp;
-{{< button href="/zh-cn/installation" >}}安装指南{{< /button >}}
+{{< button relref="installation.md" >}}安装指南{{< /button >}}
 
 {{< /columns >}}
 

--- a/docs-site/hugo.toml
+++ b/docs-site/hugo.toml
@@ -4,6 +4,7 @@
 baseURL = ""
 theme = "hugo-geekdoc"
 
+canonifyURLs = true
 pluralizeListTitles = false
 pygmentsUseClasses = true
 pygmentsCodeFences = true

--- a/docs-site/layouts/partials/head/custom.html
+++ b/docs-site/layouts/partials/head/custom.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" type="text/css" href="/custom.css">
+<link rel="stylesheet" type="text/css" href="{{ "custom.css" | relURL }}">


### PR DESCRIPTION
## Problem

Internal links on the GitHub Pages site all 404. For example:
- `https://ai-pivot.github.io/xbot/features/skills-agents/` works ✅
- But links rendered **inside pages** point to `https://ai-pivot.github.io/features/skills-agents/` (missing `/xbot/`) → 404 ❌

This affects **200+ absolute links** across all content pages (EN + ZH) — markdown links like `](/channels/)`, button shortcodes, image references, etc.

## Root Cause

Hugo content uses absolute paths like `](/channels/)` without the baseURL prefix. Since the site is hosted at `/xbot/`, these resolve to the domain root instead of the subpath.

## Fix

| File | Change |
|------|--------|
| `docs-site/hugo.toml` | Add `canonifyURLs = true` — Hugo prepends baseURL (`/xbot/`) to all absolute URLs in final HTML |
| `docs-site/layouts/partials/head/custom.html` | Use `relURL` pipe instead of hardcoded `/custom.css` |
| `docs-site/content/en/_index.md` | Button shortcodes: `href="/path"` → `relref="path.md"` |
| `docs-site/content/zh-cn/_index.md` | Same for ZH buttons |

## Verification

- ✅ Pre-commit hooks passed
- Should be tested after deploy: `https://ai-pivot.github.io/xbot/features/skills-agents/`
