### PR TITLE
fix: formatToolLabel panic on long tool names causing get_history crash

### DIFF
--- a/channel/subscription.go
+++ b/channel/subscription.go
@@ -52,6 +52,22 @@ type iterToolSnap struct {
 	Summary   string `json:"summary,omitempty"`
 }
 
+// truncateLabel safely truncates a string to maxRunes, appending "..." if truncated.
+// If maxRunes <= 0 or >= len(runes), returns the original string unchanged.
+func truncateLabel(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	if maxRunes <= 3 {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-3]) + "..."
+}
+
 // formatToolLabel generates a short human-readable label from a tool name and its JSON arguments.
 // Used when restoring progress from intermediate assistant messages (no Detail snapshot),
 // e.g. after server restart. Produces labels like "Shell(tail -100 file.log)" or "Read(path)".
@@ -72,14 +88,21 @@ func formatToolLabel(name, argsJSON string) string {
 		return ""
 	}
 
+	// budget returns the max runes available for the argument value,
+	// accounting for "name(" + ")" wrapper. Returns 0 if name itself exceeds maxLen.
+	budget := func() int {
+		n := maxLen - len(name) - 2 // len("name(") + len(")") = len(name) + 2
+		if n < 0 {
+			n = 0
+		}
+		return n
+	}
+
 	switch name {
 	case "Shell":
 		cmd := get("command")
 		if cmd != "" {
-			if len(cmd) > maxLen-len(name)-2 {
-				cmd = cmd[:maxLen-len(name)-5] + "..."
-			}
-			return name + "(" + cmd + ")"
+			return name + "(" + truncateLabel(cmd, budget()) + ")"
 		}
 	case "Read":
 		p := get("path")
@@ -115,8 +138,8 @@ func formatToolLabel(name, argsJSON string) string {
 		r := get("role")
 		t := get("task")
 		if r != "" {
-			if t != "" && len(t) > 30 {
-				t = t[:27] + "..."
+			if t != "" {
+				t = truncateLabel(t, 30)
 			}
 			if t != "" {
 				return name + "(" + r + ": " + t + ")"
@@ -127,10 +150,7 @@ func formatToolLabel(name, argsJSON string) string {
 		// Generic: show first string parameter
 		for _, v := range args {
 			if s, ok := v.(string); ok && s != "" {
-				if len(s) > maxLen-len(name)-2 {
-					s = s[:maxLen-len(name)-5] + "..."
-				}
-				return name + "(" + s + ")"
+				return name + "(" + truncateLabel(s, budget()) + ")"
 			}
 		}
 	}

--- a/channel/subscription.go
+++ b/channel/subscription.go
@@ -52,8 +52,9 @@ type iterToolSnap struct {
 	Summary   string `json:"summary,omitempty"`
 }
 
-// truncateLabel safely truncates a string to maxRunes, appending "..." if truncated.
-// If maxRunes <= 0 or >= len(runes), returns the original string unchanged.
+// truncateLabel safely truncates a string to maxRunes.
+// Appends "..." if truncated and maxRunes > 3.
+// If maxRunes <= 0 or the string already fits, returns original unchanged.
 func truncateLabel(s string, maxRunes int) string {
 	if maxRunes <= 0 {
 		return s
@@ -90,6 +91,7 @@ func formatToolLabel(name, argsJSON string) string {
 
 	// budget returns the max runes available for the argument value,
 	// accounting for "name(" + ")" wrapper. Returns 0 if name itself exceeds maxLen.
+	// Tool names are always ASCII, so len(name) == rune count.
 	budget := func() int {
 		n := maxLen - len(name) - 2 // len("name(") + len(")") = len(name) + 2
 		if n < 0 {

--- a/channel/subscription_test.go
+++ b/channel/subscription_test.go
@@ -1,0 +1,101 @@
+package channel
+
+import (
+	"testing"
+)
+
+func TestFormatToolLabel_Short(t *testing.T) {
+	tests := []struct {
+		name     string
+		argsJSON string
+		want     string
+	}{
+		{"Shell", `{"command":"ls -la"}`, "Shell(ls -la)"},
+		{"Read", `{"path":"/etc/hosts"}`, "Read(/etc/hosts)"},
+		{"Grep", `{"pattern":"TODO"}`, "Grep(TODO)"},
+		{"WebSearch", `{"query":"hello"}`, "WebSearch(hello)"},
+		{"SubAgent", `{"role":"explore","task":"find bug"}`, "SubAgent(explore: find bug)"},
+		{"Unknown", `{"key":"value"}`, "Unknown(value)"},
+		{"NoArgs", `{}`, "NoArgs"},
+		{"InvalidJSON", `not json`, "InvalidJSON"},
+	}
+	for _, tt := range tests {
+		got := formatToolLabel(tt.name, tt.argsJSON)
+		if got != tt.want {
+			t.Errorf("formatToolLabel(%q, %q) = %q, want %q", tt.name, tt.argsJSON, got, tt.want)
+		}
+	}
+}
+
+func TestFormatToolLabel_LongCommand(t *testing.T) {
+	longCmd := "this is a very long shell command that exceeds the max label length and should be truncated"
+	got := formatToolLabel("Shell", `{"command":"`+longCmd+`"}`)
+	if len(got) <= 0 {
+		t.Fatal("expected non-empty result")
+	}
+	if len(got) <= len("Shell()") {
+		t.Fatalf("result too short: %q", got)
+	}
+	// Should be truncated with "..."
+	if len([]rune(got)) > 60 {
+		t.Errorf("result too long (%d runes): %q", len([]rune(got)), got)
+	}
+}
+
+func TestFormatToolLabel_LongToolName(t *testing.T) {
+	// Tool name longer than maxLen (60) — must NOT panic.
+	longName := "very_long_tool_name_that_exceeds_the_max_label_length_of_sixty_characters_xxxxxxxxxxxxxxxx"
+	got := formatToolLabel(longName, `{"param":"some value"}`)
+	if got == "" {
+		t.Fatal("expected non-empty result")
+	}
+}
+
+func TestFormatToolLabel_VeryLongToolName(t *testing.T) {
+	// Extremely long tool name — must NOT panic.
+	extremeName := "a" + string(make([]byte, 500))
+	got := formatToolLabel(extremeName, `{"param":"val"}`)
+	if got == "" {
+		t.Fatal("expected non-empty result")
+	}
+}
+
+func TestFormatToolLabel_CJKContent(t *testing.T) {
+	// CJK characters — rune-safe truncation.
+	cjk := "这是一个非常长的中文命令需要被截断处理测试用例"
+	got := formatToolLabel("Shell", `{"command":"`+cjk+`"}`)
+	if got == "" {
+		t.Fatal("expected non-empty result")
+	}
+}
+
+func TestTruncateLabel(t *testing.T) {
+	tests := []struct {
+		s        string
+		maxRunes int
+		want     string
+	}{
+		{"hello", 10, "hello"},       // no truncation needed
+		{"hello", 5, "hello"},        // exactly fits
+		{"hello", 3, "hel"},          // maxRunes <= 3, no "..."
+		{"hello world", 8, "hello..."},  // truncate with ellipsis
+		{"hello", 0, "hello"},         // maxRunes <= 0, return original
+		{"hello", -1, "hello"},        // negative, return original
+		{"hi", 1, "h"},                // very short maxRunes
+	}
+	for _, tt := range tests {
+		got := truncateLabel(tt.s, tt.maxRunes)
+		if got != tt.want {
+			t.Errorf("truncateLabel(%q, %d) = %q, want %q", tt.s, tt.maxRunes, got, tt.want)
+		}
+	}
+}
+
+func TestFormatToolLabel_SubAgentLongTask(t *testing.T) {
+	longTask := "this is a very long task description that should be truncated to fit within thirty runes"
+	got := formatToolLabel("SubAgent", `{"role":"explore","task":"`+longTask+`"}`)
+	// Should not panic and should contain truncation
+	if len([]rune(got)) > 60 {
+		t.Errorf("result too long: %q (%d runes)", got, len([]rune(got)))
+	}
+}

--- a/channel/subscription_test.go
+++ b/channel/subscription_test.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -53,7 +54,7 @@ func TestFormatToolLabel_LongToolName(t *testing.T) {
 
 func TestFormatToolLabel_VeryLongToolName(t *testing.T) {
 	// Extremely long tool name — must NOT panic.
-	extremeName := "a" + string(make([]byte, 500))
+	extremeName := "a" + strings.Repeat("x", 500)
 	got := formatToolLabel(extremeName, `{"param":"val"}`)
 	if got == "" {
 		t.Fatal("expected non-empty result")

--- a/channel/subscription_test.go
+++ b/channel/subscription_test.go
@@ -75,13 +75,13 @@ func TestTruncateLabel(t *testing.T) {
 		maxRunes int
 		want     string
 	}{
-		{"hello", 10, "hello"},       // no truncation needed
-		{"hello", 5, "hello"},        // exactly fits
-		{"hello", 3, "hel"},          // maxRunes <= 3, no "..."
-		{"hello world", 8, "hello..."},  // truncate with ellipsis
-		{"hello", 0, "hello"},         // maxRunes <= 0, return original
-		{"hello", -1, "hello"},        // negative, return original
-		{"hi", 1, "h"},                // very short maxRunes
+		{"hello", 10, "hello"},         // no truncation needed
+		{"hello", 5, "hello"},          // exactly fits
+		{"hello", 3, "hel"},            // maxRunes <= 3, no "..."
+		{"hello world", 8, "hello..."}, // truncate with ellipsis
+		{"hello", 0, "hello"},          // maxRunes <= 0, return original
+		{"hello", -1, "hello"},         // negative, return original
+		{"hi", 1, "h"},                 // very short maxRunes
 	}
 	for _, tt := range tests {
 		got := truncateLabel(tt.s, tt.maxRunes)

--- a/channel/web/web.go
+++ b/channel/web/web.go
@@ -957,7 +957,18 @@ func (wc *WebChannel) readPump(c *Client, si *sessionInfo) {
 				log.WithError(err).Debug("Invalid RPC message from CLI client")
 				continue
 			}
-			result, rpcErr := wc.callbacks.RPCHandler(rpcReq.Method, rpcReq.Params, c.userID)
+			var result json.RawMessage
+			var rpcErr error
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.WithField("method", rpcReq.Method).WithField("rpc_id", rpcReq.ID).
+							WithError(fmt.Errorf("%v", r)).Error("RPC handler panic")
+						rpcErr = fmt.Errorf("internal error: %v", r)
+					}
+				}()
+				result, rpcErr = wc.callbacks.RPCHandler(rpcReq.Method, rpcReq.Params, c.userID)
+			}()
 			rpcMsg := protocol.WSMessage{Type: protocol.MsgTypeRPCResponse, ID: rpcReq.ID}
 			if rpcErr != nil {
 				rpcMsg.Error = rpcErr.Error()

--- a/channel/web/web.go
+++ b/channel/web/web.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -962,8 +963,11 @@ func (wc *WebChannel) readPump(c *Client, si *sessionInfo) {
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
-						log.WithField("method", rpcReq.Method).WithField("rpc_id", rpcReq.ID).
-							WithError(fmt.Errorf("%v", r)).Error("RPC handler panic")
+						log.WithField("method", rpcReq.Method).
+							WithField("rpc_id", rpcReq.ID).
+							WithField("stack", string(debug.Stack())).
+							WithError(fmt.Errorf("%v", r)).
+							Error("RPC handler panic")
 						rpcErr = fmt.Errorf("internal error: %v", r)
 					}
 				}()


### PR DESCRIPTION
## Summary

Fixes #167

`formatToolLabel` in `channel/subscription.go` used manual byte-slice arithmetic (`cmd[:maxLen-len(name)-5]`) to truncate tool arguments. When the tool name is long (≥ 56 chars, common for MCP/channel-plugin tools), the slice end becomes negative — `[:-359]` — causing a runtime panic.

The panic occurred inside `ConvertMessagesToHistory`, called by the `get_history` RPC handler. Since `readPump` had no `recover()`, the panic killed the entire WebSocket connection, making the session permanently inaccessible with `Failed to load history: RPC get_history: connection lost`.

## Changes

### `channel/subscription.go`
- **Add `truncateLabel(s string, maxRunes int) string`**: rune-safe helper. Returns original string when `maxRunes <= 0` (no truncation possible). Never panics.
- **Replace all manual slice arithmetic** in `formatToolLabel` with `truncateLabel()` calls.
- Refactored truncation budget calculation into a `budget()` closure for clarity.

### `channel/web/web.go`
- **Add `recover()` to `readPump` RPC dispatch**: defense-in-depth so future panics in any RPC handler return an error to the client instead of killing the WS connection.

### `channel/subscription_test.go` (new)
- 7 test cases covering: short names, long commands, very long tool names (500+ chars), CJK content, SubAgent long task, and `truncateLabel` edge cases.

## Testing

```
=== RUN   TestFormatToolLabel_Short
--- PASS
=== RUN   TestFormatToolLabel_LongCommand
--- PASS
=== RUN   TestFormatToolLabel_LongToolName
--- PASS
=== RUN   TestFormatToolLabel_VeryLongToolName
--- PASS
=== RUN   TestFormatToolLabel_CJKContent
--- PASS
=== RUN   TestTruncateLabel
--- PASS
=== RUN   TestFormatToolLabel_SubAgentLongTask
--- PASS
PASS
```

## Design Decision

Rather than patching the symptom (adding `if n <= 0 { n = 1 }` guards), the fix replaces the root cause: manual byte-slice arithmetic. The new `truncateLabel` helper is:
- **Rune-safe**: works correctly with CJK/emoji content
- **Panic-proof**: returns original string when truncation is impossible
- **Consistent**: follows the pattern already used by 10+ other truncate helpers in the codebase (`truncateArgs`, `truncate` in sqlite/chat.go, etc.)

The `recover()` in readPump is defense-in-depth — not the primary fix, but prevents future panics in any RPC handler from cascading into WS connection loss.