### PR TITLE
fix(cli): incremental iteration render in updateStreamingOnly (O(1) per iteration)

### DIFF
--- a/channel/cli/cli_progress_test.go
+++ b/channel/cli/cli_progress_test.go
@@ -1320,6 +1320,77 @@ func TestUpdateStreamingOnly_IncrementalAppend(t *testing.T) {
 		}
 		t.Logf("Full rebuild confirmed: width reset from 999 → %d, all %d iterations re-rendered", model.rc.streamCompletedWidth, model.rc.streamCompletedCount)
 	})
+
+	t.Run("cross-kind-separator-single-blank-line", func(t *testing.T) {
+		model := setupModel()
+
+		// Seed: iteration 1 ends with tools, iteration 2 is reasoning only.
+		// Different block kinds (tools → reasoning) should produce exactly one
+		// blank guide line as separator between old and new iteration groups.
+		model.progressState.iterations = []cliIterationSnapshot{
+			{Iteration: 1, Tools: []protocol.ToolProgress{
+				{Name: "Read", Label: "read file", Status: "done", Elapsed: 100, Iteration: 1},
+			}},
+		}
+		model.rc.streamCompletedWidth = -1
+		model.updateStreamingOnly()
+
+		if model.rc.streamCompletedCount != 1 {
+			t.Fatalf("expected count=1 after seed, got %d", model.rc.streamCompletedCount)
+		}
+		oldLines := make([]string, len(model.rc.streamCompletedLines))
+		copy(oldLines, model.rc.streamCompletedLines)
+
+		// Add iteration 2: Reasoning block (different kind from tools).
+		model.progressState.iterations = append(model.progressState.iterations,
+			cliIterationSnapshot{Iteration: 2, Reasoning: "cross-kind reasoning text"})
+
+		model.updateStreamingOnly()
+
+		if model.rc.streamCompletedCount != 2 {
+			t.Fatalf("expected count=2 after increment, got %d", model.rc.streamCompletedCount)
+		}
+
+		// Old lines preserved
+		newLines := model.rc.streamCompletedLines
+		for i := range oldLines {
+			if newLines[i] != oldLines[i] {
+				t.Errorf("line %d changed: old=%q new=%q", i, oldLines[i], newLines[i])
+			}
+		}
+
+		// The appended portion should contain exactly one blank guide line
+		// (separator) before the reasoning content.
+		appended := newLines[len(oldLines):]
+		if len(appended) < 2 {
+			t.Fatalf("expected at least 2 appended lines (separator + content), got %d", len(appended))
+		}
+		// First appended line should be a blank guide line (just the guide symbol,
+		// no content). Strip ANSI then check that only "┊ " remains.
+		guideSym := "┊"
+		firstStripped := strings.TrimRight(stripAnsi(appended[0]), " ")
+		if firstStripped != guideSym {
+			t.Errorf("first appended line should be blank guide (just %q), got %q", guideSym, firstStripped)
+		}
+		// Reasoning marker should appear somewhere in appended content
+		appendedText := strings.Join(appended, "\n")
+		if !strings.Contains(stripAnsi(appendedText), "cross-kind reasoning text") {
+			t.Errorf("appended portion should contain reasoning marker, got:\n%s", stripAnsi(appendedText))
+		}
+		// Verify no double blank guide lines (bug: "\n\n" prepend would produce 2)
+		blankCount := 0
+		for _, l := range appended {
+			s := strings.TrimRight(stripAnsi(l), " ")
+			if s == guideSym {
+				blankCount++
+			}
+		}
+		if blankCount != 1 {
+			t.Errorf("expected exactly 1 blank guide line as separator, got %d", blankCount)
+		}
+
+		t.Logf("Cross-kind separator correct: 1 blank guide line between tools→reasoning")
+	})
 }
 
 // TestSyncProgressTodos_SameCountPreservesCache locks in the P3 fix:

--- a/channel/cli/cli_progress_test.go
+++ b/channel/cli/cli_progress_test.go
@@ -1208,3 +1208,230 @@ func TestAgentSession_MultipleSubAgents_DistinctToolEntries(t *testing.T) {
 		t.Errorf("expected 3 SubAgent tools in summary, got %d (dedup bug)", tools)
 	}
 }
