### PR TITLE
fix(memory): 为 memory_provider 添加无操作提供程序："none"

### DIFF
--- a/memory/noop/noop.go
+++ b/memory/noop/noop.go
@@ -1,0 +1,40 @@
+package noop
+
+import (
+	"context"
+
+	"xbot/memory"
+)
+
+// NoOpMemory is a no-op memory provider.
+// It satisfies the MemoryProvider interface but performs no actual work:
+// no LLM calls, no file I/O, no persistence.
+// Used when memory_provider is set to "none" to disable memory entirely.
+type NoOpMemory struct{}
+
+var _ memory.MemoryProvider = (*NoOpMemory)(nil)
+
+// New creates a new NoOpMemory instance.
+func New() *NoOpMemory {
+	return &NoOpMemory{}
+}
+
+// Recall returns empty string — no memory to inject.
+func (m *NoOpMemory) Recall(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+// Memorize returns success without performing any work.
+// The NewLastConsolidated is set to len(messages) so the caller treats all
+// messages as already consolidated, avoiding repeated invocations.
+func (m *NoOpMemory) Memorize(_ context.Context, input memory.MemorizeInput) (memory.MemorizeResult, error) {
+	return memory.MemorizeResult{
+		NewLastConsolidated: len(input.Messages),
+		OK:                  true,
+	}, nil
+}
+
+// Close is a no-op.
+func (m *NoOpMemory) Close() error {
+	return nil
+}

--- a/session/multitenant.go
+++ b/session/multitenant.go
@@ -18,6 +18,7 @@ import (
 	"xbot/memory"
 	"xbot/memory/flat"
 	"xbot/memory/letta"
+	"xbot/memory/noop"
 	"xbot/storage/sqlite"
 	"xbot/storage/vectordb"
 	"xbot/tools"
@@ -311,6 +312,9 @@ func (m *MultiTenantSession) GetOrCreateSession(channel, chatID string) (*Tenant
 		memProvider = letta.New(tenantID, m.coreSvc, m.archivalSvc, m.memorySvc, m.toolIndexSvc)
 		// 前向兼容：一次性迁移 user_profiles → core memory blocks
 		m.migrateProfileToCoreMemory(tenantID)
+	case "none":
+		// 禁用记忆：不创建文件、不调用 LLM、不写入任何记忆存储
+		memProvider = noop.New()
 	default:
 		// Flat memory: file-based storage under ~/.xbot/memory/{tenantID}/
 		// Use tenantID (numeric) as directory name for filesystem safety


### PR DESCRIPTION
当 `memory_provider` 设置为 `"none"` 时，`session/multitenant.go` 中的 switch 语句落入 default 分支并创建了一个 `FlatMemory` 实例。这意味着 `/new` 仍然会触发完整的内存归档（LLM 摘要 + 写入 MEMORY.md / HISTORY.md），违背了禁用内存的初衷。

添加一个明确的 `"none"` 分支，创建一个实现了 `MemoryProvider` 接口的 `NoOpMemory` 提供者，其方法均为空操作

Fixes #175