### PR TITLE
fix(feishu): AskUser P2P chat_id 不匹配导致上下文丢失

### DIFF
--- a/channel/feishu/feishu.go
+++ b/channel/feishu/feishu.go
@@ -1043,7 +1043,8 @@ func (f *FeishuChannel) onMessage(ctx context.Context, event *larkim.P2MessageRe
 
 	// AskUser text reply fallback: if there's a pending AskUser for this chat+user,
 	// treat the text message as the answer instead of a new conversation turn.
-	if askKey := chatID + ":" + senderID; f.tryResolveAskUserByText(askKey, finalContent, senderID, senderName, chatID, chatType, msgTime, requestID, metadata) {
+	askKey, pending := f.findPendingAskUser(chatID, senderID)
+	if pending != nil && f.tryResolveAskUserByText(askKey, finalContent, senderID, senderName, chatID, chatType, msgTime, requestID, metadata) {
 		return nil
 	}
 
@@ -1963,6 +1964,26 @@ func (f *FeishuChannel) buildSimpleAskUserCard(questions []ch.AskQItem) map[stri
 	}
 }
 
+// findPendingAskUser looks up a pending AskUser state by chat+user.
+// In P2P chats, msg.ChatID is senderID (open_id), but card/text callbacks
+// return the real P2P chat_id (oc_xxx). So we try both key formats.
+func (f *FeishuChannel) findPendingAskUser(chatID, senderID string) (string, *feishuPendingAskUser) {
+	primaryKey := chatID + ":" + senderID
+	f.askUserMu.Lock()
+	if pending, ok := f.askUsers[primaryKey]; ok {
+		f.askUserMu.Unlock()
+		return primaryKey, pending
+	}
+	// P2P fallback: the pending state was registered with senderID as ChatID
+	p2pKey := senderID + ":" + senderID
+	if pending, ok := f.askUsers[p2pKey]; ok {
+		f.askUserMu.Unlock()
+		return p2pKey, pending
+	}
+	f.askUserMu.Unlock()
+	return "", nil
+}
+
 // handleAskUserCardAction intercepts card callbacks from AskUser cards.
 // Returns (response, true) if the action was an AskUser action, (nil, false) otherwise.
 func (f *FeishuChannel) handleAskUserCardAction(actionData map[string]any, action *callback.CallBackAction, chatID, senderID, messageID string) (*callback.CardActionTriggerResponse, bool) {
@@ -1975,15 +1996,9 @@ func (f *FeishuChannel) handleAskUserCardAction(actionData map[string]any, actio
 	}
 
 	// Find pending AskUser for this chat+user
-	askKey := chatID + ":" + senderID
-	f.askUserMu.Lock()
-	pending, ok := f.askUsers[askKey]
-	// NOTE: Do NOT delete from askUsers here — we keep it alive for
-	// multi-question mode where the user answers questions one at a time.
-	// Only delete on final submit, cancel, or reject.
-	f.askUserMu.Unlock()
+	askKey, pending := f.findPendingAskUser(chatID, senderID)
 
-	if !ok {
+	if pending == nil {
 		// Log all existing keys for debugging key mismatch
 		existingKeys := []string{}
 		f.askUserMu.Lock()
@@ -2011,13 +2026,13 @@ func (f *FeishuChannel) handleAskUserCardAction(actionData map[string]any, actio
 		f.msgBus.Inbound <- bus.InboundMessage{
 			Channel:   "feishu",
 			SenderID:  senderID,
-			ChatID:    chatID,
+			ChatID:    pending.ChatID,
 			ChatType:  "p2p",
 			Content:   "/cancel",
 			Time:      time.Now(),
 			RequestID: log.NewRequestID(),
 			From:      bus.NewIMAddress("feishu", senderID),
-			To:        bus.NewIMAddress("feishu", chatID),
+			To:        bus.NewIMAddress("feishu", pending.ChatID),
 		}
 		return f.buildAskUserAnsweredCard(pending, map[int]string{}, "Cancelled", "grey"), true
 	}
@@ -2034,13 +2049,13 @@ func (f *FeishuChannel) handleAskUserCardAction(actionData map[string]any, actio
 			Channel:    "feishu",
 			SenderID:   senderID,
 			SenderName: "",
-			ChatID:     chatID,
+			ChatID:     pending.ChatID,
 			ChatType:   "p2p",
 			Content:    content,
 			Time:       time.Now(),
 			RequestID:  log.NewRequestID(),
 			From:       bus.NewIMAddress("feishu", senderID),
-			To:         bus.NewIMAddress("feishu", chatID),
+			To:         bus.NewIMAddress("feishu", pending.ChatID),
 			Metadata:   map[string]string{"ask_user_answered": "true"},
 		}
 		return f.buildAskUserAnsweredCard(pending, map[int]string{0: "Rejected"}, "Rejected", "red"), true
@@ -2139,17 +2154,20 @@ func (f *FeishuChannel) recordAskUserAnswer(askKey string, pending *feishuPendin
 	}
 	content := strings.Join(parts, "\n\n")
 
+	// Use pending.ChatID (the session's ChatID from the original conversation)
+	// not the card callback's chatID. In P2P chats these differ: the session
+	// uses senderID (open_id) as ChatID, but card callbacks return oc_xxx.
 	f.msgBus.Inbound <- bus.InboundMessage{
 		Channel:    "feishu",
 		SenderID:   senderID,
 		SenderName: "",
-		ChatID:     chatID,
+		ChatID:     pending.ChatID,
 		ChatType:   "p2p",
 		Content:    content,
 		Time:       time.Now(),
 		RequestID:  log.NewRequestID(),
 		From:       bus.NewIMAddress("feishu", senderID),
-		To:         bus.NewIMAddress("feishu", chatID),
+		To:         bus.NewIMAddress("feishu", pending.ChatID),
 		Metadata:   map[string]string{"ask_user_answered": "true"},
 	}
 


### PR DESCRIPTION
## 问题

飞书 P2P 聊天中使用 AskUser 工具时，用户点击按钮或输入文字提交后，xbot 丢失所有上下文（历史对话、工作上下文），且 `/cancel` 被迫排队无法生效。

## 根因

P2P 聊天中存在两种 chatID 格式：

| 来源 | 值 | 用途 |
|------|-----|------|
| 消息事件 `replyTo` | `ou_xxx` (open_id) | session 存储、InboundMessage.ChatID |
| 卡片回调 `chat_id` | `oc_xxx` (P2P chat_id) | handleAskUserCardAction 参数 |

`feishu.go` L961-963 中 P2P 聊天 `replyTo = senderID`（open_id），所以原始 session 存在 `feishu:ou_xxx` 下。但飞书卡片回调返回真实 P2P chat_id（`oc_xxx`），导致：

1. **Pending state key 不匹配**：注册时 key = `ou_xxx:ou_xxx`，查找时 key = `oc_xxx:ou_xxx` → 找不到 → fallthrough 到 generic handler
2. **Answer 路由到错误 session**：即使 pending state 找到，InboundMessage 用 `oc_xxx` 发到 bus → 加载了空 session → 无历史对话 → AskUser tool result 也找不到

## 修复

### 1. 提取 `findPendingAskUser` 辅助方法
查找 pending state 时尝试两种 key 格式：
- `chatID:senderID` — 群聊场景
- `senderID:senderID` — P2P 场景 fallback

### 2. 所有 InboundMessage dispatch 使用 `pending.ChatID`
三个路径（answer/cancel/reject）原来用卡片回调的 `chatID`（oc_xxx），改为用 `pending.ChatID`（注册时保存的 ou_xxx），确保路由到正确的 session。

## 影响范围

仅影响飞书 P2P 聊天的 AskUser 交互。群聊不受影响（群聊中 chatID 一致）。