+
+// =============================================================================
+// Performance regression tests: O(1) complexity guards
+// =============================================================================
+
+// TestUpdateStreamingOnly_IncrementalAppend verifies that updateStreamingOnly
+// uses the incremental path when iteration count increases but width is unchanged:
+// only NEW iterations are rendered (O(1) per new iteration), old completedLines
+// are preserved. Full rebuild only happens on width change or count reset.
+func TestUpdateStreamingOnly_IncrementalAppend(t *testing.T) {
+	setupModel := func() *cliModel {
+		model := initTestModel()
+		model.ticker.frame = 0
+		model.rc.valid = true
+		model.messages = append(model.messages, cliMessage{
+			role:      "assistant",
+			turnID:    1,
+			timestamp: time.Now(),
+			isPartial: true,
+		})
+		model.streamingMsgIdx = 0
+		model.typing = true
+		return model
+	}
+
+	t.Run("incremental-preserves-old-lines", func(t *testing.T) {
+		model := setupModel()
+
+		// Seed with 2 iterations, force full rebuild via width mismatch
+		model.progressState.iterations = []cliIterationSnapshot{
+			{Iteration: 1, Thinking: "first-iter-thinking"},
+			{Iteration: 2, Thinking: "second-iter-thinking"},
+		}
+		model.rc.streamCompletedWidth = -1
+		model.updateStreamingOnly()
+
+		if model.rc.streamCompletedCount != 2 {
+			t.Fatalf("expected count=2 after seed, got %d", model.rc.streamCompletedCount)
+		}
+		oldLines := make([]string, len(model.rc.streamCompletedLines))
+		copy(oldLines, model.rc.streamCompletedLines)
+		oldMaxW := model.rc.streamMaxW
+
+		// Add a 3rd iteration — should trigger INCREMENTAL path (same width)
+		model.progressState.iterations = append(model.progressState.iterations,
+			cliIterationSnapshot{Iteration: 3, Thinking: "third-iter-thinking"})
+
+		model.updateStreamingOnly()
+
+		// Assert count increased
+		if model.rc.streamCompletedCount != 3 {
+			t.Fatalf("expected count=3 after increment, got %d", model.rc.streamCompletedCount)
+		}
+
+		// Assert old lines are preserved verbatim (prefix of new lines)
+		newLines := model.rc.streamCompletedLines
+		if len(newLines) <= len(oldLines) {
+			t.Fatalf("newLines(%d) should be longer than oldLines(%d)", len(newLines), len(oldLines))
+		}
+		for i := range oldLines {
+			if newLines[i] != oldLines[i] {
+				t.Errorf("line %d changed: old=%q new=%q — old completedLines should be preserved", i, oldLines[i], newLines[i])
+			}
+		}
+
+		// Assert new iteration marker appears ONLY in appended portion
+		oldText := strings.Join(oldLines, "\n")
+		appendedText := strings.Join(newLines[len(oldLines):], "\n")
+
+		if !strings.Contains(appendedText, "third-iter-thinking") {
+			t.Error("third-iter-thinking not found in appended portion")
+		}
+		if strings.Contains(oldText, "third-iter-thinking") {
+			t.Error("third-iter-thinking leaked into old portion — should only be in appended area")
+		}
+
+		// Assert max width is maintained/updated correctly
+		if model.rc.streamMaxW < oldMaxW {
+			t.Errorf("maxW decreased from %d to %d", oldMaxW, model.rc.streamMaxW)
+		}
+
+		t.Logf("O(1) confirmed: %d lines preserved, %d new lines appended", len(oldLines), len(newLines)-len(oldLines))
+	})
+
+	t.Run("width-change-triggers-full-rebuild", func(t *testing.T) {
+		model := setupModel()
+
+		model.progressState.iterations = []cliIterationSnapshot{
+			{Iteration: 1, Thinking: "iter-one"},
+			{Iteration: 2, Thinking: "iter-two"},
+		}
+		// First call at width W1
+		model.rc.streamCompletedWidth = -1
+		model.updateStreamingOnly()
+		firstWidth := model.rc.streamCompletedWidth
+
+		// Add iteration + change cached width → should trigger full rebuild
+		model.progressState.iterations = append(model.progressState.iterations,
+			cliIterationSnapshot{Iteration: 3, Thinking: "iter-three"})
+		model.rc.streamCompletedWidth = 999 // mismatched → forces full rebuild
+
+		model.updateStreamingOnly()
+
+		if model.rc.streamCompletedCount != 3 {
+			t.Errorf("expected count=3 after width change rebuild, got %d", model.rc.streamCompletedCount)
+		}
+		// Full rebuild resets width to actual contentWidth, not the stale 999.
+		if model.rc.streamCompletedWidth != firstWidth {
+			t.Errorf("streamCompletedWidth should be %d (contentWidth) after rebuild, got %d", firstWidth, model.rc.streamCompletedWidth)
+		}
+		t.Logf("Full rebuild confirmed: width reset from 999 → %d, all %d iterations re-rendered", model.rc.streamCompletedWidth, model.rc.streamCompletedCount)
+	})
+}
+
+// TestSyncProgressTodos_SameCountPreservesCache locks in the P3 fix:
+// when todos have the same length but content changes, rc.valid must stay true.
+// Previously syncProgressTodos set rc.valid=false on same-count changes,
+// triggering fullRebuild → O(all_messages) glamour on every todo status change.
+func TestSyncProgressTodos_SameCountPreservesCache(t *testing.T) {
+	model := initTestModel()
+	model.rc.valid = true
+
+	// Initial todos: 3 items, none done
+	model.todos = []protocol.TodoItem{
+		{ID: 1, Text: "task-a", Done: false},
+		{ID: 2, Text: "task-b", Done: false},
+		{ID: 3, Text: "task-c", Done: false},
+	}
+
+	// Same count, different content: item 2 marked done
+	payload := &protocol.ProgressEvent{
+		Todos: []protocol.TodoItem{
+			{ID: 1, Text: "task-a", Done: false},
+			{ID: 2, Text: "task-b", Done: true}, // changed
+			{ID: 3, Text: "task-c", Done: false},
+		},
+	}
+
+	model.syncProgressTodos(payload)
+
+	// O(1) invariant: rc.valid must remain true — no fullRebuild triggered
+	if !model.rc.valid {
+		t.Error("P3 regression: syncProgressTodos with same-count todos set rc.valid=false — fullRebuild would be triggered on next updateViewportContent")
+	}
+
+	// Verify todos were still updated correctly
+	if len(model.todos) != 3 {
+		t.Errorf("expected 3 todos, got %d", len(model.todos))
+	}
+	if !model.todos[1].Done {
+		t.Error("todo item 2 should be marked done")
+	}
+	if model.todos[0].Done {
+		t.Error("todo item 1 should still be not done")
+	}
+}
+
+// TestUpdateStreamingOnly_LiveOnlyRendersCurrentIteration verifies that the
+// live (per-tick) rendering path only uses m.progressState.current for the
+// dynamic part, not iterating over m.progressState.iterations for live content.
+// Completed iterations come from the streamCompletedLines cache (O(1) hit).
+func TestUpdateStreamingOnly_LiveOnlyRendersCurrentIteration(t *testing.T) {
+	model := initTestModel()
+	model.ticker.frame = 0
+	model.rc.valid = true
+
+	// Set up a streaming message
+	model.messages = append(model.messages, cliMessage{
+		role:      "assistant",
+		turnID:    1,
+		timestamp: time.Now(),
+		isPartial: true,
+	})
+	model.streamingMsgIdx = 0
+	model.typing = true
+
+	// Completed iterations (should land in streamCompletedLines cache)
+	model.progressState.iterations = []cliIterationSnapshot{
+		{Iteration: 1, Thinking: "completed-thinking-iter1"},
+		{Iteration: 2, Thinking: "completed-thinking-iter2"},
+	}
+
+	// Live iteration (should be rendered fresh every tick, NOT from cache)
+	model.progressState.current = &protocol.ProgressEvent{
+		Iteration:              3,
+		StreamContent:          "live-stream-content",
+		ReasoningStreamContent: "live-reasoning-stream",
+		ActiveTools: []protocol.ToolProgress{
+			{Name: "Shell", Label: "live-running-tool", Status: "running", Elapsed: 500},
+		},
+	}
+
+	// First call: populate cache
+	model.rc.streamCompletedWidth = -1 // force cache miss
+	model.updateStreamingOnly()
+
+	// Verify completed cache is populated
+	if model.rc.streamCompletedCount != 2 {
+		t.Fatalf("expected streamCompletedCount=2, got %d", model.rc.streamCompletedCount)
+	}
+
+	// Verify streamCompletedLines contain ONLY completed iteration content
+	completedText := strings.Join(model.rc.streamCompletedLines, "\n")
+	if !strings.Contains(completedText, "completed-thinking-iter1") {
+		t.Error("streamCompletedLines missing iter1 content")
+	}
+	if !strings.Contains(completedText, "completed-thinking-iter2") {
+		t.Error("streamCompletedLines missing iter2 content")
+	}
+	// Live content must NOT leak into completed cache
+	if strings.Contains(completedText, "live-stream-content") {
+		t.Error("P1 violation: live-stream-content leaked into streamCompletedLines cache")
+	}
+	if strings.Contains(completedText, "live-running-tool") {
+		t.Error("P1 violation: live tool leaked into streamCompletedLines cache")
+	}
+
+	// Second call with cache hit: verify completed cache is reused, not re-rendered
+	beforeLen := len(model.rc.streamCompletedLines)
+	model.updateStreamingOnly()
+	if model.rc.streamCompletedCount != 2 {
+		t.Error("completed count changed unexpectedly on cache hit")
+	}
+	if len(model.rc.streamCompletedLines) != beforeLen {
+		t.Error("streamCompletedLines were re-rendered on cache hit — should have been reused")
+	}
+}

