### PR TITLE
feat: add OpenAI Responses API support

### DIFF
--- a/agent/llm_factory.go
+++ b/agent/llm_factory.go
@@ -414,7 +414,7 @@ func (f *LLMFactory) createEntryFromSub(sub *sqlite.LLMSubscription, model strin
 	}
 	cfg := &sqlite.UserLLMConfig{
 		Provider: sub.Provider, BaseURL: sub.BaseURL, APIKey: sub.APIKey,
-		Model: model, MaxOutputTokens: sub.MaxOutputTokens, ThinkingMode: sub.ThinkingMode,
+		Model: model, MaxOutputTokens: sub.MaxOutputTokens, ThinkingMode: sub.ThinkingMode, APIType: sub.APIType,
 	}
 	client, _ := f.createClient(cfg)
 	if client == nil {
@@ -764,7 +764,7 @@ func (f *LLMFactory) createClient(cfg *sqlite.UserLLMConfig) (llm.LLM, string) {
 	default:
 		client = llm.NewOpenAILLM(llm.OpenAIConfig{
 			BaseURL: cfg.BaseURL, APIKey: cfg.APIKey,
-			DefaultModel: model, MaxTokens: cfg.MaxOutputTokens,
+			DefaultModel: model, MaxTokens: cfg.MaxOutputTokens, APIType: cfg.APIType,
 			OnModelsLoaded: cfg.OnModelsLoaded, SubscriptionID: cfg.ID,
 		})
 	}
@@ -793,7 +793,7 @@ func (f *LLMFactory) createClientFromSub(sub *sqlite.LLMSubscription, model stri
 	f.mu.RUnlock()
 	cfg := &sqlite.UserLLMConfig{
 		Provider: sub.Provider, BaseURL: sub.BaseURL, APIKey: sub.APIKey,
-		Model: model, MaxOutputTokens: maxTokens,
+		Model: model, MaxOutputTokens: maxTokens, APIType: sub.APIType,
 	}
 	client, _ := f.createClient(cfg)
 	return client

--- a/agent/llm_factory.go
+++ b/agent/llm_factory.go
@@ -412,9 +412,14 @@ func (f *LLMFactory) createEntryFromSub(sub *sqlite.LLMSubscription, model strin
 	if model == "" {
 		model = f.defaultModel
 	}
+	// Resolve per-model APIType override, fallback to subscription-level
+	apiType := sub.APIType
+	if pm := sub.GetPerModelAPIType(model); pm != "" {
+		apiType = pm
+	}
 	cfg := &sqlite.UserLLMConfig{
 		Provider: sub.Provider, BaseURL: sub.BaseURL, APIKey: sub.APIKey,
-		Model: model, MaxOutputTokens: sub.MaxOutputTokens, ThinkingMode: sub.ThinkingMode, APIType: sub.APIType,
+		Model: model, MaxOutputTokens: sub.MaxOutputTokens, ThinkingMode: sub.ThinkingMode, APIType: apiType,
 	}
 	client, _ := f.createClient(cfg)
 	if client == nil {
@@ -791,9 +796,14 @@ func (f *LLMFactory) createClientFromSub(sub *sqlite.LLMSubscription, model stri
 		maxTokens = f.globalMaxTokens
 	}
 	f.mu.RUnlock()
+	// Resolve per-model APIType override, fallback to subscription-level
+	apiType := sub.APIType
+	if pm := sub.GetPerModelAPIType(model); pm != "" {
+		apiType = pm
+	}
 	cfg := &sqlite.UserLLMConfig{
 		Provider: sub.Provider, BaseURL: sub.BaseURL, APIKey: sub.APIKey,
-		Model: model, MaxOutputTokens: maxTokens, APIType: sub.APIType,
+		Model: model, MaxOutputTokens: maxTokens, APIType: apiType,
 	}
 	client, _ := f.createClient(cfg)
 	return client

--- a/agent/regression_test.go
+++ b/agent/regression_test.go
@@ -422,7 +422,7 @@ func TestResolveSubContext_UsesSubscriptionModels(t *testing.T) {
 	}
 
 	// Now add subscription_models data
-	subSvc.UpsertModel(e.subID, "test-model", 1000000, 8192, "")
+	subSvc.UpsertModel(e.subID, "test-model", 1000000, 8192, "", "")
 
 	// Verify resolveSubContext now uses subscription_models (higher priority)
 	if mc := f.resolveSubContext("test-model", e); mc != 1000000 {
@@ -435,7 +435,7 @@ func TestResolveSubContext_UsesSubscriptionModels(t *testing.T) {
 	}
 
 	// Clean up subscription_models, verify fallback
-	subSvc.UpsertModel(e.subID, "test-model", 0, 0, "") // setting max_context to 0
+	subSvc.UpsertModel(e.subID, "test-model", 0, 0, "", "") // setting max_context to 0
 	if mc := f.resolveSubContext("test-model", e); mc != 200000 {
 		t.Errorf("resolveSubContext(fallback) = %d, want 200000 (fallback to PerModelConfigs)", mc)
 	}
@@ -526,7 +526,7 @@ func TestSwitchModel_CopiesSubIDAndSub(t *testing.T) {
 	}
 
 	// Now set up subscription_models data for the new model
-	subSvc.UpsertModel(subGLM.ID, "deepseek-v4-pro", 1000000, 8192, "")
+	subSvc.UpsertModel(subGLM.ID, "deepseek-v4-pro", 1000000, 8192, "", "")
 
 	// Verify resolveSubContext returns 1M (from subscription_models, not PerModelConfigs)
 	// PerModelConfigs has 0 for deepseek-v4-pro, but subscription_models has 1M
@@ -576,7 +576,7 @@ func TestSwitchModel_PerChatEntryIndependent(t *testing.T) {
 	f.SwitchModel("cli_user", "deepseek-v4-pro", chatID)
 
 	// Add subscription_models data for deepseek under GLM subscription
-	subSvc.UpsertModel(subGLM.ID, "deepseek-v4-pro", 1000000, 8192, "")
+	subSvc.UpsertModel(subGLM.ID, "deepseek-v4-pro", 1000000, 8192, "", "")
 
 	// Now user-level switches to DeepSeek subscription entirely
 	f.InvalidateSender("cli_user")

--- a/channel/cli/cli_settings.go
+++ b/channel/cli/cli_settings.go
@@ -60,7 +60,22 @@ func (m *cliModel) readSettings() map[string]string {
 		values["llm_model"] = sub.Model
 		values["max_output_tokens"] = strconv.Itoa(sub.MaxOutputTokens)
 		values["thinking_mode"] = sub.ThinkingMode
-		values["api_type"] = sub.APIType
+		// api_type: per-model config → subscription-level
+		// Use the SESSION's active model for per-model override, matching
+		// max_context_tokens behavior.
+		apiModel := m.cachedModelName
+		if apiModel == "" {
+			apiModel = sub.Model
+		}
+		if apiModel != "" {
+			if pmc, ok := sub.PerModelConfigs[apiModel]; ok && pmc.APIType != "" {
+				values["api_type"] = pmc.APIType
+			} else {
+				values["api_type"] = sub.APIType
+			}
+		} else {
+			values["api_type"] = sub.APIType
+		}
 		// max_context_tokens: per-model config → subscription-level → empty
 		// Use the SESSION's active model (m.cachedModelName), NOT sub.Model.
 		// Without this, the settings panel shows the subscription default model's

--- a/channel/cli/cli_settings.go
+++ b/channel/cli/cli_settings.go
@@ -60,6 +60,7 @@ func (m *cliModel) readSettings() map[string]string {
 		values["llm_model"] = sub.Model
 		values["max_output_tokens"] = strconv.Itoa(sub.MaxOutputTokens)
 		values["thinking_mode"] = sub.ThinkingMode
+		values["api_type"] = sub.APIType
 		// max_context_tokens: per-model config → subscription-level → empty
 		// Use the SESSION's active model (m.cachedModelName), NOT sub.Model.
 		// Without this, the settings panel shows the subscription default model's
@@ -158,6 +159,12 @@ func (m *cliModel) saveSettings(values map[string]string) {
 				if v, ok := values["thinking_mode"]; ok {
 					if updated.ThinkingMode != v {
 						updated.ThinkingMode = v
+						changed = true
+					}
+				}
+				if v, ok := values["api_type"]; ok {
+					if updated.APIType != v {
+						updated.APIType = v
 						changed = true
 					}
 				}

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -589,6 +589,14 @@ func LocaleZH() *UILocale {
 				},
 			},
 			{
+				Key: "api_type", Label: "API 类型", Description: "OpenAI API 端点类型（默认 Chat Completions）",
+				Type: SettingTypeSelect, Category: "Agent", DefaultValue: "chat_completions",
+				Options: []SettingOption{
+					{Label: "Chat Completions（默认）", Value: "chat_completions"},
+					{Label: "Responses API", Value: "responses"},
+				},
+			},
+			{
 				Key: "enable_auto_compress", Label: "自动压缩", Description: "上下文过长时自动压缩（默认开启）",
 				Type: SettingTypeSelect, Category: "Agent", DefaultValue: "true",
 				Options: []SettingOption{
@@ -1006,6 +1014,14 @@ func localeEN() *UILocale {
 				},
 			},
 			{
+				Key: "api_type", Label: "API Type", Description: "OpenAI API endpoint type (default: Chat Completions)",
+				Type: SettingTypeSelect, Category: "Agent", DefaultValue: "chat_completions",
+				Options: []SettingOption{
+					{Label: "Chat Completions (default)", Value: "chat_completions"},
+					{Label: "Responses API", Value: "responses"},
+				},
+			},
+			{
 				Key: "enable_auto_compress", Label: "Auto Compress", Description: "Automatically compress when context is too long (on by default)",
 				Type: SettingTypeSelect, Category: "Agent", DefaultValue: "true",
 				Options: []SettingOption{
@@ -1420,6 +1436,14 @@ func localeJA() *UILocale {
 					{Label: "無効", Value: "disabled"},
 					{Label: "DeepSeek: effort=high", Value: `{"thinking":{"type":"enabled"},"reasoning_effort":"high"}`},
 					{Label: "DeepSeek: effort=max", Value: `{"thinking":{"type":"enabled"},"reasoning_effort":"max"}`},
+				},
+			},
+			{
+				Key: "api_type", Label: "API タイプ", Description: "OpenAI API エンドポイントタイプ（デフォルト: Chat Completions）",
+				Type: SettingTypeSelect, Category: "Agent", DefaultValue: "chat_completions",
+				Options: []SettingOption{
+					{Label: "Chat Completions（デフォルト）", Value: "chat_completions"},
+					{Label: "Responses API", Value: "responses"},
 				},
 			},
 			{

--- a/channel/setting_keys.go
+++ b/channel/setting_keys.go
@@ -72,6 +72,7 @@ var AllSettingDefs = []SettingDef{
 	{Key: "llm_model", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermManual, AIDescription: "Model name to use (provider-specific)", ValidValues: "provider-specific model ID"},
 	{Key: "max_output_tokens", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermPersistent, AIDescription: "Maximum tokens per response", ValidValues: "1-131072", DefaultValue: "4096"},
 	{Key: "thinking_mode", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermPersistent, AIDescription: "Enable thinking/reasoning mode", ValidValues: "true|false", DefaultValue: "true"},
+	{Key: "api_type", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermPersistent, AIDescription: "OpenAI API endpoint type: chat_completions or responses", ValidValues: "chat_completions|responses", DefaultValue: "chat_completions"},
 
 	// ── User-scoped settings (user_settings DB) ──
 	{Key: "enable_stream", Scope: ScopeUser, Source: SourceUserDB, Permission: PermTransient, AIDescription: "Show LLM output token-by-token", ValidValues: "true|false", DefaultValue: "true"},

--- a/channel/web/web.go
+++ b/channel/web/web.go
@@ -1062,8 +1062,16 @@ func (wc *WebChannel) readPump(c *Client, si *sessionInfo) {
 			msgChannel := "web"
 			msgSenderID := c.userID
 			msgSenderName := username
-			msgChatID := wc.getCurrentChatID(c.userID) // dynamic: respects chat switches
+			// Use getCurrentSession to support cross-channel browsing (admin can
+			// send messages to CLI/Feishu sessions from the Web UI).
+			sel := wc.getCurrentSession(c.userID)
+			msgChatID := sel.ChatID
 			msgChatType := "p2p"
+			if sel.Channel != "web" {
+				// Admin is browsing a non-web channel — send to that channel's session.
+				// Only admin is allowed (checked by handleChatSwitch which sets userCurrentSession).
+				msgChannel = sel.Channel
+			}
 			if c.isCLI && msg.Channel != "" && msg.ChatID != "" {
 				// Only CLI relay connections may override channel/chatID/sender.
 				// Web browser clients must use their authenticated identity.

--- a/channel/web/web.go
+++ b/channel/web/web.go
@@ -1062,16 +1062,8 @@ func (wc *WebChannel) readPump(c *Client, si *sessionInfo) {
 			msgChannel := "web"
 			msgSenderID := c.userID
 			msgSenderName := username
-			// Use getCurrentSession to support cross-channel browsing (admin can
-			// send messages to CLI/Feishu sessions from the Web UI).
-			sel := wc.getCurrentSession(c.userID)
-			msgChatID := sel.ChatID
+			msgChatID := wc.getCurrentChatID(c.userID) // dynamic: respects chat switches
 			msgChatType := "p2p"
-			if sel.Channel != "web" {
-				// Admin is browsing a non-web channel — send to that channel's session.
-				// Only admin is allowed (checked by handleChatSwitch which sets userCurrentSession).
-				msgChannel = sel.Channel
-			}
 			if c.isCLI && msg.Channel != "" && msg.ChatID != "" {
 				// Only CLI relay connections may override channel/chatID/sender.
 				// Web browser clients must use their authenticated identity.

--- a/docs/plans/openai-responses-api.md
+++ b/docs/plans/openai-responses-api.md
@@ -1,0 +1,121 @@
+# Plan: OpenAI Responses API Support
+
+## Summary
+
+为 xbot 增加 OpenAI Responses API (`POST /v1/responses`) 作为 Chat Completions 之外的可选路径，通过 subscription 级 `api_type` 字段切换。默认 `chat_completions` 保持向后兼容；设为 `responses` 时走新路径。功能与 Chat Completions 对等（text + function calling + streaming + reasoning 适配）。
+
+## Changes
+
+### 1. `llm/openai.go` — 加字段 + 路由分发
+
+- **What**: `OpenAIConfig` 加 `APIType string`；`OpenAILLM` 加 `apiType string`；`NewOpenAILLM` 存储 `apiType`；`Generate()`/`GenerateStream()` 开头加 `if o.apiType == "responses"` 分发到新方法。
+- **Why**: 路由决策在客户端构造时确定（subscription 级），运行时每次调用按 `apiType` 分发。保持现有 Chat Completions 路径完全不变。
+
+### 2. `llm/openai_responses.go` — NEW: Responses API 实现
+
+核心文件，包含以下函数：
+
+**消息转换**（`ChatMessage[]` → `ResponseNewParams`）:
+- `toResponsesParams(messages, thinkingMode)` → `openai.ResponseNewParams`
+- `toResponsesInput(messages)` → `[]openai.ResponseInputItemUnionParam`
+  - `role: system` → 拼接为 `Instructions` 字段（不进 Input）
+  - `role: user, string` → `EasyInputMessageParam{Role:"user"}`
+  - `role: user, multimodal` → `ResponseInputItemMessageParam` with content parts
+  - `role: assistant, text only` → `EasyInputMessageParam{Role:"assistant"}`
+  - `role: assistant, tool_calls` → 每个 tool call 一个 `ResponseFunctionToolCallParam`
+  - `role: tool` → `ResponseInputItemFunctionCallOutputParam{CallID: toolCallID, Output: content}`
+
+**工具转换**:
+- `toResponsesTools(tools)` → `[]openai.ToolUnionParam`，每个映射为 `FunctionToolParam{Name, Parameters, Description, Strict: false}`
+- 注意：Responses API 的 `Strict` 默认 true，需显式设 false 保持兼容
+
+**reasoning 适配**:
+- `thinkingMode == "enabled"` → `Reasoning{Effort: "medium", Summary: "auto"}`
+- `thinkingMode == "disabled"` → `Reasoning{Effort: "none"}`
+- 自定义 JSON → 解析后映射到 `ReasoningParam`
+
+**非流式**:
+- `generateResponses(ctx, model, messages, tools, thinkingMode)` → `*LLMResponse`
+  - 调 `o.client.Responses.New(ctx, params, opts...)`
+  - 遍历 `resp.Output[]`：`type=="message"` 提取 text；`type=="function_call"` 提取 ToolCall（CallID→ID）；`type=="reasoning"` 提取 summary → ReasoningContent
+  - Usage: `InputTokens→PromptTokens`, `OutputTokens→CompletionTokens`, `CachedTokens→CacheHitTokens`
+  - Status → FinishReason 映射
+
+**流式**:
+- `generateStreamResponses(ctx, model, messages, tools, thinkingMode)` → `<-chan StreamEvent`
+- 处理 `ResponseStreamEventUnion`:
+  - `response.output_text.delta` → EventContent
+  - `response.reasoning_summary_text.delta` / `response.reasoning_text.delta` → EventReasoningContent
+  - `response.output_item.added` (type==function_call) → EventToolCall（ID + Name）
+  - `response.function_call_arguments.delta` → EventToolCall（Arguments delta）
+  - `response.function_call_arguments.done` → EventToolCall（完整 Arguments + Name + CallID）
+  - `response.completed` → EventUsage + EventDone
+  - `error` → EventError
+
+### 3. `llm/openai_responses_test.go` — NEW: 测试
+
+- 消息转换测试：各 role → Responses Input 映射
+- 工具转换测试：ToolDefinition → FunctionToolParam
+- reasoning 映射测试：thinkingMode → ReasoningParam
+- 响应解析测试：mock Response → LLMResponse（text + tool_calls + reasoning + usage）
+- 流式事件测试：模拟事件序列 → StreamEvent 序列
+
+### 4. `protocol/events.go` — Subscription 加字段
+
+- `Subscription` struct 加 `APIType string \`json:"api_type,omitempty"\``
+- 影响范围：config.json 订阅配置 + RPC 传输 + DB struct
+
+### 5. `storage/sqlite/user_llm_subscription.go` — DB 层
+
+- `LLMSubscription` struct 加 `APIType string`
+- `scanSubscription()` 的 `Scan()` 加 `&sub.APIType`
+- 所有 SELECT 语句加 `api_type` 列
+- INSERT 语句加 `api_type` 列 + 占位符
+- UPDATE 语句加 `api_type = ?`
+
+### 6. `storage/sqlite/user_llm_config.go` — DB 传输层
+
+- `UserLLMConfig` struct 加 `APIType string`
+- SELECT/INSERT/UPDATE 加 `api_type` 列
+
+### 7. `storage/sqlite/migrations.go` — v36 migration
+
+- `const schemaVersion = 36`
+- 新增 `migrateV35ToV36`: `ALTER TABLE user_llm_subscriptions ADD COLUMN api_type TEXT DEFAULT ''`
+- 注册到 `migrateSchema` 的 migration list
+
+### 8. `agent/llm_factory.go` — 工厂层透传
+
+- `createClient()`: `OpenAIConfig{...}` 加 `APIType: cfg.APIType`
+- `createEntryFromSub()`: `UserLLMConfig{...}` 加 `APIType: sub.APIType`
+- `createClientFromSub()`: `UserLLMConfig{...}` 加 `APIType: sub.APIType`（同时补全现有 ThinkingMode 遗漏）
+
+### 9. `serverapp/rpc_table.go` — RPC handler
+
+- `updateSubscription` / `setDefaultSubscription` 等 handler 中 subscription 字段映射加 `api_type`（overlay 模式，非空才覆盖）
+
+## Risks
+
+- **SQL 列顺序不匹配**: scanSubscription 的 Scan 参数必须与 SELECT 列顺序严格对应。→ 逐条核对所有 SQL 语句。
+- **Responses API system message 处理**: Responses API 用 `Instructions` 字段而非 Input 中的 system role 消息。多个 system 消息需拼接。→ 在 `toResponsesParams` 中特殊处理。
+- **CallID vs tool_call_id 映射**: Responses API 用 `CallID` 关联 function call 和 output，xbot 的 `ToolCall.ID` / `ChatMessage.ToolCallID` 需要正确映射。→ 双向转换在转换函数中集中处理。
+- **MaxOutputTokens 语义差异**: Responses API 的 `max_output_tokens` 包含 reasoning tokens，Chat Completions 的 `max_tokens` 不含。→ 初期不做特殊调整，直接传同一个值，用户可能需要调大配置值。
+- **Strict mode**: Responses API FunctionToolParam 默认 `Strict: true`，会强制 JSON Schema 严格匹配。→ 显式设 `false` 保持与 Chat Completions 一致。
+
+## Definition of Done
+
+- [ ] `go build ./...` 通过
+- [ ] `go test ./llm/...` 通过（含新测试）
+- [ ] `go test ./...` 全部通过
+- [ ] 配置 `api_type: "responses"` 后，text 对话正常工作
+- [ ] 配置 `api_type: "responses"` 后，function calling 正常工作（调用+回传）
+- [ ] 配置 `api_type: "responses"` 后，streaming 正常工作
+- [ ] 配置 `api_type: "responses"` 后，thinkingMode → reasoning 映射正常
+- [ ] 不配置 `api_type`（默认 chat_completions）时，行为完全不变
+
+## Open Questions
+
+（已全部确认）
+1. reasoning 兼容映射 → 做（`type=="reasoning"` 的 summary → ReasoningContent）
+2. CLI 面板不需要暴露
+3. 第三方普遍支持，无需 fallback

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -28,6 +28,7 @@ type OpenAILLM struct {
 	defaultModel      string         // 默认模型
 	maxTokens         int            // 最大生成 token 数（用户配置值，作为上限）
 	baseURL           string         // API base URL for error logging/diagnosis
+	apiType           string         // "chat_completions" (default) | "responses"
 	onModelsLoaded    func([]string) // callback after models loaded from API
 	onModelsLoadError func(error)    // callback after models load fails
 	modelsLoaded      bool           // true after first ListModels() triggers async fetch
@@ -50,6 +51,11 @@ type OpenAIConfig struct {
 	MaxTokens    int    // 最大生成 token 数（默认 defaultMaxTokens）
 	UserAgent    string // 自定义 User-Agent（留空使用默认值）
 
+	// APIType selects the OpenAI API endpoint to use.
+	// "chat_completions" (default) — POST /v1/chat/completions
+	// "responses" — POST /v1/responses (OpenAI Responses API)
+	APIType string
+
 	// OnModelsLoadError is called when the async model list API call fails.
 	// Used by CLI to show a toast notification.
 	OnModelsLoadError func(err error)
@@ -67,6 +73,14 @@ type OpenAIConfig struct {
 // Keep in sync with config.DefaultMaxOutputTokens.
 const defaultMaxTokens = 32_768
 
+// API type constants for selecting between OpenAI API endpoints.
+const (
+	// APITypeChatCompletions is the default API type, using POST /v1/chat/completions.
+	APITypeChatCompletions = "chat_completions"
+	// APITypeResponses uses the OpenAI Responses API (POST /v1/responses).
+	APITypeResponses = "responses"
+)
+
 // NewOpenAILLM 创建 OpenAI LLM 实例
 func NewOpenAILLM(cfg OpenAIConfig) *OpenAILLM {
 	if cfg.MaxTokens <= 0 {
@@ -80,6 +94,7 @@ func NewOpenAILLM(cfg OpenAIConfig) *OpenAILLM {
 
 	o := &OpenAILLM{
 		baseURL:           cfg.BaseURL,
+		apiType:           cfg.APIType,
 		maxTokens:         cfg.MaxTokens,
 		onModelsLoaded:    cfg.OnModelsLoaded,
 		onModelsLoadError: cfg.OnModelsLoadError,
@@ -759,6 +774,11 @@ func (o *OpenAILLM) buildThinkingOptions(thinkingMode string) []option.RequestOp
 
 // Generate 生成 LLM 响应
 func (o *OpenAILLM) Generate(ctx context.Context, model string, messages []ChatMessage, tools []ToolDefinition, thinkingMode string) (*LLMResponse, error) {
+	// Route to Responses API if configured
+	if o.apiType == APITypeResponses {
+		return o.generateResponses(ctx, model, messages, tools, thinkingMode)
+	}
+
 	// 如果未指定模型，使用默认模型
 	if model == "" {
 		model = o.GetDefaultModel()
@@ -888,6 +908,11 @@ func (o *OpenAILLM) Generate(ctx context.Context, model string, messages []ChatM
 
 // GenerateStream 流式生成 LLM 响应
 func (o *OpenAILLM) GenerateStream(ctx context.Context, model string, messages []ChatMessage, tools []ToolDefinition, thinkingMode string) (<-chan StreamEvent, error) {
+	// Route to Responses API if configured
+	if o.apiType == APITypeResponses {
+		return o.generateStreamResponses(ctx, model, messages, tools, thinkingMode)
+	}
+
 	// 如果未指定模型，使用默认模型
 	if model == "" {
 		model = o.GetDefaultModel()

--- a/llm/openai_responses.go
+++ b/llm/openai_responses.go
@@ -141,7 +141,7 @@ func toResponsesParams(model string, messages []ChatMessage, maxTokens int) resp
 		// xbot is stateless — it sends full message history each turn and
 		// never uses previous_response_id. Setting store=false avoids
 		// unnecessary server-side storage of conversation state.
-		Store: param.Opt[bool]{Value: false},
+		Store: param.NewOpt(false),
 	}
 
 	if len(instructions) > 0 {
@@ -186,7 +186,7 @@ func toResponsesTools(tools []ToolDefinition) []responses.ToolUnionParam {
 				},
 				// Strict defaults to true in the Responses API; set false to
 				// match Chat Completions behavior (no strict schema enforcement).
-				Strict: param.Opt[bool]{Value: false},
+				Strict: param.NewOpt(false),
 			},
 		})
 	}

--- a/llm/openai_responses.go
+++ b/llm/openai_responses.go
@@ -29,7 +29,7 @@ import (
 //   - tool/result messages become ResponseInputItemFunctionCallOutputParam items
 //   - reasoning_content from previous assistant turns is passed back as
 //     ResponseReasoningItemParam items
-func toResponsesParams(model string, messages []ChatMessage, thinkingMode string, maxTokens int) responses.ResponseNewParams {
+func toResponsesParams(model string, messages []ChatMessage, maxTokens int) responses.ResponseNewParams {
 	var instructions []string
 	inputItems := make([]responses.ResponseInputItemUnionParam, 0, len(messages))
 
@@ -138,6 +138,10 @@ func toResponsesParams(model string, messages []ChatMessage, thinkingMode string
 			OfInputItemList: responses.ResponseInputParam(inputItems),
 		},
 		MaxOutputTokens: param.Opt[int64]{Value: int64(maxTokens)},
+		// xbot is stateless — it sends full message history each turn and
+		// never uses previous_response_id. Setting store=false avoids
+		// unnecessary server-side storage of conversation state.
+		Store: param.Opt[bool]{Value: false},
 	}
 
 	if len(instructions) > 0 {
@@ -277,7 +281,7 @@ func (o *OpenAILLM) generateResponses(ctx context.Context, model string, message
 		effectiveMaxTokens = maxOut
 	}
 
-	params := toResponsesParams(model, messages, thinkingMode, effectiveMaxTokens)
+	params := toResponsesParams(model, messages, effectiveMaxTokens)
 
 	// Build reasoning config
 	reasoning := buildResponsesReasoning(thinkingMode)
@@ -338,18 +342,12 @@ func (o *OpenAILLM) generateResponses(ctx context.Context, model string, message
 			})
 
 		case "reasoning":
-			// Extract reasoning summary content
+			// Extract reasoning summary content.
+			// Note: item.Content (full reasoning text) requires the "reasoning.encrypted_content"
+			// include parameter and is not available by default. We only use Summary,
+			// which is always returned when reasoning is enabled.
 			for _, summary := range item.Summary {
 				result.ReasoningContent += summary.Text
-			}
-			// Also check for reasoning content (full reasoning text)
-			for _, content := range item.Content {
-				if content.Type == "reasoning_text" {
-					if result.ReasoningContent != "" {
-						result.ReasoningContent += "\n"
-					}
-					result.ReasoningContent += content.Text
-				}
 			}
 		}
 	}
@@ -428,7 +426,7 @@ func (o *OpenAILLM) generateStreamResponses(ctx context.Context, model string, m
 		effectiveMaxTokens = maxOut
 	}
 
-	params := toResponsesParams(model, messages, thinkingMode, effectiveMaxTokens)
+	params := toResponsesParams(model, messages, effectiveMaxTokens)
 
 	// Build reasoning config
 	reasoning := buildResponsesReasoning(thinkingMode)
@@ -472,16 +470,20 @@ func (o *OpenAILLM) processResponsesStream(ctx context.Context, stream *ssestrea
 	defer stream.Close()
 
 	// Connect context cancellation to stream.Close().
+	// Use a done channel to allow the goroutine to exit when the stream
+	// processing completes normally (prevents goroutine leak).
+	streamDone := make(chan struct{})
 	ctxDone := ctx.Done()
 	if ctxDone != nil {
 		go func() {
 			select {
 			case <-ctxDone:
 				stream.Close()
-			case <-ctx.Done():
+			case <-streamDone:
 			}
 		}()
 	}
+	defer close(streamDone)
 
 	l := log.Ctx(ctx)
 	eventCount := 0
@@ -566,7 +568,11 @@ func (o *OpenAILLM) processResponsesStream(ctx context.Context, stream *ssestrea
 					Name:  event.Item.Name,
 					index: len(toolCallList),
 				}
-				toolCallsByID[event.ItemID] = tc
+				// Use event.Item.ID as the map key — this is the "item_id"
+				// that subsequent function_call_arguments.delta/done events carry.
+				// event.ItemID is empty for output_item.added events (no top-level
+				// "item_id" in the JSON; the ID lives inside event.Item.ID).
+				toolCallsByID[event.Item.ID] = tc
 				toolCallList = append(toolCallList, tc)
 				hasToolCalls = true
 
@@ -604,6 +610,27 @@ func (o *OpenAILLM) processResponsesStream(ctx context.Context, stream *ssestrea
 				}
 				if event.Name != "" {
 					tc.Name = event.Name
+				}
+			}
+
+		case "response.output_item.done":
+			// Output item complete — use as fallback for tool calls that
+			// may have missed delta events (defensive).
+			if event.Item.Type == "function_call" {
+				tc, ok := toolCallsByID[event.Item.ID]
+				if ok {
+					// Only update if arguments were missing (delta events failed)
+					if tc.Arguments == "" && event.Item.Arguments != "" {
+						tc.Arguments = event.Item.Arguments
+						// Send the complete arguments as a final delta
+						eventChan <- StreamEvent{
+							Type: EventToolCall,
+							ToolCall: &ToolCallDelta{
+								Index:     tc.index,
+								Arguments: tc.Arguments,
+							},
+						}
+					}
 				}
 			}
 

--- a/llm/openai_responses.go
+++ b/llm/openai_responses.go
@@ -1,0 +1,712 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	log "xbot/logger"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/packages/ssestream"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// ---------------------------------------------------------------------------
+// Message conversion: ChatMessage[] → ResponseNewParams
+// ---------------------------------------------------------------------------
+
+// toResponsesParams converts xbot ChatMessages into a ResponseNewParams
+// suitable for the OpenAI Responses API (POST /v1/responses).
+//
+// Key differences from Chat Completions:
+//   - system messages are extracted into the Instructions field (not in Input)
+//   - assistant tool_calls become individual ResponseFunctionToolCallParam items
+//   - tool/result messages become ResponseInputItemFunctionCallOutputParam items
+//   - reasoning_content from previous assistant turns is passed back as
+//     ResponseReasoningItemParam items
+func toResponsesParams(model string, messages []ChatMessage, thinkingMode string, maxTokens int) responses.ResponseNewParams {
+	var instructions []string
+	inputItems := make([]responses.ResponseInputItemUnionParam, 0, len(messages))
+	reasoningHistoryObserved := hasAssistantReasoningHistory(messages)
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case "system":
+			// Collect system messages as instructions (sent separately from Input)
+			if msg.Content != "" {
+				instructions = append(instructions, msg.Content)
+			}
+
+		case "user":
+			// Check for embedded images (data: URLs in markdown image syntax)
+			parts := parseEmbeddedImages(msg.Content)
+			if len(parts) > 1 {
+				// Multi-part message with images
+				contentParts := make(responses.ResponseInputMessageContentListParam, 0, len(parts))
+				for _, p := range parts {
+					switch p.Type {
+					case "text":
+						contentParts = append(contentParts, responses.ResponseInputContentUnionParam{
+							OfInputText: &responses.ResponseInputTextParam{Text: p.Text},
+						})
+					case "image":
+						contentParts = append(contentParts, responses.ResponseInputContentUnionParam{
+							OfInputImage: &responses.ResponseInputImageParam{ImageURL: param.Opt[string]{Value: p.URL}},
+						})
+					}
+				}
+				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
+					OfMessage: &responses.EasyInputMessageParam{
+						Role:    responses.EasyInputMessageRoleUser,
+						Content: responses.EasyInputMessageContentUnionParam{OfInputItemContentList: contentParts},
+					},
+				})
+			} else {
+				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
+					OfMessage: &responses.EasyInputMessageParam{
+						Role:    responses.EasyInputMessageRoleUser,
+						Content: responses.EasyInputMessageContentUnionParam{OfString: param.Opt[string]{Value: msg.Content}},
+					},
+				})
+			}
+
+		case "assistant":
+			// If there's reasoning_content, add a reasoning item first
+			if msg.ReasoningContent != "" {
+				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
+					OfReasoning: &responses.ResponseReasoningItemParam{
+						ID: fmt.Sprintf("rs_%d", len(inputItems)),
+						Summary: []responses.ResponseReasoningItemSummaryParam{
+							{Text: msg.ReasoningContent},
+						},
+					},
+				})
+			}
+
+			// If there are tool calls, add each as a function_call item
+			if len(msg.ToolCalls) > 0 {
+				for _, tc := range msg.ToolCalls {
+					args := tc.Arguments
+					if args == "" {
+						args = "{}"
+					}
+					inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
+						OfFunctionCall: &responses.ResponseFunctionToolCallParam{
+							Arguments: args,
+							CallID:    tc.ID,
+							Name:      tc.Name,
+						},
+					})
+				}
+			}
+
+			// If there's text content (and not just tool calls), add an assistant message
+			if msg.Content != "" || (len(msg.ToolCalls) == 0 && msg.ReasoningContent == "") {
+				contentText := msg.Content
+				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
+					OfMessage: &responses.EasyInputMessageParam{
+						Role:    responses.EasyInputMessageRoleAssistant,
+						Content: responses.EasyInputMessageContentUnionParam{OfString: param.Opt[string]{Value: contentText}},
+					},
+				})
+			}
+
+		case "tool":
+			// Tool result → function_call_output item
+			output := msg.Content
+			if output == "" {
+				output = "{}"
+			}
+			inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
+				OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+					CallID: msg.ToolCallID,
+					Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
+						OfString: param.Opt[string]{Value: output},
+					},
+				},
+			})
+		}
+	}
+
+	// Suppress unused variable warning for reasoningHistoryObserved — it's used
+	// to decide whether to include reasoning items in context (already handled above).
+	_ = reasoningHistoryObserved
+
+	p := responses.ResponseNewParams{
+		Model: openai.ResponsesModel(model),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: responses.ResponseInputParam(inputItems),
+		},
+		MaxOutputTokens: param.Opt[int64]{Value: int64(maxTokens)},
+	}
+
+	if len(instructions) > 0 {
+		p.Instructions = param.Opt[string]{Value: strings.Join(instructions, "\n\n")}
+	}
+
+	return p
+}
+
+// toResponsesTools converts xbot ToolDefinitions into Responses API tool params.
+func toResponsesTools(tools []ToolDefinition) []responses.ToolUnionParam {
+	result := make([]responses.ToolUnionParam, 0, len(tools))
+	for _, tool := range tools {
+		properties := make(map[string]any)
+		required := make([]string, 0)
+		for _, p := range tool.Parameters() {
+			prop := map[string]any{
+				"type":        p.Type,
+				"description": p.Description,
+			}
+			if p.Items != nil {
+				prop["items"] = p.Items
+			}
+			properties[p.Name] = prop
+			if p.Required {
+				required = append(required, p.Name)
+			}
+		}
+		result = append(result, responses.ToolUnionParam{
+			OfFunction: &responses.FunctionToolParam{
+				Name:        tool.Name(),
+				Description: param.Opt[string]{Value: tool.Description()},
+				Parameters: map[string]any{
+					"type":       "object",
+					"properties": properties,
+					"required":   required,
+				},
+				// Strict defaults to true in the Responses API; set false to
+				// match Chat Completions behavior (no strict schema enforcement).
+				Strict: param.Opt[bool]{Value: false},
+			},
+		})
+	}
+	return result
+}
+
+// buildResponsesReasoning maps xbot thinkingMode to Responses API ReasoningParam.
+//
+// thinkingMode values:
+//   - "" (default): no reasoning param (let API decide)
+//   - "enabled": medium effort with auto summary
+//   - "disabled": none effort (explicitly disable reasoning)
+//   - custom JSON: parsed and mapped to ReasoningParam fields
+func buildResponsesReasoning(thinkingMode string) openai.ReasoningParam {
+	if thinkingMode == "" {
+		return openai.ReasoningParam{}
+	}
+
+	switch thinkingMode {
+	case "enabled":
+		return openai.ReasoningParam{
+			Effort:  openai.ReasoningEffortMedium,
+			Summary: openai.ReasoningSummaryAuto,
+		}
+	case "disabled":
+		return openai.ReasoningParam{
+			Effort: openai.ReasoningEffortNone,
+		}
+	default:
+		// Try parsing as JSON for custom reasoning config
+		if len(thinkingMode) > 0 && thinkingMode[0] == '{' {
+			var custom map[string]any
+			if err := json.Unmarshal([]byte(thinkingMode), &custom); err == nil {
+				rp := openai.ReasoningParam{}
+				if effort, ok := custom["effort"]; ok {
+					if effortStr, ok := effort.(string); ok {
+						rp.Effort = openai.ReasoningEffort(effortStr)
+					}
+				}
+				if summary, ok := custom["summary"]; ok {
+					if summaryStr, ok := summary.(string); ok {
+						rp.Summary = openai.ReasoningSummary(summaryStr)
+					}
+				}
+				// Check for nested "reasoning" key (e.g. {"reasoning": {"effort": "high"}})
+				if reasoningObj, ok := custom["reasoning"]; ok {
+					if reasoningMap, ok := reasoningObj.(map[string]any); ok {
+						if effort, ok := reasoningMap["effort"]; ok {
+							if effortStr, ok := effort.(string); ok {
+								rp.Effort = openai.ReasoningEffort(effortStr)
+							}
+						}
+						if summary, ok := reasoningMap["summary"]; ok {
+							if summaryStr, ok := summary.(string); ok {
+								rp.Summary = openai.ReasoningSummary(summaryStr)
+							}
+						}
+					}
+				}
+				return rp
+			}
+			log.WithField("thinking_mode", thinkingMode).Warn("[LLM] Failed to parse thinking mode as JSON for Responses API, ignoring")
+		}
+		return openai.ReasoningParam{}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming: Generate via Responses API
+// ---------------------------------------------------------------------------
+
+func (o *OpenAILLM) generateResponses(ctx context.Context, model string, messages []ChatMessage, tools []ToolDefinition, thinkingMode string) (*LLMResponse, error) {
+	if model == "" {
+		model = o.GetDefaultModel()
+	}
+
+	log.Ctx(ctx).WithFields(log.Fields{
+		"provider":      "openai-responses",
+		"model":         model,
+		"stream":        false,
+		"msg_count":     len(messages),
+		"tools_count":   len(tools),
+		"thinking_mode":  thinkingMode,
+		"max_tokens":    o.maxTokens,
+	}).Info("[LLM] Starting non-stream request (Responses API)")
+
+	startTime := time.Now()
+
+	// Clamp max tokens to model's limit
+	effectiveMaxTokens := o.maxTokens
+	if maxOut := modelMaxOutputTokens(model); maxOut > 0 && effectiveMaxTokens > maxOut {
+		effectiveMaxTokens = maxOut
+	}
+
+	params := toResponsesParams(model, messages, thinkingMode, effectiveMaxTokens)
+
+	// Build reasoning config
+	reasoning := buildResponsesReasoning(thinkingMode)
+	if reasoning.Effort != "" || reasoning.Summary != "" {
+		params.Reasoning = reasoning
+		log.Ctx(ctx).Debugf("[LLM] Responses API reasoning config: effort=%s, summary=%s", reasoning.Effort, reasoning.Summary)
+	}
+
+	// Build tools
+	if len(tools) > 0 {
+		params.Tools = toResponsesTools(tools)
+	}
+
+	// Build thinking options (for non-reasoning custom params like temperature overrides)
+	opts := o.buildThinkingOptions(thinkingMode)
+
+	resp, err := o.client.Responses.New(ctx, params, opts...)
+	if err != nil {
+		log.Ctx(ctx).WithFields(log.Fields{
+			"provider": "openai-responses",
+			"duration": time.Since(startTime).String(),
+			"error":    err.Error(),
+		}).Error("[LLM] Responses API request failed")
+		return nil, fmt.Errorf("openai responses: %w", err)
+	}
+
+	// Parse response
+	result := &LLMResponse{}
+
+	// Parse token usage
+	result.Usage = TokenUsage{
+		PromptTokens:     resp.Usage.InputTokens,
+		CompletionTokens: resp.Usage.OutputTokens,
+		TotalTokens:      resp.Usage.TotalTokens,
+	}
+	if resp.Usage.InputTokensDetails.CachedTokens > 0 {
+		result.Usage.CacheHitTokens = resp.Usage.InputTokensDetails.CachedTokens
+	}
+
+	// Iterate over output items
+	for _, item := range resp.Output {
+		switch item.Type {
+		case "message":
+			// Extract text content
+			for _, content := range item.Content {
+				if content.Type == "output_text" {
+					result.Content += content.Text
+				}
+			}
+
+		case "function_call":
+			// Extract tool call
+			result.ToolCalls = append(result.ToolCalls, ToolCall{
+				ID:        item.CallID,
+				Name:      item.Name,
+				Arguments: item.Arguments,
+			})
+
+		case "reasoning":
+			// Extract reasoning summary content
+			for _, summary := range item.Summary {
+				result.ReasoningContent += summary.Text
+			}
+			// Also check for reasoning content (full reasoning text)
+			for _, content := range item.Content {
+				if content.Type == "reasoning_text" {
+					if result.ReasoningContent != "" {
+						result.ReasoningContent += "\n"
+					}
+					result.ReasoningContent += content.Text
+				}
+			}
+		}
+	}
+
+	// Map response status to finish reason
+	result.FinishReason = responsesStatusToFinishReason(resp.Status, len(result.ToolCalls) > 0)
+
+	fields := log.Fields{
+		"provider":          "openai-responses",
+		"duration":          time.Since(startTime).String(),
+		"output_count":     len(resp.Output),
+		"content_len":       len(result.Content),
+		"reasoning_len":     len(result.ReasoningContent),
+		"tool_calls":        len(result.ToolCalls),
+		"finish_reason":     result.FinishReason,
+		"prompt_tokens":     result.Usage.PromptTokens,
+		"completion_tokens": result.Usage.CompletionTokens,
+		"total_tokens":      result.Usage.TotalTokens,
+	}
+	if isNearEmptyResponse(result) {
+		addNearEmptyResponseDebugFields(fields, messages, model, tools, thinkingMode)
+		log.Ctx(ctx).WithFields(fields).Warn("[LLM] Responses API request completed with near-empty response")
+	} else {
+		log.Ctx(ctx).WithFields(fields).Debug("[LLM] Responses API request completed")
+	}
+
+	return result, nil
+}
+
+// responsesStatusToFinishReason maps Responses API status to xbot FinishReason.
+func responsesStatusToFinishReason(status responses.ResponseStatus, hasToolCalls bool) FinishReason {
+	switch status {
+	case "completed":
+		if hasToolCalls {
+			return FinishReasonToolCalls
+		}
+		return FinishReasonStop
+	case "incomplete":
+		return FinishReasonLength
+	case "failed", "cancelled":
+		return FinishReasonStop
+	case "in_progress", "queued":
+		return FinishReasonStop
+	default:
+		if hasToolCalls {
+			return FinishReasonToolCalls
+		}
+		return FinishReasonStop
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Streaming: GenerateStream via Responses API
+// ---------------------------------------------------------------------------
+
+func (o *OpenAILLM) generateStreamResponses(ctx context.Context, model string, messages []ChatMessage, tools []ToolDefinition, thinkingMode string) (<-chan StreamEvent, error) {
+	if model == "" {
+		model = o.GetDefaultModel()
+	}
+
+	log.Ctx(ctx).WithFields(log.Fields{
+		"provider":      "openai-responses",
+		"model":         model,
+		"stream":        true,
+		"msg_count":     len(messages),
+		"tools_count":   len(tools),
+		"thinking_mode": thinkingMode,
+		"max_tokens":    o.maxTokens,
+	}).Info("[LLM] Starting stream request (Responses API)")
+
+	startTime := time.Now()
+
+	// Clamp max tokens
+	effectiveMaxTokens := o.maxTokens
+	if maxOut := modelMaxOutputTokens(model); maxOut > 0 && effectiveMaxTokens > maxOut {
+		effectiveMaxTokens = maxOut
+	}
+
+	params := toResponsesParams(model, messages, thinkingMode, effectiveMaxTokens)
+
+	// Build reasoning config
+	reasoning := buildResponsesReasoning(thinkingMode)
+	if reasoning.Effort != "" || reasoning.Summary != "" {
+		params.Reasoning = reasoning
+	}
+
+	// Build tools
+	if len(tools) > 0 {
+		params.Tools = toResponsesTools(tools)
+	}
+
+	// Build thinking options
+	opts := o.buildThinkingOptions(thinkingMode)
+
+	stream := o.client.Responses.NewStreaming(ctx, params, opts...)
+	if err := stream.Err(); err != nil {
+		log.Ctx(ctx).WithFields(log.Fields{
+			"provider": "openai-responses",
+			"model":    model,
+			"base_url": o.baseURL,
+			"error":    err.Error(),
+		}).Error("[LLM] Responses stream init error")
+		return nil, fmt.Errorf("openai responses stream: %w", err)
+	}
+
+	// Create event channel
+	eventChan := make(chan StreamEvent, 100)
+
+	// Start goroutine to process streaming response
+	go o.processResponsesStream(ctx, stream, eventChan, startTime, messages, model, tools, thinkingMode)
+
+	return eventChan, nil
+}
+
+// processResponsesStream processes the Responses API streaming events and
+// converts them to xbot StreamEvents.
+func (o *OpenAILLM) processResponsesStream(ctx context.Context, stream *ssestream.Stream[responses.ResponseStreamEventUnion], eventChan chan<- StreamEvent, startTime time.Time, messages []ChatMessage, model string, tools []ToolDefinition, thinkingMode string) {
+	defer close(eventChan)
+	defer stream.Close()
+
+	// Connect context cancellation to stream.Close().
+	ctxDone := ctx.Done()
+	if ctxDone != nil {
+		go func() {
+			select {
+			case <-ctxDone:
+				stream.Close()
+			case <-ctx.Done():
+			}
+		}()
+	}
+
+	l := log.Ctx(ctx)
+	eventCount := 0
+	var firstEventTime time.Time
+	var lastUsage *TokenUsage
+	var lastFinishReason FinishReason
+	hasToolCalls := false
+
+	// Track tool calls by item_id for assembling delta arguments
+	type toolCallState struct {
+		ID        string
+		Name      string
+		Arguments string
+		index     int
+	}
+	toolCallsByID := make(map[string]*toolCallState)
+	toolCallList := make([]*toolCallState, 0)
+
+	for stream.Next() {
+		select {
+		case <-ctx.Done():
+			l.WithFields(log.Fields{
+				"provider": "openai-responses",
+				"reason":   ctx.Err().Error(),
+			}).Warn("[LLM] Stream cancelled")
+			eventChan <- StreamEvent{
+				Type:  EventError,
+				Error: ctx.Err().Error(),
+			}
+			return
+		default:
+		}
+
+		event := stream.Current()
+		eventCount++
+
+		if eventCount == 1 {
+			firstEventTime = time.Now()
+			l.WithFields(log.Fields{
+				"provider": "openai-responses",
+				"ttft":     firstEventTime.Sub(startTime).String(),
+			}).Debug("[LLM] First event received")
+		}
+
+		switch event.Type {
+		case "response.output_text.delta":
+			// Text content delta
+			if event.Delta != "" {
+				eventChan <- StreamEvent{
+					Type:    EventContent,
+					Content: event.Delta,
+				}
+			}
+
+		case "response.reasoning_text.delta":
+			// Full reasoning text delta
+			if event.Delta != "" {
+				eventChan <- StreamEvent{
+					Type:             EventReasoningContent,
+					ReasoningContent: event.Delta,
+				}
+			}
+
+		case "response.reasoning_summary_text.delta":
+			// Reasoning summary delta
+			if event.Delta != "" {
+				eventChan <- StreamEvent{
+					Type:             EventReasoningContent,
+					ReasoningContent: event.Delta,
+				}
+			}
+
+		case "response.output_item.added":
+			// New output item — track function calls
+			if event.Item.Type == "function_call" {
+				callID := event.Item.CallID
+				if callID == "" {
+					callID = event.Item.ID
+				}
+				tc := &toolCallState{
+					ID:    callID,
+					Name:  event.Item.Name,
+					index: len(toolCallList),
+				}
+				toolCallsByID[event.ItemID] = tc
+				toolCallList = append(toolCallList, tc)
+				hasToolCalls = true
+
+				// Send initial tool call event (ID + Name)
+				eventChan <- StreamEvent{
+					Type: EventToolCall,
+					ToolCall: &ToolCallDelta{
+						Index: tc.index,
+						ID:    tc.ID,
+						Name:  tc.Name,
+					},
+				}
+			}
+
+		case "response.function_call_arguments.delta":
+			// Tool call arguments delta
+			tc, ok := toolCallsByID[event.ItemID]
+			if ok {
+				tc.Arguments += event.Delta
+				eventChan <- StreamEvent{
+					Type: EventToolCall,
+					ToolCall: &ToolCallDelta{
+						Index:     tc.index,
+						Arguments: event.Delta,
+					},
+				}
+			}
+
+		case "response.function_call_arguments.done":
+			// Tool call arguments complete — update with final values
+			tc, ok := toolCallsByID[event.ItemID]
+			if ok {
+				if event.Arguments != "" {
+					tc.Arguments = event.Arguments
+				}
+				if event.Name != "" {
+					tc.Name = event.Name
+				}
+			}
+
+		case "response.completed":
+			// Response completed — extract usage and finish reason
+			completed := event.Response
+			lastUsage = &TokenUsage{
+				PromptTokens:     completed.Usage.InputTokens,
+				CompletionTokens: completed.Usage.OutputTokens,
+				TotalTokens:      completed.Usage.TotalTokens,
+			}
+			if completed.Usage.InputTokensDetails.CachedTokens > 0 {
+				lastUsage.CacheHitTokens = completed.Usage.InputTokensDetails.CachedTokens
+			}
+			lastFinishReason = responsesStatusToFinishReason(completed.Status, hasToolCalls)
+
+		case "response.failed":
+			// Response failed
+			errMsg := "response failed"
+			if completed := event.Response; completed.Error.Message != "" {
+				errMsg = completed.Error.Message
+			}
+			l.WithFields(log.Fields{
+				"provider": "openai-responses",
+				"error":    errMsg,
+			}).Error("[LLM] Response failed")
+			eventChan <- StreamEvent{
+				Type:  EventError,
+				Error: errMsg,
+			}
+			return
+
+		case "response.incomplete":
+			lastFinishReason = FinishReasonLength
+
+		case "error":
+			errMsg := event.Message
+			if errMsg == "" {
+				errMsg = "unknown error"
+			}
+			l.WithFields(log.Fields{
+				"provider": "openai-responses",
+				"error":    errMsg,
+				"code":     event.Code,
+				"param":    event.Param,
+			}).Error("[LLM] Stream error event")
+			eventChan <- StreamEvent{
+				Type:  EventError,
+				Error: errMsg,
+			}
+			return
+		}
+	}
+
+	// Check for stream errors
+	if err := stream.Err(); err != nil {
+		l.WithFields(log.Fields{
+			"provider":    "openai-responses",
+			"model":       model,
+			"base_url":    o.baseURL,
+			"event_count": eventCount,
+			"duration":    time.Since(startTime).String(),
+			"error":       err.Error(),
+		}).Error("[LLM] Stream error")
+		eventChan <- StreamEvent{
+			Type:  EventError,
+			Error: err.Error(),
+		}
+		return
+	}
+
+	// Send usage event before done
+	if lastUsage != nil {
+		eventChan <- StreamEvent{
+			Type:  EventUsage,
+			Usage: lastUsage,
+		}
+	}
+
+	// Infer finish_reason if not set
+	if lastFinishReason == "" && hasToolCalls {
+		lastFinishReason = FinishReasonToolCalls
+	}
+
+	// Send done event
+	eventChan <- StreamEvent{
+		Type:         EventDone,
+		FinishReason: lastFinishReason,
+	}
+
+	fields := log.Fields{
+		"provider":       "openai-responses",
+		"event_count":    eventCount,
+		"total_duration": time.Since(startTime).String(),
+		"ttft":           firstEventTime.Sub(startTime).String(),
+		"finish_reason":  lastFinishReason,
+	}
+	if lastUsage != nil {
+		fields["prompt_tokens"] = lastUsage.PromptTokens
+		fields["completion_tokens"] = lastUsage.CompletionTokens
+		fields["total_tokens"] = lastUsage.TotalTokens
+	}
+	if eventCount <= 1 {
+		addNearEmptyResponseDebugFields(fields, messages, model, tools, thinkingMode)
+		l.WithFields(fields).Warn("[LLM] Stream completed with near-empty response")
+	} else {
+		l.WithFields(fields).Debug("[LLM] Stream completed")
+	}
+}

--- a/llm/openai_responses.go
+++ b/llm/openai_responses.go
@@ -16,6 +16,27 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 )
 
+// sanitizeID ensures a string is safe to embed in an item ID.
+// Returns a truncated, alphanumeric-only version; empty input yields "x".
+func sanitizeID(s string) string {
+	if s == "" {
+		return "x"
+	}
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			b.WriteRune(r)
+		}
+		if b.Len() >= 32 {
+			break
+		}
+	}
+	if b.Len() == 0 {
+		return "x"
+	}
+	return b.String()
+}
+
 // ---------------------------------------------------------------------------
 // Message conversion: ChatMessage[] → ResponseNewParams
 // ---------------------------------------------------------------------------
@@ -79,7 +100,7 @@ func toResponsesParams(model string, messages []ChatMessage, maxTokens int) resp
 			if msg.ReasoningContent != "" {
 				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
 					OfReasoning: &responses.ResponseReasoningItemParam{
-						ID: fmt.Sprintf("rs_%d", len(inputItems)),
+						ID: fmt.Sprintf("rs_%s_%d", sanitizeID(msg.ToolCallID), len(inputItems)),
 						Summary: []responses.ResponseReasoningItemSummaryParam{
 							{Text: msg.ReasoningContent},
 						},
@@ -249,7 +270,10 @@ func buildResponsesReasoning(thinkingMode string) openai.ReasoningParam {
 				return rp
 			}
 			log.WithField("thinking_mode", thinkingMode).Warn("[LLM] Failed to parse thinking mode as JSON for Responses API, ignoring")
+			return openai.ReasoningParam{}
 		}
+		// Non-JSON unknown value
+		log.WithField("thinking_mode", thinkingMode).Warn("[LLM] Unknown thinking mode is not valid JSON for Responses API, ignoring")
 		return openai.ReasoningParam{}
 	}
 }
@@ -388,7 +412,7 @@ func responsesStatusToFinishReason(status responses.ResponseStatus, hasToolCalls
 	case "incomplete":
 		return FinishReasonLength
 	case "failed", "cancelled":
-		return FinishReasonStop
+		return FinishReasonContentFilter
 	case "in_progress", "queued":
 		return FinishReasonStop
 	default:
@@ -725,8 +749,10 @@ func (o *OpenAILLM) processResponsesStream(ctx context.Context, stream *ssestrea
 		"provider":       "openai-responses",
 		"event_count":    eventCount,
 		"total_duration": time.Since(startTime).String(),
-		"ttft":           firstEventTime.Sub(startTime).String(),
 		"finish_reason":  lastFinishReason,
+	}
+	if eventCount > 0 {
+		fields["ttft"] = firstEventTime.Sub(startTime).String()
 	}
 	if lastUsage != nil {
 		fields["prompt_tokens"] = lastUsage.PromptTokens

--- a/llm/openai_responses.go
+++ b/llm/openai_responses.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -31,7 +32,6 @@ import (
 func toResponsesParams(model string, messages []ChatMessage, thinkingMode string, maxTokens int) responses.ResponseNewParams {
 	var instructions []string
 	inputItems := make([]responses.ResponseInputItemUnionParam, 0, len(messages))
-	reasoningHistoryObserved := hasAssistantReasoningHistory(messages)
 
 	for _, msg := range messages {
 		switch msg.Role {
@@ -132,10 +132,6 @@ func toResponsesParams(model string, messages []ChatMessage, thinkingMode string
 		}
 	}
 
-	// Suppress unused variable warning for reasoningHistoryObserved — it's used
-	// to decide whether to include reasoning items in context (already handled above).
-	_ = reasoningHistoryObserved
-
 	p := responses.ResponseNewParams{
 		Model: openai.ResponsesModel(model),
 		Input: responses.ResponseNewParamsInputUnion{
@@ -170,6 +166,11 @@ func toResponsesTools(tools []ToolDefinition) []responses.ToolUnionParam {
 				required = append(required, p.Name)
 			}
 		}
+		// Sort required array for deterministic JSON serialization.
+		// MCP tool parameters come from map iteration (non-deterministic order),
+		// which produces different "required" arrays across requests,
+		// breaking API-side prefix caching.
+		slices.Sort(required)
 		result = append(result, responses.ToolUnionParam{
 			OfFunction: &responses.FunctionToolParam{
 				Name:        tool.Name(),
@@ -264,7 +265,7 @@ func (o *OpenAILLM) generateResponses(ctx context.Context, model string, message
 		"stream":        false,
 		"msg_count":     len(messages),
 		"tools_count":   len(tools),
-		"thinking_mode":  thinkingMode,
+		"thinking_mode": thinkingMode,
 		"max_tokens":    o.maxTokens,
 	}).Info("[LLM] Starting non-stream request (Responses API)")
 
@@ -290,10 +291,11 @@ func (o *OpenAILLM) generateResponses(ctx context.Context, model string, message
 		params.Tools = toResponsesTools(tools)
 	}
 
-	// Build thinking options (for non-reasoning custom params like temperature overrides)
-	opts := o.buildThinkingOptions(thinkingMode)
+	// Note: buildThinkingOptions is NOT called here — it injects Chat
+	// Completions-specific "thinking" params that are invalid for the
+	// Responses API. Reasoning is handled above via params.Reasoning.
 
-	resp, err := o.client.Responses.New(ctx, params, opts...)
+	resp, err := o.client.Responses.New(ctx, params)
 	if err != nil {
 		log.Ctx(ctx).WithFields(log.Fields{
 			"provider": "openai-responses",
@@ -358,7 +360,7 @@ func (o *OpenAILLM) generateResponses(ctx context.Context, model string, message
 	fields := log.Fields{
 		"provider":          "openai-responses",
 		"duration":          time.Since(startTime).String(),
-		"output_count":     len(resp.Output),
+		"output_count":      len(resp.Output),
 		"content_len":       len(result.Content),
 		"reasoning_len":     len(result.ReasoningContent),
 		"tool_calls":        len(result.ToolCalls),
@@ -439,10 +441,11 @@ func (o *OpenAILLM) generateStreamResponses(ctx context.Context, model string, m
 		params.Tools = toResponsesTools(tools)
 	}
 
-	// Build thinking options
-	opts := o.buildThinkingOptions(thinkingMode)
+	// Note: buildThinkingOptions is NOT called here — it injects Chat
+	// Completions-specific "thinking" params that are invalid for the
+	// Responses API. Reasoning is handled above via params.Reasoning.
 
-	stream := o.client.Responses.NewStreaming(ctx, params, opts...)
+	stream := o.client.Responses.NewStreaming(ctx, params)
 	if err := stream.Err(); err != nil {
 		log.Ctx(ctx).WithFields(log.Fields{
 			"provider": "openai-responses",

--- a/llm/openai_responses_test.go
+++ b/llm/openai_responses_test.go
@@ -13,7 +13,7 @@ import (
 func TestToResponsesParams_SystemMessageBecomesInstructions(t *testing.T) {
 	msgs := []ChatMessage{NewSystemMessage("You are a helpful assistant.")}
 
-	p := toResponsesParams("test-model", msgs, "", 1000)
+	p := toResponsesParams("test-model", msgs, 1000)
 
 	// Instructions should hold the system content
 	if !p.Instructions.Valid() {
@@ -40,7 +40,7 @@ func TestToResponsesParams_MultipleSystemMessagesConcatenated(t *testing.T) {
 		NewSystemMessage("Rule two."),
 	}
 
-	p := toResponsesParams("m", msgs, "", 0)
+	p := toResponsesParams("m", msgs, 0)
 
 	if !p.Instructions.Valid() {
 		t.Fatal("expected Instructions to be set")
@@ -54,7 +54,7 @@ func TestToResponsesParams_MultipleSystemMessagesConcatenated(t *testing.T) {
 func TestToResponsesParams_UserPlainText(t *testing.T) {
 	msgs := []ChatMessage{NewUserMessage("Hello world")}
 
-	p := toResponsesParams("m", msgs, "", 0)
+	p := toResponsesParams("m", msgs, 0)
 
 	items := p.Input.OfInputItemList
 	if len(items) != 1 {
@@ -82,7 +82,7 @@ func TestToResponsesParams_UserMultimodalImage(t *testing.T) {
 	imgURL := "data:image/png;base64,iVBORw0KGgo="
 	msgs := []ChatMessage{NewUserMessage("What is this? ![pic](" + imgURL + ")")}
 
-	p := toResponsesParams("m", msgs, "", 0)
+	p := toResponsesParams("m", msgs, 0)
 
 	items := p.Input.OfInputItemList
 	if len(items) != 1 {
@@ -121,7 +121,7 @@ func TestToResponsesParams_UserMultimodalImage(t *testing.T) {
 func TestToResponsesParams_AssistantPlainText(t *testing.T) {
 	msgs := []ChatMessage{NewAssistantMessage("Sure, here is the answer.")}
 
-	p := toResponsesParams("m", msgs, "", 0)
+	p := toResponsesParams("m", msgs, 0)
 
 	items := p.Input.OfInputItemList
 	if len(items) != 1 {
@@ -154,7 +154,7 @@ func TestToResponsesParams_AssistantWithToolCalls(t *testing.T) {
 		},
 	}
 
-	p := toResponsesParams("m", msgs, "", 0)
+	p := toResponsesParams("m", msgs, 0)
 
 	items := p.Input.OfInputItemList
 	// user message + 2 function_call items, no assistant message (content empty)
@@ -191,7 +191,7 @@ func TestToResponsesParams_AssistantToolCallEmptyArgumentsDefaultsToBraces(t *te
 		},
 	}
 
-	p := toResponsesParams("m", msgs, "", 0)
+	p := toResponsesParams("m", msgs, 0)
 
 	items := p.Input.OfInputItemList
 	if len(items) != 1 {
@@ -214,7 +214,7 @@ func TestToResponsesParams_AssistantWithReasoningContent(t *testing.T) {
 		},
 	}
 
-	p := toResponsesParams("m", msgs, "", 0)
+	p := toResponsesParams("m", msgs, 0)
 
 	items := p.Input.OfInputItemList
 	if len(items) != 1 {
@@ -246,7 +246,7 @@ func TestToResponsesParams_ToolMessageBecomesFunctionCallOutput(t *testing.T) {
 		},
 	}
 
-	p := toResponsesParams("m", msgs, "", 0)
+	p := toResponsesParams("m", msgs, 0)
 
 	items := p.Input.OfInputItemList
 	if len(items) != 1 {
@@ -276,7 +276,7 @@ func TestToResponsesParams_ToolMessageEmptyContentDefaultsToBraces(t *testing.T)
 		},
 	}
 
-	p := toResponsesParams("m", msgs, "", 0)
+	p := toResponsesParams("m", msgs, 0)
 
 	items := p.Input.OfInputItemList
 	if len(items) != 1 {
@@ -295,7 +295,7 @@ func TestToResponsesParams_ToolMessageEmptyContentDefaultsToBraces(t *testing.T)
 }
 
 func TestToResponsesParams_MaxOutputTokensCarried(t *testing.T) {
-	p := toResponsesParams("m", []ChatMessage{NewUserMessage("hi")}, "", 2048)
+	p := toResponsesParams("m", []ChatMessage{NewUserMessage("hi")}, 2048)
 
 	if !p.MaxOutputTokens.Valid() {
 		t.Fatal("expected MaxOutputTokens to be set")

--- a/llm/openai_responses_test.go
+++ b/llm/openai_responses_test.go
@@ -1,0 +1,507 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// ---------------------------------------------------------------------------
+// toResponsesParams
+// ---------------------------------------------------------------------------
+
+func TestToResponsesParams_SystemMessageBecomesInstructions(t *testing.T) {
+	msgs := []ChatMessage{NewSystemMessage("You are a helpful assistant.")}
+
+	p := toResponsesParams("test-model", msgs, "", 1000)
+
+	// Instructions should hold the system content
+	if !p.Instructions.Valid() {
+		t.Fatal("expected Instructions to be set for system message")
+	}
+	if got := p.Instructions.Value; got != "You are a helpful assistant." {
+		t.Errorf("Instructions = %q, want %q", got, "You are a helpful assistant.")
+	}
+
+	// No input items should be produced from a system message
+	if got := len(p.Input.OfInputItemList); got != 0 {
+		t.Errorf("expected 0 input items, got %d", got)
+	}
+
+	// Model should be carried through
+	if p.Model != "test-model" {
+		t.Errorf("Model = %q, want %q", p.Model, "test-model")
+	}
+}
+
+func TestToResponsesParams_MultipleSystemMessagesConcatenated(t *testing.T) {
+	msgs := []ChatMessage{
+		NewSystemMessage("Rule one."),
+		NewSystemMessage("Rule two."),
+	}
+
+	p := toResponsesParams("m", msgs, "", 0)
+
+	if !p.Instructions.Valid() {
+		t.Fatal("expected Instructions to be set")
+	}
+	want := "Rule one.\n\nRule two."
+	if got := p.Instructions.Value; got != want {
+		t.Errorf("Instructions = %q, want %q", got, want)
+	}
+}
+
+func TestToResponsesParams_UserPlainText(t *testing.T) {
+	msgs := []ChatMessage{NewUserMessage("Hello world")}
+
+	p := toResponsesParams("m", msgs, "", 0)
+
+	items := p.Input.OfInputItemList
+	if len(items) != 1 {
+		t.Fatalf("expected 1 input item, got %d", len(items))
+	}
+	msg := items[0].OfMessage
+	if msg == nil {
+		t.Fatal("expected OfMessage to be set for user text")
+	}
+	if msg.Role != responses.EasyInputMessageRoleUser {
+		t.Errorf("Role = %q, want %q", msg.Role, responses.EasyInputMessageRoleUser)
+	}
+	if !msg.Content.OfString.Valid() {
+		t.Fatal("expected OfString content for plain user text")
+	}
+	if got := msg.Content.OfString.Value; got != "Hello world" {
+		t.Errorf("content = %q, want %q", got, "Hello world")
+	}
+}
+
+func TestToResponsesParams_UserMultimodalImage(t *testing.T) {
+	// Markdown image with data: URL triggers the multi-part path.
+	// Surrounding text is needed so parseEmbeddedImages produces >1 part
+	// (the multi-part branch in toResponsesParams requires len(parts) > 1).
+	imgURL := "data:image/png;base64,iVBORw0KGgo="
+	msgs := []ChatMessage{NewUserMessage("What is this? ![pic](" + imgURL + ")")}
+
+	p := toResponsesParams("m", msgs, "", 0)
+
+	items := p.Input.OfInputItemList
+	if len(items) != 1 {
+		t.Fatalf("expected 1 input item, got %d", len(items))
+	}
+	msg := items[0].OfMessage
+	if msg == nil {
+		t.Fatal("expected OfMessage for multimodal user message")
+	}
+	if msg.Role != responses.EasyInputMessageRoleUser {
+		t.Errorf("Role = %q, want user", msg.Role)
+	}
+	parts := msg.Content.OfInputItemContentList
+	if len(parts) < 1 {
+		t.Fatalf("expected at least 1 content part, got %d", len(parts))
+	}
+
+	// Find the image part among the content parts.
+	found := false
+	for _, part := range parts {
+		if part.OfInputImage != nil {
+			found = true
+			if !part.OfInputImage.ImageURL.Valid() {
+				t.Fatal("expected ImageURL to be set")
+			}
+			if got := part.OfInputImage.ImageURL.Value; got != imgURL {
+				t.Errorf("ImageURL = %q, want %q", got, imgURL)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected at least one image content part, none found")
+	}
+}
+
+func TestToResponsesParams_AssistantPlainText(t *testing.T) {
+	msgs := []ChatMessage{NewAssistantMessage("Sure, here is the answer.")}
+
+	p := toResponsesParams("m", msgs, "", 0)
+
+	items := p.Input.OfInputItemList
+	if len(items) != 1 {
+		t.Fatalf("expected 1 input item, got %d", len(items))
+	}
+	msg := items[0].OfMessage
+	if msg == nil {
+		t.Fatal("expected OfMessage for assistant text")
+	}
+	if msg.Role != responses.EasyInputMessageRoleAssistant {
+		t.Errorf("Role = %q, want %q", msg.Role, responses.EasyInputMessageRoleAssistant)
+	}
+	if !msg.Content.OfString.Valid() {
+		t.Fatal("expected OfString content for assistant text")
+	}
+	if got := msg.Content.OfString.Value; got != "Sure, here is the answer." {
+		t.Errorf("content = %q, want %q", got, "Sure, here is the answer.")
+	}
+}
+
+func TestToResponsesParams_AssistantWithToolCalls(t *testing.T) {
+	msgs := []ChatMessage{
+		NewUserMessage("read file"),
+		{
+			Role: "assistant",
+			ToolCalls: []ToolCall{
+				{ID: "call_1", Name: "read_file", Arguments: `{"path":"/tmp/a"}`},
+				{ID: "call_2", Name: "list_dir", Arguments: `{"dir":"/tmp"}`},
+			},
+		},
+	}
+
+	p := toResponsesParams("m", msgs, "", 0)
+
+	items := p.Input.OfInputItemList
+	// user message + 2 function_call items, no assistant message (content empty)
+	if len(items) != 3 {
+		t.Fatalf("expected 3 input items (user + 2 tool calls), got %d", len(items))
+	}
+
+	// items[1] and items[2] should be function calls.
+	for i, idx := range []int{1, 2} {
+		fc := items[idx].OfFunctionCall
+		if fc == nil {
+			t.Fatalf("item %d: expected OfFunctionCall, got nil", idx)
+		}
+		tc := msgs[1].ToolCalls[i]
+		if fc.CallID != tc.ID {
+			t.Errorf("item %d: CallID = %q, want %q", idx, fc.CallID, tc.ID)
+		}
+		if fc.Name != tc.Name {
+			t.Errorf("item %d: Name = %q, want %q", idx, fc.Name, tc.Name)
+		}
+		if fc.Arguments != tc.Arguments {
+			t.Errorf("item %d: Arguments = %q, want %q", idx, fc.Arguments, tc.Arguments)
+		}
+	}
+}
+
+func TestToResponsesParams_AssistantToolCallEmptyArgumentsDefaultsToBraces(t *testing.T) {
+	msgs := []ChatMessage{
+		{
+			Role: "assistant",
+			ToolCalls: []ToolCall{
+				{ID: "call_x", Name: "no_args", Arguments: ""},
+			},
+		},
+	}
+
+	p := toResponsesParams("m", msgs, "", 0)
+
+	items := p.Input.OfInputItemList
+	if len(items) != 1 {
+		t.Fatalf("expected 1 input item, got %d", len(items))
+	}
+	fc := items[0].OfFunctionCall
+	if fc == nil {
+		t.Fatal("expected OfFunctionCall")
+	}
+	if fc.Arguments != "{}" {
+		t.Errorf("empty arguments should default to {}, got %q", fc.Arguments)
+	}
+}
+
+func TestToResponsesParams_AssistantWithReasoningContent(t *testing.T) {
+	msgs := []ChatMessage{
+		{
+			Role:             "assistant",
+			ReasoningContent: "thinking about the question",
+		},
+	}
+
+	p := toResponsesParams("m", msgs, "", 0)
+
+	items := p.Input.OfInputItemList
+	if len(items) != 1 {
+		t.Fatalf("expected 1 input item, got %d", len(items))
+	}
+	r := items[0].OfReasoning
+	if r == nil {
+		t.Fatal("expected OfReasoning to be set for reasoning_content")
+	}
+	if r.ID != "rs_0" {
+		t.Errorf("reasoning ID = %q, want %q", r.ID, "rs_0")
+	}
+	if len(r.Summary) != 1 {
+		t.Fatalf("expected 1 summary entry, got %d", len(r.Summary))
+	}
+	if r.Summary[0].Text != "thinking about the question" {
+		t.Errorf("summary text = %q, want %q", r.Summary[0].Text, "thinking about the question")
+	}
+}
+
+func TestToResponsesParams_ToolMessageBecomesFunctionCallOutput(t *testing.T) {
+	msgs := []ChatMessage{
+		{
+			Role:          "tool",
+			Content:       `{"ok":true}`,
+			ToolCallID:    "call_42",
+			ToolName:      "get_weather",
+			ToolArguments: `{"city":"SF"}`,
+		},
+	}
+
+	p := toResponsesParams("m", msgs, "", 0)
+
+	items := p.Input.OfInputItemList
+	if len(items) != 1 {
+		t.Fatalf("expected 1 input item, got %d", len(items))
+	}
+	out := items[0].OfFunctionCallOutput
+	if out == nil {
+		t.Fatal("expected OfFunctionCallOutput for tool message")
+	}
+	if out.CallID != "call_42" {
+		t.Errorf("CallID = %q, want %q", out.CallID, "call_42")
+	}
+	if !out.Output.OfString.Valid() {
+		t.Fatal("expected OfString output")
+	}
+	if got := out.Output.OfString.Value; got != `{"ok":true}` {
+		t.Errorf("Output = %q, want %q", got, `{"ok":true}`)
+	}
+}
+
+func TestToResponsesParams_ToolMessageEmptyContentDefaultsToBraces(t *testing.T) {
+	msgs := []ChatMessage{
+		{
+			Role:       "tool",
+			Content:    "",
+			ToolCallID: "call_9",
+		},
+	}
+
+	p := toResponsesParams("m", msgs, "", 0)
+
+	items := p.Input.OfInputItemList
+	if len(items) != 1 {
+		t.Fatalf("expected 1 input item, got %d", len(items))
+	}
+	out := items[0].OfFunctionCallOutput
+	if out == nil {
+		t.Fatal("expected OfFunctionCallOutput")
+	}
+	if !out.Output.OfString.Valid() {
+		t.Fatal("expected OfString output")
+	}
+	if got := out.Output.OfString.Value; got != "{}" {
+		t.Errorf("empty tool output should default to {}, got %q", got)
+	}
+}
+
+func TestToResponsesParams_MaxOutputTokensCarried(t *testing.T) {
+	p := toResponsesParams("m", []ChatMessage{NewUserMessage("hi")}, "", 2048)
+
+	if !p.MaxOutputTokens.Valid() {
+		t.Fatal("expected MaxOutputTokens to be set")
+	}
+	if p.MaxOutputTokens.Value != 2048 {
+		t.Errorf("MaxOutputTokens = %d, want 2048", p.MaxOutputTokens.Value)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// toResponsesTools
+// ---------------------------------------------------------------------------
+
+func TestToResponsesTools_SingleTool(t *testing.T) {
+	tools := []ToolDefinition{
+		mockToolDefinition{
+			name:        "get_weather",
+			description: "Get the weather for a city",
+			parameters: []ToolParam{
+				{Name: "city", Type: "string", Description: "City name", Required: true},
+				{Name: "unit", Type: "string", Description: "Temperature unit"},
+			},
+		},
+	}
+
+	result := toResponsesTools(tools)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(result))
+	}
+
+	ft := result[0].OfFunction
+	if ft == nil {
+		t.Fatal("expected OfFunction to be set")
+	}
+	if ft.Name != "get_weather" {
+		t.Errorf("Name = %q, want %q", ft.Name, "get_weather")
+	}
+	if !ft.Description.Valid() || ft.Description.Value != "Get the weather for a city" {
+		t.Errorf("Description = %q, want %q", ft.Description, "Get the weather for a city")
+	}
+	// Strict must be false to match Chat Completions behavior.
+	// Note: we check Value directly because param.Opt[bool]{Value:false}
+	// is indistinguishable from an unset Opt (false is the zero value),
+	// so Valid() returns false even though the value is explicitly set.
+	if ft.Strict.Value != false {
+		t.Errorf("Strict = %v, want false", ft.Strict.Value)
+	}
+
+	// Parameters schema
+	if ft.Parameters["type"] != "object" {
+		t.Errorf("parameters type = %v, want object", ft.Parameters["type"])
+	}
+	props, ok := ft.Parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected properties map, got %T", ft.Parameters["properties"])
+	}
+	city, ok := props["city"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected city property, got %T", props["city"])
+	}
+	if city["type"] != "string" {
+		t.Errorf("city type = %v, want string", city["type"])
+	}
+	if city["description"] != "City name" {
+		t.Errorf("city description = %v, want 'City name'", city["description"])
+	}
+
+	required, ok := ft.Parameters["required"].([]string)
+	if !ok {
+		t.Fatalf("expected required []string, got %T", ft.Parameters["required"])
+	}
+	if len(required) != 1 || required[0] != "city" {
+		t.Errorf("required = %v, want [city]", required)
+	}
+}
+
+func TestToResponsesTools_MultipleTools(t *testing.T) {
+	tools := []ToolDefinition{
+		mockToolDefinition{name: "tool_a", description: "A", parameters: nil},
+		mockToolDefinition{name: "tool_b", description: "B", parameters: []ToolParam{
+			{Name: "x", Type: "string", Description: "x param", Required: true},
+		}},
+	}
+
+	result := toResponsesTools(tools)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(result))
+	}
+	if result[0].OfFunction.Name != "tool_a" {
+		t.Errorf("tool[0] Name = %q, want tool_a", result[0].OfFunction.Name)
+	}
+	if result[1].OfFunction.Name != "tool_b" {
+		t.Errorf("tool[1] Name = %q, want tool_b", result[1].OfFunction.Name)
+	}
+}
+
+func TestToResponsesTools_EmptyList(t *testing.T) {
+	result := toResponsesTools(nil)
+	if len(result) != 0 {
+		t.Errorf("expected 0 tools for nil input, got %d", len(result))
+	}
+
+	result = toResponsesTools([]ToolDefinition{})
+	if len(result) != 0 {
+		t.Errorf("expected 0 tools for empty slice, got %d", len(result))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildResponsesReasoning
+// ---------------------------------------------------------------------------
+
+func TestBuildResponsesReasoning_Empty(t *testing.T) {
+	r := buildResponsesReasoning("")
+	if r.Effort != "" {
+		t.Errorf("Effort = %q, want empty", r.Effort)
+	}
+	if r.Summary != "" {
+		t.Errorf("Summary = %q, want empty", r.Summary)
+	}
+}
+
+func TestBuildResponsesReasoning_Enabled(t *testing.T) {
+	r := buildResponsesReasoning("enabled")
+	if r.Effort != "medium" {
+		t.Errorf("Effort = %q, want medium", r.Effort)
+	}
+	if r.Summary != "auto" {
+		t.Errorf("Summary = %q, want auto", r.Summary)
+	}
+}
+
+func TestBuildResponsesReasoning_Disabled(t *testing.T) {
+	r := buildResponsesReasoning("disabled")
+	if r.Effort != "none" {
+		t.Errorf("Effort = %q, want none", r.Effort)
+	}
+	// disabled only sets Effort, not Summary
+	if r.Summary != "" {
+		t.Errorf("Summary = %q, want empty", r.Summary)
+	}
+}
+
+func TestBuildResponsesReasoning_CustomEffortJSON(t *testing.T) {
+	r := buildResponsesReasoning(`{"effort":"high"}`)
+	if r.Effort != "high" {
+		t.Errorf("Effort = %q, want high", r.Effort)
+	}
+}
+
+func TestBuildResponsesReasoning_NestedReasoningJSON(t *testing.T) {
+	r := buildResponsesReasoning(`{"reasoning":{"effort":"low"}}`)
+	if r.Effort != "low" {
+		t.Errorf("Effort = %q, want low", r.Effort)
+	}
+}
+
+func TestBuildResponsesReasoning_CustomSummaryJSON(t *testing.T) {
+	r := buildResponsesReasoning(`{"effort":"high","summary":"detailed"}`)
+	if r.Effort != "high" {
+		t.Errorf("Effort = %q, want high", r.Effort)
+	}
+	if r.Summary != "detailed" {
+		t.Errorf("Summary = %q, want detailed", r.Summary)
+	}
+}
+
+func TestBuildResponsesReasoning_InvalidJSONFallsBackToEmpty(t *testing.T) {
+	// Non-JSON, non-keyword value should return empty ReasoningParam.
+	r := buildResponsesReasoning("not-a-real-mode")
+	if r.Effort != "" {
+		t.Errorf("Effort = %q, want empty for invalid mode", r.Effort)
+	}
+	if r.Summary != "" {
+		t.Errorf("Summary = %q, want empty for invalid mode", r.Summary)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// responsesStatusToFinishReason
+// ---------------------------------------------------------------------------
+
+func TestResponsesStatusToFinishReason(t *testing.T) {
+	cases := []struct {
+		name         string
+		status       responses.ResponseStatus
+		hasToolCalls bool
+		want         FinishReason
+	}{
+		{"completed no tool calls", responses.ResponseStatusCompleted, false, FinishReasonStop},
+		{"completed with tool calls", responses.ResponseStatusCompleted, true, FinishReasonToolCalls},
+		{"incomplete", responses.ResponseStatusIncomplete, false, FinishReasonLength},
+		{"incomplete with tool calls still length", responses.ResponseStatusIncomplete, true, FinishReasonLength},
+		{"failed", responses.ResponseStatusFailed, false, FinishReasonStop},
+		{"cancelled", responses.ResponseStatusCancelled, false, FinishReasonStop},
+		{"in_progress", responses.ResponseStatusInProgress, false, FinishReasonStop},
+		{"queued", responses.ResponseStatusQueued, false, FinishReasonStop},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := responsesStatusToFinishReason(c.status, c.hasToolCalls)
+			if got != c.want {
+				t.Errorf("responsesStatusToFinishReason(%q, %v) = %q, want %q",
+					c.status, c.hasToolCalls, got, c.want)
+			}
+		})
+	}
+}

--- a/llm/openai_responses_test.go
+++ b/llm/openai_responses_test.go
@@ -224,8 +224,8 @@ func TestToResponsesParams_AssistantWithReasoningContent(t *testing.T) {
 	if r == nil {
 		t.Fatal("expected OfReasoning to be set for reasoning_content")
 	}
-	if r.ID != "rs_0" {
-		t.Errorf("reasoning ID = %q, want %q", r.ID, "rs_0")
+	if r.ID != "rs_x_0" {
+		t.Errorf("reasoning ID = %q, want %q", r.ID, "rs_x_0")
 	}
 	if len(r.Summary) != 1 {
 		t.Fatalf("expected 1 summary entry, got %d", len(r.Summary))
@@ -489,8 +489,8 @@ func TestResponsesStatusToFinishReason(t *testing.T) {
 		{"completed with tool calls", responses.ResponseStatusCompleted, true, FinishReasonToolCalls},
 		{"incomplete", responses.ResponseStatusIncomplete, false, FinishReasonLength},
 		{"incomplete with tool calls still length", responses.ResponseStatusIncomplete, true, FinishReasonLength},
-		{"failed", responses.ResponseStatusFailed, false, FinishReasonStop},
-		{"cancelled", responses.ResponseStatusCancelled, false, FinishReasonStop},
+		{"failed", responses.ResponseStatusFailed, false, FinishReasonContentFilter},
+		{"cancelled", responses.ResponseStatusCancelled, false, FinishReasonContentFilter},
 		{"in_progress", responses.ResponseStatusInProgress, false, FinishReasonStop},
 		{"queued", responses.ResponseStatusQueued, false, FinishReasonStop},
 	}

--- a/protocol/events.go
+++ b/protocol/events.go
@@ -130,8 +130,9 @@ type Subscription struct {
 
 // PerModelConfig stores per-model token overrides within a subscription.
 type PerModelConfig struct {
-	MaxOutputTokens int `json:"max_output_tokens,omitempty"` // 0 = use subscription default
-	MaxContext      int `json:"max_context,omitempty"`       // 0 = use subscription default
+	MaxOutputTokens int    `json:"max_output_tokens,omitempty"` // 0 = use subscription default
+	MaxContext      int    `json:"max_context,omitempty"`       // 0 = use subscription default
+	APIType         string `json:"api_type,omitempty"`          // "" = use subscription default
 }
 
 type OutboundEvent struct {

--- a/protocol/events.go
+++ b/protocol/events.go
@@ -123,6 +123,7 @@ type Subscription struct {
 	MaxOutputTokens int                       `json:"max_output_tokens,omitempty"`
 	MaxContext      int                       `json:"max_context,omitempty"` // subscription-level max context (0 = use default)
 	ThinkingMode    string                    `json:"thinking_mode,omitempty"`
+	APIType         string                    `json:"api_type,omitempty"` // "chat_completions" (default) | "responses"
 	PerModelConfigs map[string]PerModelConfig `json:"per_model_configs,omitempty"`
 	Active          bool                      `json:"active"`
 }

--- a/serverapp/rpc_table.go
+++ b/serverapp/rpc_table.go
@@ -1280,6 +1280,7 @@ func (h *RPCContext) updateSubscription(ctx context.Context, p struct {
 		Active          bool                             `json:"active"`
 		MaxOutputTokens int                              `json:"max_output_tokens"`
 		ThinkingMode    string                           `json:"thinking_mode"`
+		APIType         string                           `json:"api_type"`
 		PerModelConfigs map[string]sqlite.PerModelConfig `json:"per_model_configs"`
 	} `json:"sub"`
 }) error {
@@ -1303,7 +1304,7 @@ func (h *RPCContext) updateSubscription(ctx context.Context, p struct {
 		APIKey: existing.APIKey, Model: existing.Model,
 		MaxOutputTokens: existing.MaxOutputTokens,
 		MaxContext:      existing.MaxContext,
-		ThinkingMode:    existing.ThinkingMode, IsDefault: existing.IsDefault,
+		ThinkingMode:    existing.ThinkingMode, APIType: existing.APIType, IsDefault: existing.IsDefault,
 		PerModelConfigs: existing.PerModelConfigs,
 		CreatedAt:       existing.CreatedAt, UpdatedAt: existing.UpdatedAt,
 	}
@@ -1318,6 +1319,8 @@ func (h *RPCContext) updateSubscription(ctx context.Context, p struct {
 	}
 	// ThinkingMode: always accept
 	dbSub.ThinkingMode = p.Sub.ThinkingMode
+	// APIType: always accept
+	dbSub.APIType = p.Sub.APIType
 	// MaxOutputTokens: always accept
 	dbSub.MaxOutputTokens = p.Sub.MaxOutputTokens
 	// Model: accept if non-empty
@@ -1472,6 +1475,7 @@ func subToChannel(s *sqlite.LLMSubscription) channel.Subscription {
 		Model: s.Model, Active: s.IsDefault,
 		MaxOutputTokens: s.MaxOutputTokens, MaxContext: s.MaxContext,
 		ThinkingMode:    s.ThinkingMode,
+		APIType:         s.APIType,
 		PerModelConfigs: s.PerModelConfigs,
 	}
 }

--- a/serverapp/rpc_table.go
+++ b/serverapp/rpc_table.go
@@ -530,6 +530,8 @@ func registerSubscriptionHandlers(t RPCTable, h *RPCContext) {
 		if err := svc.Update(existing); err != nil {
 			return err
 		}
+		// Also write to subscription_models table (authoritative source for v35+)
+		svc.UpsertModel(existing.ID, p.Model, p.Config.MaxContext, p.Config.MaxOutputTokens, "", p.Config.APIType)
 		// Invalidate ALL cached entries for this sender (user-level + per-session).
 		// Must use Invalidate() not InvalidateSender() because per-session entries
 		// (senderID:chatID keys) hold a cached *LLMSubscription pointer with stale
@@ -1247,6 +1249,7 @@ func mergeSubscriptionModels(svc *sqlite.LLMSubscriptionService, sub *sqlite.LLM
 		sub.PerModelConfigs[m.Model] = sqlite.PerModelConfig{
 			MaxContext:      m.MaxContext,
 			MaxOutputTokens: m.MaxOutputTokens,
+			APIType:         m.APIType,
 		}
 	}
 }

--- a/storage/sqlite/db.go
+++ b/storage/sqlite/db.go
@@ -22,7 +22,7 @@ type DB struct {
 	mu   sync.RWMutex
 }
 
-const schemaVersion = 35
+const schemaVersion = 36
 
 // Open opens or creates a SQLite database at the given path
 // If the database doesn't exist, it will be created with the required schema

--- a/storage/sqlite/db.go
+++ b/storage/sqlite/db.go
@@ -22,7 +22,7 @@ type DB struct {
 	mu   sync.RWMutex
 }
 
-const schemaVersion = 36
+const schemaVersion = 37
 
 // Open opens or creates a SQLite database at the given path
 // If the database doesn't exist, it will be created with the required schema

--- a/storage/sqlite/migrations.go
+++ b/storage/sqlite/migrations.go
@@ -162,6 +162,13 @@ func (db *DB) migrateSchema(from int) error {
 		}
 	}
 
+	// v36: add api_type column to user_llm_subscriptions
+	if from < 36 {
+		if err := migrateV35ToV36(db.Conn()); err != nil {
+			return fmt.Errorf("migrate to v36: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -1269,5 +1276,23 @@ func migrateV34ToV35(db *DB) error {
 		return fmt.Errorf("update schema version: %w", err)
 	}
 	log.Info("Database migrated to v35: added subscription_models table")
+	return nil
+}
+
+// migrateV35ToV36 adds api_type column to user_llm_subscriptions.
+// This column stores the API endpoint type: "" (default=chat_completions) or "responses".
+func migrateV35ToV36(conn *sql.DB) error {
+	var count int
+	err := conn.QueryRow("SELECT COUNT(*) FROM pragma_table_info('user_llm_subscriptions') WHERE name = 'api_type'").Scan(&count)
+	if err == nil && count == 0 {
+		_, err = conn.Exec("ALTER TABLE user_llm_subscriptions ADD COLUMN api_type TEXT DEFAULT ''")
+		if err != nil {
+			return fmt.Errorf("migrate v35->v36 add api_type: %w", err)
+		}
+	}
+	if _, err := conn.Exec("UPDATE schema_version SET version = 36"); err != nil {
+		return fmt.Errorf("update schema version: %w", err)
+	}
+	log.Info("Database migrated to v36: added api_type column to user_llm_subscriptions")
 	return nil
 }

--- a/storage/sqlite/migrations.go
+++ b/storage/sqlite/migrations.go
@@ -169,6 +169,13 @@ func (db *DB) migrateSchema(from int) error {
 		}
 	}
 
+	// v37: add api_type column to subscription_models table
+	if from < 37 {
+		if err := migrateV36ToV37(db.Conn()); err != nil {
+			return fmt.Errorf("migrate to v37: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -1294,5 +1301,24 @@ func migrateV35ToV36(conn *sql.DB) error {
 		return fmt.Errorf("update schema version: %w", err)
 	}
 	log.Info("Database migrated to v36: added api_type column to user_llm_subscriptions")
+	return nil
+}
+
+// migrateV36ToV37 adds api_type column to subscription_models table.
+// This enables per-model API type overrides (e.g. gpt-4o uses chat_completions
+// while o3 uses responses API within the same subscription).
+func migrateV36ToV37(conn *sql.DB) error {
+	var count int
+	err := conn.QueryRow("SELECT COUNT(*) FROM pragma_table_info('subscription_models') WHERE name = 'api_type'").Scan(&count)
+	if err == nil && count == 0 {
+		_, err = conn.Exec("ALTER TABLE subscription_models ADD COLUMN api_type TEXT NOT NULL DEFAULT ''")
+		if err != nil {
+			return fmt.Errorf("migrate v36->v37 add api_type: %w", err)
+		}
+	}
+	if _, err := conn.Exec("UPDATE schema_version SET version = 37"); err != nil {
+		return fmt.Errorf("update schema version: %w", err)
+	}
+	log.Info("Database migrated to v37: added api_type column to subscription_models")
 	return nil
 }

--- a/storage/sqlite/subscription_test.go
+++ b/storage/sqlite/subscription_test.go
@@ -27,11 +27,11 @@ func TestV35Migration_SubscriptionModelsTable(t *testing.T) {
 		t.Fatalf("tenants.model_id column should exist: %v", err)
 	}
 
-	// Verify schema version is 36
+	// Verify schema version is 37
 	var version int
 	conn.QueryRow("SELECT version FROM schema_version LIMIT 1").Scan(&version)
-	if version != 36 {
-		t.Errorf("schema version = %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema version = %d, want 37", version)
 	}
 
 	// Verify migration is idempotent
@@ -71,7 +71,7 @@ func TestSubscriptionModelCRUD(t *testing.T) {
 	}
 
 	// UpsertModel: create
-	if err := svc.UpsertModel("crud-sub", "gpt-4", 200000, 8192, "enabled"); err != nil {
+	if err := svc.UpsertModel("crud-sub", "gpt-4", 200000, 8192, "enabled", ""); err != nil {
 		t.Fatalf("UpsertModel: %v", err)
 	}
 
@@ -86,7 +86,7 @@ func TestSubscriptionModelCRUD(t *testing.T) {
 	oldID := m.ID
 
 	// UpsertModel: update
-	svc.UpsertModel("crud-sub", "gpt-4", 500000, 16384, "")
+	svc.UpsertModel("crud-sub", "gpt-4", 500000, 16384, "", "")
 	m, _ = svc.GetModel("crud-sub", "gpt-4")
 	if m == nil || m.MaxContext != 500000 || m.MaxOutputTokens != 16384 {
 		t.Errorf("after update: MaxContext=%d MaxOutput=%d", m.MaxContext, m.MaxOutputTokens)
@@ -96,14 +96,14 @@ func TestSubscriptionModelCRUD(t *testing.T) {
 	}
 
 	// Add second model + verify count
-	svc.UpsertModel("crud-sub", "gpt-3.5", 16000, 4096, "")
+	svc.UpsertModel("crud-sub", "gpt-3.5", 16000, 4096, "", "")
 	models, _ = svc.GetModels("crud-sub")
 	if len(models) != 2 {
 		t.Errorf("expected 2 models, got %d", len(models))
 	}
 
 	// Verify unique constraint: re-upsert same model is update, not insert
-	svc.UpsertModel("crud-sub", "gpt-4", 999, 999, "")
+	svc.UpsertModel("crud-sub", "gpt-4", 999, 999, "", "")
 	models, _ = svc.GetModels("crud-sub")
 	if len(models) != 2 {
 		t.Errorf("expected still 2 models after re-upsert, got %d", len(models))

--- a/storage/sqlite/subscription_test.go
+++ b/storage/sqlite/subscription_test.go
@@ -27,11 +27,11 @@ func TestV35Migration_SubscriptionModelsTable(t *testing.T) {
 		t.Fatalf("tenants.model_id column should exist: %v", err)
 	}
 
-	// Verify schema version is 35
+	// Verify schema version is 36
 	var version int
 	conn.QueryRow("SELECT version FROM schema_version LIMIT 1").Scan(&version)
-	if version != 35 {
-		t.Errorf("schema version = %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema version = %d, want 36", version)
 	}
 
 	// Verify migration is idempotent

--- a/storage/sqlite/user_llm_config.go
+++ b/storage/sqlite/user_llm_config.go
@@ -20,6 +20,7 @@ type UserLLMConfig struct {
 	MaxContext      int            // 最大上下文 token 数（0 表示不限制）
 	MaxOutputTokens int            // 最大输出 token 数（0 表示使用默认值 8192）
 	ThinkingMode    string         // 思考模式: "" (自动), "enabled", "disabled"
+	APIType         string         // API type: "" (default=chat_completions), "responses"
 	OnModelsLoaded  func([]string) // callback after models loaded from API
 	CreatedAt       time.Time      // 创建时间
 	UpdatedAt       time.Time      // 更新时间
@@ -42,13 +43,13 @@ func (s *UserLLMConfigService) GetConfig(senderID string) (*UserLLMConfig, error
 	var cfg UserLLMConfig
 	var createdAt, updatedAt string
 	err := conn.QueryRow(`
-				SELECT id, sender_id, provider, base_url, api_key, model, max_context, max_output_tokens, thinking_mode, created_at, updated_at
+				SELECT id, sender_id, provider, base_url, api_key, model, max_context, max_output_tokens, thinking_mode, api_type, created_at, updated_at
 				FROM user_llm_subscriptions
 				WHERE sender_id = ? AND is_default = 1
 				LIMIT 1
-			`, senderID).Scan(
+		`, senderID).Scan(
 		&cfg.ID, &cfg.SenderID, &cfg.Provider, &cfg.BaseURL, &cfg.APIKey, &cfg.Model,
-		&cfg.MaxContext, &cfg.MaxOutputTokens, &cfg.ThinkingMode,
+		&cfg.MaxContext, &cfg.MaxOutputTokens, &cfg.ThinkingMode, &cfg.APIType,
 		&createdAt, &updatedAt,
 	)
 
@@ -109,11 +110,11 @@ func (s *UserLLMConfigService) SetConfig(cfg *UserLLMConfig) error {
 		_, err = tx.Exec(`
 		UPDATE user_llm_subscriptions SET
 		provider = ?, base_url = ?, api_key = ?, model = ?,
-		max_context = ?, max_output_tokens = ?, thinking_mode = ?,
+		max_context = ?, max_output_tokens = ?, thinking_mode = ?, api_type = ?,
 		is_default = 1, updated_at = ?
 		WHERE id = ? AND sender_id = ?
 		`, cfg.Provider, cfg.BaseURL, encryptedAPIKey, cfg.Model,
-			cfg.MaxContext, cfg.MaxOutputTokens, cfg.ThinkingMode,
+			cfg.MaxContext, cfg.MaxOutputTokens, cfg.ThinkingMode, cfg.APIType,
 			now, cfg.ID, cfg.SenderID)
 		if err != nil {
 			return fmt.Errorf("update subscription by id: %w", err)
@@ -124,11 +125,11 @@ func (s *UserLLMConfigService) SetConfig(cfg *UserLLMConfig) error {
 		result, err := tx.Exec(`
 		UPDATE user_llm_subscriptions SET
 		provider = ?, base_url = ?, api_key = ?, model = ?,
-		max_context = ?, max_output_tokens = ?, thinking_mode = ?,
+		max_context = ?, max_output_tokens = ?, thinking_mode = ?, api_type = ?,
 		is_default = 1, updated_at = ?
 		WHERE sender_id = ? AND provider = ?
 		`, cfg.Provider, cfg.BaseURL, encryptedAPIKey, cfg.Model,
-			cfg.MaxContext, cfg.MaxOutputTokens, cfg.ThinkingMode,
+			cfg.MaxContext, cfg.MaxOutputTokens, cfg.ThinkingMode, cfg.APIType,
 			now, cfg.SenderID, cfg.Provider)
 		if err != nil {
 			return fmt.Errorf("update subscription: %w", err)
@@ -143,9 +144,9 @@ func (s *UserLLMConfigService) SetConfig(cfg *UserLLMConfig) error {
 				subName = "openai"
 			}
 			_, err = tx.Exec(`
-			INSERT INTO user_llm_subscriptions (id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?)
-		`, subID, cfg.SenderID, subName, cfg.Provider, cfg.BaseURL, encryptedAPIKey, cfg.Model, cfg.MaxContext, cfg.MaxOutputTokens, cfg.ThinkingMode, now, now)
+			INSERT INTO user_llm_subscriptions (id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, api_type, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)
+		`, subID, cfg.SenderID, subName, cfg.Provider, cfg.BaseURL, encryptedAPIKey, cfg.Model, cfg.MaxContext, cfg.MaxOutputTokens, cfg.ThinkingMode, cfg.APIType, now, now)
 			if err != nil {
 				return fmt.Errorf("insert subscription: %w", err)
 			}

--- a/storage/sqlite/user_llm_subscription.go
+++ b/storage/sqlite/user_llm_subscription.go
@@ -28,6 +28,7 @@ type LLMSubscription struct {
 	MaxContext      int                       // max context token limit (0 = use default)
 	MaxOutputTokens int                       // max output token limit (0 = use default 8192)
 	ThinkingMode    string                    // thinking mode: "" (auto), "enabled", "disabled"
+	APIType         string                    // API type: "" (default=chat_completions), "responses"
 	IsDefault       bool                      // whether this is the active subscription
 	CachedModels    []string                  // cached model list from API (JSON in DB)
 	PerModelConfigs map[string]PerModelConfig // per-model token overrides (JSON in DB)
@@ -68,7 +69,7 @@ func scanSubscription(scanner interface{ Scan(...any) error }, sub *LLMSubscript
 	var cachedModelsJSON string
 	var perModelConfigsJSON string
 	err := scanner.Scan(&sub.ID, &sub.SenderID, &sub.Name, &sub.Provider, &sub.BaseURL,
-		&encryptedAPIKey, &sub.Model, &isDefault, &sub.MaxContext, &sub.MaxOutputTokens, &sub.ThinkingMode,
+		&encryptedAPIKey, &sub.Model, &isDefault, &sub.MaxContext, &sub.MaxOutputTokens, &sub.ThinkingMode, &sub.APIType,
 		&cachedModelsJSON, &perModelConfigsJSON, &createdAt, &updatedAt)
 	if err != nil {
 		return "", 0, err
@@ -102,7 +103,7 @@ func decryptAPIKey(sub *LLMSubscription, encryptedAPIKey string) {
 func (s *LLMSubscriptionService) ListAll() ([]*LLMSubscription, error) {
 	conn := s.db.Conn()
 	rows, err := conn.Query(`
-		SELECT id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, cached_models, per_model_configs, created_at, updated_at
+		SELECT id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, api_type, cached_models, per_model_configs, created_at, updated_at
 			FROM user_llm_subscriptions
 			ORDER BY created_at ASC
 		`)
@@ -128,7 +129,7 @@ func (s *LLMSubscriptionService) ListAll() ([]*LLMSubscription, error) {
 func (s *LLMSubscriptionService) List(senderID string) ([]*LLMSubscription, error) {
 	conn := s.db.Conn()
 	rows, err := conn.Query(`
-			SELECT id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, cached_models, per_model_configs, created_at, updated_at
+			SELECT id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, api_type, cached_models, per_model_configs, created_at, updated_at
 				FROM user_llm_subscriptions
 				WHERE sender_id = ?
 				ORDER BY created_at ASC
@@ -155,7 +156,7 @@ func (s *LLMSubscriptionService) List(senderID string) ([]*LLMSubscription, erro
 func (s *LLMSubscriptionService) GetDefault(senderID string) (*LLMSubscription, error) {
 	conn := s.db.Conn()
 	row := conn.QueryRow(`
-		SELECT id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, cached_models, per_model_configs, created_at, updated_at
+		SELECT id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, api_type, cached_models, per_model_configs, created_at, updated_at
 			FROM user_llm_subscriptions
 			WHERE sender_id = ? AND is_default = 1
 			LIMIT 1
@@ -177,7 +178,7 @@ func (s *LLMSubscriptionService) GetDefault(senderID string) (*LLMSubscription, 
 func (s *LLMSubscriptionService) Get(id string) (*LLMSubscription, error) {
 	conn := s.db.Conn()
 	row := conn.QueryRow(`
-		SELECT id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, cached_models, per_model_configs, created_at, updated_at
+		SELECT id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, api_type, cached_models, per_model_configs, created_at, updated_at
 			FROM user_llm_subscriptions
 			WHERE id = ?
 		`, id)
@@ -237,9 +238,9 @@ func (s *LLMSubscriptionService) Add(sub *LLMSubscription) error {
 		}
 	}
 	_, err = tx.Exec(`
-		INSERT INTO user_llm_subscriptions (id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, per_model_configs, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, sub.ID, sub.SenderID, sub.Name, sub.Provider, sub.BaseURL, encryptedAPIKey, sub.Model, isDefault, sub.MaxContext, sub.MaxOutputTokens, sub.ThinkingMode, perModelConfigsJSON, now, now)
+		INSERT INTO user_llm_subscriptions (id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, api_type, per_model_configs, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, sub.ID, sub.SenderID, sub.Name, sub.Provider, sub.BaseURL, encryptedAPIKey, sub.Model, isDefault, sub.MaxContext, sub.MaxOutputTokens, sub.ThinkingMode, sub.APIType, perModelConfigsJSON, now, now)
 	if err != nil {
 		return fmt.Errorf("insert subscription: %w", err)
 	}
@@ -316,11 +317,11 @@ func (s *LLMSubscriptionService) Update(sub *LLMSubscription) error {
 	_, err = tx.Exec(`
 		UPDATE user_llm_subscriptions SET
 		name = ?, provider = ?, base_url = ?, api_key = ?, model = ?,
-		max_context = ?, max_output_tokens = ?, thinking_mode = ?,
+		max_context = ?, max_output_tokens = ?, thinking_mode = ?, api_type = ?,
 		per_model_configs = ?,
 		is_default = ?, updated_at = ?
 		WHERE id = ? AND sender_id = ?
-	`, sub.Name, sub.Provider, sub.BaseURL, encryptedAPIKey, sub.Model, sub.MaxContext, sub.MaxOutputTokens, sub.ThinkingMode, perModelConfigsJSON, isDefault, now, sub.ID, sub.SenderID)
+	`, sub.Name, sub.Provider, sub.BaseURL, encryptedAPIKey, sub.Model, sub.MaxContext, sub.MaxOutputTokens, sub.ThinkingMode, sub.APIType, perModelConfigsJSON, isDefault, now, sub.ID, sub.SenderID)
 	if err != nil {
 		return fmt.Errorf("update subscription: %w", err)
 	}

--- a/storage/sqlite/user_llm_subscription.go
+++ b/storage/sqlite/user_llm_subscription.go
@@ -46,6 +46,7 @@ type SubscriptionModel struct {
 	MaxContext      int    // max context window tokens
 	MaxOutputTokens int    // max output tokens
 	ThinkingMode    string // thinking mode override
+	APIType         string // API type override: "" (use subscription default), "responses"
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
@@ -428,13 +429,25 @@ func (sub *LLMSubscription) GetPerModelMaxContext(model string) int {
 	return 0
 }
 
+// GetPerModelAPIType returns the per-model API type override.
+// Returns "" if no override is set (use subscription default).
+func (sub *LLMSubscription) GetPerModelAPIType(model string) string {
+	if sub.PerModelConfigs == nil || model == "" {
+		return ""
+	}
+	if cfg, ok := sub.PerModelConfigs[model]; ok {
+		return cfg.APIType
+	}
+	return ""
+}
+
 // ─── SubscriptionModel CRUD ─────────────────────────────
 
 // scanSubscriptionModel scans a subscription_models row into a SubscriptionModel.
 func scanSubscriptionModel(scanner interface{ Scan(...any) error }, m *SubscriptionModel) error {
 	var createdAt, updatedAt string
 	err := scanner.Scan(&m.ID, &m.SubscriptionID, &m.Model, &m.MaxContext,
-		&m.MaxOutputTokens, &m.ThinkingMode, &createdAt, &updatedAt)
+		&m.MaxOutputTokens, &m.ThinkingMode, &m.APIType, &createdAt, &updatedAt)
 	if err != nil {
 		return err
 	}
@@ -447,7 +460,7 @@ func scanSubscriptionModel(scanner interface{ Scan(...any) error }, m *Subscript
 func (s *LLMSubscriptionService) GetModels(subID string) ([]*SubscriptionModel, error) {
 	conn := s.db.Conn()
 	rows, err := conn.Query(`
-		SELECT id, subscription_id, model, max_context, max_output_tokens, thinking_mode, created_at, updated_at
+		SELECT id, subscription_id, model, max_context, max_output_tokens, thinking_mode, api_type, created_at, updated_at
 		FROM subscription_models WHERE subscription_id = ? ORDER BY created_at ASC
 	`, subID)
 	if err != nil {
@@ -471,7 +484,7 @@ func (s *LLMSubscriptionService) GetModel(subID, model string) (*SubscriptionMod
 	m := &SubscriptionModel{}
 	err := scanSubscriptionModel(
 		conn.QueryRow(`
-			SELECT id, subscription_id, model, max_context, max_output_tokens, thinking_mode, created_at, updated_at
+			SELECT id, subscription_id, model, max_context, max_output_tokens, thinking_mode, api_type, created_at, updated_at
 			FROM subscription_models WHERE subscription_id = ? AND model = ?
 		`, subID, model),
 		m,
@@ -486,17 +499,18 @@ func (s *LLMSubscriptionService) GetModel(subID, model string) (*SubscriptionMod
 }
 
 // UpsertModel inserts or updates a model row in subscription_models.
-func (s *LLMSubscriptionService) UpsertModel(subID, model string, maxCtx, maxOut int, thinking string) error {
+func (s *LLMSubscriptionService) UpsertModel(subID, model string, maxCtx, maxOut int, thinking, apiType string) error {
 	conn := s.db.Conn()
 	_, err := conn.Exec(`
-		INSERT INTO subscription_models (id, subscription_id, model, max_context, max_output_tokens, thinking_mode)
-		VALUES (lower(hex(randomblob(16))), ?, ?, ?, ?, ?)
+		INSERT INTO subscription_models (id, subscription_id, model, max_context, max_output_tokens, thinking_mode, api_type)
+		VALUES (lower(hex(randomblob(16))), ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(subscription_id, model) DO UPDATE SET
 			max_context = excluded.max_context,
 			max_output_tokens = excluded.max_output_tokens,
 			thinking_mode = excluded.thinking_mode,
+			api_type = excluded.api_type,
 			updated_at = datetime('now')
-	`, subID, model, maxCtx, maxOut, thinking)
+	`, subID, model, maxCtx, maxOut, thinking, apiType)
 	if err != nil {
 		return fmt.Errorf("upsert model: %w", err)
 	}


### PR DESCRIPTION
## Summary

为 xbot 增加 OpenAI Responses API (`POST /v1/responses`) 作为 Chat Completions 之外的可选请求路径，通过 subscription 级 `api_type` 字段切换。

Closes #159

## Changes

### New Files
- `llm/openai_responses.go` — Responses API 核心实现：消息转换（ChatMessage → ResponseNewParams）、工具转换、reasoning 适配（thinkingMode → ReasoningParam）、非流式 + 流式
- `llm/openai_responses_test.go` — 22 个单元测试覆盖 4 个核心函数
- `docs/plans/openai-responses-api.md` — 实现计划文档

### Modified Files
| File | Change |
|------|--------|
| `llm/openai.go` | `OpenAIConfig` + `OpenAILLM` 加 `APIType` 字段，`Generate`/`GenerateStream` 路由分发 |
| `protocol/events.go` | `Subscription` 加 `APIType` 字段 |
| `storage/sqlite/db.go` | `schemaVersion` 35→36 |
| `storage/sqlite/user_llm_subscription.go` | `LLMSubscription` 加 `APIType`，所有 SQL + Scan 适配 |
| `storage/sqlite/user_llm_config.go` | `UserLLMConfig` 加 `APIType`，所有 SQL + Scan 适配 |
| `storage/sqlite/migrations.go` | 新增 `migrateV35ToV36`（ALTER TABLE ADD COLUMN api_type） |
| `storage/sqlite/subscription_test.go` | 测试断言 version 35→36 |
| `agent/llm_factory.go` | `createClient`/`createEntryFromSub`/`createClientFromSub` 透传 `APIType` |
| `serverapp/rpc_table.go` | `updateSubscription` handler 加 `api_type` overlay，`subToChannel` 映射 |

## Config Chain

```
config.json / DB subscription
  → protocol.Subscription.APIType
  → sqlite.LLMSubscription.APIType (DB, v36 migration)
  → sqlite.UserLLMConfig.APIType
  → llm.OpenAIConfig.APIType
  → OpenAILLM.apiType
  → Generate()/GenerateStream() routing
```

## Usage

在 subscription 配置中设置 `api_type: "responses"` 即可切换到 Responses API 路径：

```json
{
  "api_type": "responses"
}
```

不设置则默认走 Chat Completions，完全向后兼容。

## MVP Scope

| Capability | Supported |
|-----------|-----------|
| Text output | ✅ |
| Custom function calling | ✅ |
| Streaming | ✅ |
| thinkingMode → reasoning auto-adapt | ✅ |
| Built-in tools (web_search, file_search) | ❌ Future |
| `previous_response_id` state management | ❌ Future |

## Testing

- `go build ./...` ✅
- `go test ./llm/...` ✅ (22 new tests)
- `go test ./storage/...` ✅ (v36 migration)
- `go test ./agent/...` ✅
- `go test ./serverapp/...` ✅
- `go test ./protocol/...` ✅