--- a/channel/cli/cli_render_turn.go
+++ b/channel/cli/cli_render_turn.go
@@ -306,6 +306,23 @@ func needsTurnBlockSeparator(prev, next turnBlockKind) bool {
 	return next != turnBlockPulse && prev != next
 }
 
+// firstIterationBlockKind returns the kind of the first non-empty block
+// across a slice of iterations, scanning in forward order.
+func firstIterationBlockKind(iterations []cliIterationSnapshot) (turnBlockKind, bool) {
+	for _, iter := range iterations {
+		if iter.Reasoning != "" {
+			return turnBlockReasoning, true
+		}
+		if iter.Thinking != "" {
+			return turnBlockContent, true
+		}
+		if len(iter.Tools) > 0 {
+			return turnBlockTools, true
+		}
+	}
+	return 0, false
+}
+
 func (m *cliModel) liveIterationBlocks(p *protocol.ProgressEvent, width int, fallbackContent string) []turnBlock {
 	s := &m.styles
 	var blocks []turnBlock

--- a/channel/cli/cli_viewport.go
+++ b/channel/cli/cli_viewport.go
@@ -393,13 +393,10 @@ func (m *cliModel) updateStreamingOnly() {
 			prevKind, hasPrev := lastIterationBlockKind(m.progressState.iterations[:oldCount])
 			nextKind, hasNext := firstIterationBlockKind(newIters)
 			if hasPrev && hasNext && needsTurnBlockSeparator(prevKind, nextKind) {
-				// \n\n = different kinds, \n = same kind; splitting produces
-				// one blank guide line between old and new iteration groups.
-				if prevKind == nextKind || nextKind == turnBlockPulse {
-					bodyContent = "\n" + bodyContent
-				} else {
-					bodyContent = "\n\n" + bodyContent
-				}
+				// One blank guide line between different-kind iteration groups,
+				// matching what appendTurnBlock produces between blocks internally.
+				// (Same kind or pulse: no separator — old/new are separate arrays.)
+				bodyContent = "\n" + bodyContent
 			}
 			for _, l := range strings.Split(bodyContent, "\n") {
 				guideLine := guidePrefix + l

--- a/channel/cli/cli_viewport.go
+++ b/channel/cli/cli_viewport.go
@@ -365,7 +365,9 @@ func (m *cliModel) updateStreamingOnly() {
 
 	// --- Render completed iterations (cached) ---
 	// Uses renderTurnBody(iterations, nil, ...) to get the exact same output
-	// as the full render path. Only re-renders when iteration count changes.
+	// as the full render path. Incremental: when only the count increases and width
+	// is unchanged, renders only the NEW iterations and appends to cached lines.
+	// Full rebuild only on width change or count reset.
 	numCompleted := len(m.progressState.iterations)
 	var completedLines []string
 	completedMaxW := 0
@@ -374,8 +376,45 @@ func (m *cliModel) updateStreamingOnly() {
 		// Cache hit: reuse pre-rendered lines for completed iterations
 		completedLines = m.rc.streamCompletedLines
 		completedMaxW = m.rc.streamMaxW
+	} else if m.rc.streamCompletedCount > 0 && numCompleted > m.rc.streamCompletedCount && contentWidth == m.rc.streamCompletedWidth {
+		// Incremental path: render only NEW iterations since last cache update.
+		// This is O(1) per iteration instead of O(N) re-rendering all completed.
+		completedLines = m.rc.streamCompletedLines
+		completedMaxW = m.rc.streamMaxW
+
+		oldCount := m.rc.streamCompletedCount
+		newIters := m.progressState.iterations[oldCount:]
+		bodyContent := m.renderTurnBody(newIters, nil, contentWidth, "")
+		bodyContent = strings.TrimRight(bodyContent, "\n")
+		if bodyContent != "" {
+			// Handle separator between old last iteration and new first iteration.
+			// renderTurnBody on newIters alone resets the internal lastKind, so the
+			// first new block has no leading separator. We prepend the correct one.
+			prevKind, hasPrev := lastIterationBlockKind(m.progressState.iterations[:oldCount])
+			nextKind, hasNext := firstIterationBlockKind(newIters)
+			if hasPrev && hasNext && needsTurnBlockSeparator(prevKind, nextKind) {
+				// \n\n = different kinds, \n = same kind; splitting produces
+				// one blank guide line between old and new iteration groups.
+				if prevKind == nextKind || nextKind == turnBlockPulse {
+					bodyContent = "\n" + bodyContent
+				} else {
+					bodyContent = "\n\n" + bodyContent
+				}
+			}
+			for _, l := range strings.Split(bodyContent, "\n") {
+				guideLine := guidePrefix + l
+				if w := lipgloss.Width(guideLine); w > completedMaxW {
+					completedMaxW = w
+				}
+				completedLines = append(completedLines, guideLine)
+			}
+		}
+		// Update cache state (width unchanged)
+		m.rc.streamCompletedLines = completedLines
+		m.rc.streamCompletedCount = numCompleted
+		m.rc.streamMaxW = completedMaxW
 	} else {
-		// Cache miss: render completed iterations and cache the result
+		// Full rebuild: width changed, count went backwards, or first render.
 		if numCompleted > 0 {
 			bodyContent := m.renderTurnBody(m.progressState.iterations, nil, contentWidth, "")
 			bodyContent = strings.TrimRight(bodyContent, "\n")


### PR DESCRIPTION
## Summary

Fix P2 performance issue: `updateStreamingOnly` previously called `renderTurnBody` on **all** completed iterations every time the count changed — O(N) glamour re-renders per new iteration. This PR makes it incremental.

## Changes

### `cli_viewport.go` — three-branch completed iteration cache

| Path | Condition | Complexity |
|------|-----------|------------|
| Cache hit | count + width match | O(1) |
| **Incremental** (new) | count increased, same width | **O(1)** per new iteration |
| Full rebuild | width change / count reset | O(N) — only on resize |

The incremental path slices only new iterations (`iterations[oldCount:]`), renders them, handles the separator between old and new iteration groups, and appends to cached lines.

### `cli_render_turn.go` — helper

Added `firstIterationBlockKind()` — forward-scans iterations for the first non-empty block kind. Mirror of existing `lastIterationBlockKind()`.

### Tests

- **`TestUpdateStreamingOnly_IncrementalAppend`** — verifies old lines preserved verbatim, new markers only in appended portion, width change triggers full rebuild
- **`TestSyncProgressTodos_SameCountPreservesCache`** — locks in P3 fix: `rc.valid` stays true after same-count todo changes
- **`TestUpdateStreamingOnly_LiveOnlyRendersCurrentIteration`** — confirms live rendering only uses `m.progressState.current`

## Verification

```
go test ./channel/cli/ -count=1 → ok (all existing + new tests pass)
golangci-lint run ./... → 0 issues
```