### PR TITLE
refactor(config/tui): separate concerns, enable AI full config control

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -462,6 +463,130 @@ func (a *Agent) listLLMSubsFn(channel string) func(ch, senderID string) []tools.
 		}
 		return result
 	}
+}
+
+// getActiveSubFieldFn returns a function that reads a single field from the
+// active subscription. Used by config tool's get action for subscription-scoped keys.
+func (a *Agent) getActiveSubFieldFn(channel string) func(key string) (string, error) {
+	if a.llmFactory == nil {
+		return nil
+	}
+	svc := a.llmFactory.GetSubscriptionSvc()
+	if svc == nil {
+		return nil
+	}
+	return func(key string) (string, error) {
+		// Use cliSenderID for CLI channel
+		senderID := a.cliSenderID
+		if senderID == "" {
+			senderID = "cli_user"
+		}
+		sub, err := svc.GetDefault(senderID)
+		if err != nil || sub == nil {
+			return "", nil
+		}
+		return subFieldValue(sub, key), nil
+	}
+}
+
+// updateActiveSubFn returns a function that updates a single field in the active
+// subscription. Used by config tool's set action for subscription-scoped keys.
+func (a *Agent) updateActiveSubFn(channel string) func(key, value string) (string, error) {
+	if a.llmFactory == nil {
+		return nil
+	}
+	svc := a.llmFactory.GetSubscriptionSvc()
+	if svc == nil {
+		return nil
+	}
+	return func(key, value string) (string, error) {
+		senderID := a.cliSenderID
+		if senderID == "" {
+			senderID = "cli_user"
+		}
+		sub, err := svc.GetDefault(senderID)
+		if err != nil {
+			return "", fmt.Errorf("get default subscription: %w", err)
+		}
+		if sub == nil {
+			return "", fmt.Errorf("no active subscription found")
+		}
+		oldVal := subFieldValue(sub, key)
+		// Update the relevant field
+		if err := setSubFieldValue(sub, key, value); err != nil {
+			return "", err
+		}
+		if err := svc.Update(sub); err != nil {
+			return "", fmt.Errorf("update subscription: %w", err)
+		}
+		// Trigger switch model if model changed
+		if key == "llm_model" {
+			a.llmFactory.SwitchModel(senderID, value)
+		}
+		return oldVal, nil
+	}
+}
+
+// subFieldValue reads a single field from an LLMSubscription by config key.
+func subFieldValue(sub *sqlite.LLMSubscription, key string) string {
+	switch key {
+	case "llm_provider":
+		return sub.Provider
+	case "llm_api_key":
+		return sub.APIKey
+	case "llm_base_url":
+		return sub.BaseURL
+	case "llm_model":
+		return sub.Model
+	case "max_output_tokens":
+		if sub.MaxOutputTokens > 0 {
+			return strconv.Itoa(sub.MaxOutputTokens)
+		}
+		return "4096"
+	case "max_context_tokens":
+		if sub.MaxContext > 0 {
+			return strconv.Itoa(sub.MaxContext)
+		}
+		return ""
+	case "thinking_mode":
+		return sub.ThinkingMode
+	case "api_type":
+		return sub.APIType
+	}
+	return ""
+}
+
+// setSubFieldValue sets a single field on an LLMSubscription by config key.
+func setSubFieldValue(sub *sqlite.LLMSubscription, key, value string) error {
+	switch key {
+	case "llm_provider":
+		sub.Provider = strings.TrimSpace(value)
+	case "llm_api_key":
+		sub.APIKey = strings.TrimSpace(value)
+	case "llm_base_url":
+		sub.BaseURL = strings.TrimSpace(value)
+	case "llm_model":
+		sub.Model = strings.TrimSpace(value)
+	case "max_output_tokens":
+		n, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return fmt.Errorf("max_output_tokens must be an integer: %w", err)
+		}
+		sub.MaxOutputTokens = n
+	case "max_context_tokens":
+		n, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return fmt.Errorf("max_context_tokens must be an integer: %w", err)
+		}
+		sub.MaxContext = n
+	case "thinking_mode":
+		sub.ThinkingMode = value
+	case "api_type":
+		sub.APIType = value
+	default:
+		return fmt.Errorf("unknown subscription key: %s", key)
+	}
+	return nil
 }
 
 // LLMFactory returns the Agent's LLMFactory (for external injection of callbacks).

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -482,7 +482,10 @@ func (a *Agent) getActiveSubFieldFn(channel string) func(key string) (string, er
 			senderID = "cli_user"
 		}
 		sub, err := svc.GetDefault(senderID)
-		if err != nil || sub == nil {
+		if err != nil {
+			return "", fmt.Errorf("get default subscription: %w", err)
+		}
+		if sub == nil {
 			return "", nil
 		}
 		return subFieldValue(sub, key), nil
@@ -572,17 +575,23 @@ func setSubFieldValue(sub *sqlite.LLMSubscription, key, value string) error {
 		if err != nil {
 			return fmt.Errorf("max_output_tokens must be an integer: %w", err)
 		}
+		if n < 1 || n > 131072 {
+			return fmt.Errorf("max_output_tokens must be between 1 and 131072, got %d", n)
+		}
 		sub.MaxOutputTokens = n
 	case "max_context_tokens":
 		n, err := strconv.Atoi(strings.TrimSpace(value))
 		if err != nil {
 			return fmt.Errorf("max_context_tokens must be an integer: %w", err)
 		}
+		if n < 1 {
+			return fmt.Errorf("max_context_tokens must be positive, got %d", n)
+		}
 		sub.MaxContext = n
 	case "thinking_mode":
-		sub.ThinkingMode = value
+		sub.ThinkingMode = strings.TrimSpace(value)
 	case "api_type":
-		sub.APIType = value
+		sub.APIType = strings.TrimSpace(value)
 	default:
 		return fmt.Errorf("unknown subscription key: %s", key)
 	}

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -183,6 +183,17 @@ type RunConfig struct {
 	// ListLLMSubs returns all LLM subscriptions for the current user.
 	ListLLMSubs func(channel, senderID string) []tools.SubscriptionInfo
 
+	// UpdateActiveSubFn updates the active subscription for the current user.
+	// Used by config tool's set action for subscription-scoped keys (llm_model, llm_provider, etc.).
+	// Takes the target field key and new value, returns the old value.
+	// Implementation routes to subscription manager (user_llm_subscriptions DB).
+	UpdateActiveSubFn func(key, value string) (string, error)
+
+	// GetActiveSubFieldFn reads a single field from the active subscription.
+	// Used by config tool's get action for subscription-scoped keys.
+	// Returns the field value (empty string if not set or no active subscription).
+	GetActiveSubFieldFn func(key string) (string, error)
+
 	// OffloadStore Layer 1 offload store（nil = 不启用）
 	OffloadStore *OffloadStore
 
@@ -1138,31 +1149,49 @@ func buildToolContext(ctx context.Context, cfg *RunConfig) *tools.ToolContext {
 		hm := cfg.HookManager
 		tc.HooksReloader = hm.ReloadConfig
 	}
-	// Config read/write: from SettingsSvc (works everywhere: local + remote via RPC)
+	// Config read/write: routes to correct backend.
+	// Subscription-scoped keys (llm_model, llm_provider, etc.) use subscription manager.
+	// All other keys use user_settings DB (via SettingsSvc).
 	if cfg.SettingsSvc != nil {
 		svc := cfg.SettingsSvc
 		tc.ConfigGet = func(key string) (string, error) {
+			// Subscription-scoped keys: read from active subscription
+			if channel.IsSubscriptionScopedSettingKey(key) {
+				if cfg.GetActiveSubFieldFn != nil {
+					if v, err := cfg.GetActiveSubFieldFn(key); err == nil && v != "" {
+						return v, nil
+					}
+				}
+				return "", nil
+			}
+			// SourceConfigJSON / SourceLLMConfig: read from config.json
+			if def, ok := channel.GetSettingDef(key); ok {
+				if def.Source == channel.SourceConfigJSON || def.Source == channel.SourceLLMConfig {
+					return channel.ConfigValueBySource(key, def.Source), nil
+				}
+			}
+			// SourceUserDB: read from user_settings DB
 			vals, err := svc.GetSettings(cfg.Channel, cfg.OriginUserID)
 			if err == nil {
 				if v, ok := vals[key]; ok && v != "" {
 					return v, nil
 				}
 			}
-			// Fallback: try config.json for SourceConfigJSON / SourceLLMConfig keys.
-			// Also fallback for SourceUserDB keys that may have a default in config.json
-			// (e.g. tavily_api_key can be set globally in config.json as a default).
-			if def, ok := channel.GetSettingDef(key); ok {
-				if def.Source == channel.SourceConfigJSON || def.Source == channel.SourceLLMConfig {
-					return channel.ConfigValueBySource(key, def.Source), nil
-				}
-				// For SourceUserDB keys, try config.json fallback (global defaults)
-				if cfgVal := channel.ConfigValueBySource(key, channel.SourceConfigJSON); cfgVal != "" {
-					return cfgVal, nil
-				}
+			// Fallback: config.json for user-scoped keys with global defaults
+			if cfgVal := channel.ConfigValueBySource(key, channel.SourceConfigJSON); cfgVal != "" {
+				return cfgVal, nil
 			}
-			return "", fmt.Errorf("config: key %q not found", key)
+			return "", nil
 		}
 		tc.ConfigSet = func(key, value string) (string, error) {
+			// Subscription-scoped keys: write to active subscription via subscription manager
+			if channel.IsSubscriptionScopedSettingKey(key) {
+				if cfg.UpdateActiveSubFn == nil {
+					return "", fmt.Errorf("config: subscription manager not available")
+				}
+				return cfg.UpdateActiveSubFn(key, value)
+			}
+			// All other keys: write to user_settings DB
 			vals, err := svc.GetSettings(cfg.Channel, cfg.OriginUserID)
 			if err != nil {
 				return "", err

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -198,6 +198,10 @@ func (a *Agent) buildBaseRunConfig(
 		// Subscription listing — from LLMFactory
 		ListLLMSubs: a.listLLMSubsFn(channel),
 
+		// Subscription read/write — from LLMFactory (for config tool)
+		GetActiveSubFieldFn: a.getActiveSubFieldFn(channel),
+		UpdateActiveSubFn:   a.updateActiveSubFn(channel),
+
 		// LLM 并发限流回调（per-tenant）
 		LLMSemAcquire:             llmSemAcquire,
 		EnableConcurrentSubAgents: true,
@@ -905,6 +909,8 @@ func (a *Agent) buildToolExecutor(channel, chatID, senderID, senderName, sandbox
 	cfg.RemoteTUICtrlFn = a.buildRemoteTUICtrlFn(channel, chatID)
 	cfg.ChatRenameFn = a.renameSession
 	cfg.ListLLMSubs = a.listLLMSubsFn(channel)
+	cfg.GetActiveSubFieldFn = a.getActiveSubFieldFn(channel)
+	cfg.UpdateActiveSubFn = a.updateActiveSubFn(channel)
 
 	var sessionOnce sync.Once
 

--- a/channel/setting_keys.go
+++ b/channel/setting_keys.go
@@ -65,14 +65,14 @@ type SettingDef struct {
 // AllSettingDefs is the single registry of all known setting keys.
 // Every other scope map, runtime key list, and known-key check is derived from this.
 var AllSettingDefs = []SettingDef{
-	// ── LLM Subscription config (nested under "llm" in config.json) ──
-	{Key: "llm_provider", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermManual, AIDescription: "LLM provider (only openai and anthropic are supported)", ValidValues: "openai|anthropic", DefaultValue: "openai"},
-	{Key: "llm_api_key", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermManual, Sensitive: true, AIDescription: "API key for the LLM provider (masked)", ValidValues: "any valid API key starting with sk-"},
-	{Key: "llm_base_url", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermManual, AIDescription: "Custom API base URL (leave empty for default)", ValidValues: "empty or valid HTTPS URL"},
-	{Key: "llm_model", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermManual, AIDescription: "Model name to use (provider-specific)", ValidValues: "provider-specific model ID"},
-	{Key: "max_output_tokens", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermPersistent, AIDescription: "Maximum tokens per response", ValidValues: "1-131072", DefaultValue: "4096"},
-	{Key: "thinking_mode", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermPersistent, AIDescription: "Enable thinking/reasoning mode", ValidValues: "true|false", DefaultValue: "true"},
-	{Key: "api_type", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermPersistent, AIDescription: "OpenAI API endpoint type: chat_completions or responses", ValidValues: "chat_completions|responses", DefaultValue: "chat_completions"},
+	// ── LLM Subscription config (user_llm_subscriptions DB) ──
+	{Key: "llm_provider", Scope: ScopeSubscription, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "LLM provider (only openai and anthropic are supported)", ValidValues: "openai|anthropic", DefaultValue: "openai"},
+	{Key: "llm_api_key", Scope: ScopeSubscription, Source: SourceUserDB, Permission: PermManual, Sensitive: true, AIDescription: "API key for the LLM provider (masked)", ValidValues: "any valid API key starting with sk-"},
+	{Key: "llm_base_url", Scope: ScopeSubscription, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Custom API base URL (leave empty for default)", ValidValues: "empty or valid HTTPS URL"},
+	{Key: "llm_model", Scope: ScopeSubscription, Source: SourceUserDB, Permission: PermTransient, AIDescription: "Model name to use (provider-specific)", ValidValues: "provider-specific model ID"},
+	{Key: "max_output_tokens", Scope: ScopeSubscription, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Maximum tokens per response", ValidValues: "1-131072", DefaultValue: "4096"},
+	{Key: "thinking_mode", Scope: ScopeSubscription, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Enable thinking/reasoning mode", ValidValues: "true|false", DefaultValue: "true"},
+	{Key: "api_type", Scope: ScopeSubscription, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "OpenAI API endpoint type: chat_completions or responses", ValidValues: "chat_completions|responses", DefaultValue: "chat_completions"},
 
 	// ── User-scoped settings (user_settings DB) ──
 	{Key: "enable_stream", Scope: ScopeUser, Source: SourceUserDB, Permission: PermTransient, AIDescription: "Show LLM output token-by-token", ValidValues: "true|false", DefaultValue: "true"},
@@ -105,14 +105,14 @@ var AllSettingDefs = []SettingDef{
 	{Key: "context_mode", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Context handling: auto or manual", ValidValues: "auto|manual", DefaultValue: "auto"},
 	{Key: "max_iterations", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Max tool iterations per turn", ValidValues: "1-500", DefaultValue: "30"},
 	{Key: "max_concurrency", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Max parallel LLM calls", ValidValues: "1-100", DefaultValue: "5"},
-	{Key: "max_context_tokens", Scope: ScopeSubscription, Source: SourceLLMConfig, Runtime: true, Permission: PermPersistent, AIDescription: "Target context window size for compression (per subscription+model)", ValidValues: "any positive integer"},
+	{Key: "max_context_tokens", Scope: ScopeSubscription, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Target context window size for compression (per subscription+model)", ValidValues: "any positive integer"},
 	{Key: "enable_auto_compress", Scope: ScopeUser, Source: SourceUserDB, Runtime: true, Permission: PermPersistent, AIDescription: "Legacy alias for context_mode=auto (deprecated)", ValidValues: "true|false"},
 	{Key: "runner_server", Scope: ScopeUser, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Remote sandbox server address", ValidValues: "host:port or URL"},
 	{Key: "runner_token", Scope: ScopeUser, Source: SourceUserDB, Permission: PermManual, Sensitive: true, AIDescription: "Auth token for remote runner (masked)", ValidValues: "any valid token"},
 	{Key: "runner_workspace", Scope: ScopeUser, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Workspace dir on remote runner", ValidValues: "any valid path"},
-	{Key: "vanguard_model", Scope: ScopeUser, Source: SourceLLMConfig, Runtime: true, Permission: PermManual, AIDescription: "Model for vanguard tier", ValidValues: "any model name"},
-	{Key: "balance_model", Scope: ScopeUser, Source: SourceLLMConfig, Runtime: true, Permission: PermManual, AIDescription: "Model for balance tier", ValidValues: "any model name"},
-	{Key: "swift_model", Scope: ScopeUser, Source: SourceLLMConfig, Runtime: true, Permission: PermManual, AIDescription: "Model for swift tier", ValidValues: "any model name"},
+	{Key: "vanguard_model", Scope: ScopeUser, Source: SourceLLMConfig, Runtime: true, Permission: PermPersistent, AIDescription: "Model for vanguard tier", ValidValues: "any model name"},
+	{Key: "balance_model", Scope: ScopeUser, Source: SourceLLMConfig, Runtime: true, Permission: PermPersistent, AIDescription: "Model for balance tier", ValidValues: "any model name"},
+	{Key: "swift_model", Scope: ScopeUser, Source: SourceLLMConfig, Runtime: true, Permission: PermPersistent, AIDescription: "Model for swift tier", ValidValues: "any model name"},
 
 	// ── Action keys (UI triggers) ──
 	{Key: "subscription_manage", Scope: ScopeAction, AIDescription: "Open subscription management panel"},

--- a/tools/config_tool.go
+++ b/tools/config_tool.go
@@ -16,27 +16,25 @@ func (t *ConfigTool) Name() string { return "config" }
 
 func (t *ConfigTool) Description() string {
 	return "Read, list, and modify any xbot configuration setting. " +
+		"This is the PRIMARY tool for all configuration management — subscriptions, models, settings, plugins, and hooks. " +
 		"Use this whenever the user wants to see available configs, check a setting, or change a setting " +
-		"like max_iterations, context_mode, api_key, provider, theme (prefer tui_control for theme switching), " +
-		"sidebar_width (prefer tui_control), or any other config key. " +
+		"like max_iterations, context_mode, llm_model, llm_provider, or any other config key. " +
+		"For theme switching and TUI layout (sidebar_width, sidebar_position), use tui_control. " +
 		"Actions: list (see all configs with descriptions), get (key), set (key, value), " +
-		"subscriptions (list all LLM subscriptions). " +
-		"NOTE: To switch the active model, tell the user to run /set-model <model>. " +
-		"To configure a custom LLM provider, tell the user to run /set-llm directly. " +
+		"subscriptions (list all LLM subscriptions), reload_plugins, reload_hooks. " +
 		"To view token usage, tell the user to run /usage."
 }
 
 func (t *ConfigTool) Parameters() []llm.ToolParam {
 	return []llm.ToolParam{
-		{Name: "action", Type: "string", Description: "get or set", Required: true},
-		{Name: "key", Type: "string", Description: "Configuration key (e.g. theme, max_iterations, context_mode)", Required: true},
+		{Name: "action", Type: "string", Description: "Action: list, get, set, subscriptions, reload_plugins, reload_hooks", Required: true},
+		{Name: "key", Type: "string", Description: "Configuration key (e.g. theme, max_iterations, context_mode, llm_model)", Required: true},
 		{Name: "value", Type: "string", Description: "New value (for set action)", Required: false},
 	}
 }
 
 // isConfigKeyAllowed checks whether a key can be accessed via the config tool.
-// Subscription-scoped (LLM keys) and action-scoped keys are excluded — they have
-// dedicated management paths (/set-llm, subscription management, palette).
+// Action-scoped keys are excluded — they are UI triggers, not config values.
 func isConfigKeyAllowed(ctx *ToolContext, key string) bool {
 	if ctx.ConfigList == nil {
 		return true // can't check, allow (defensive)
@@ -141,7 +139,25 @@ func (t *ConfigTool) Execute(ctx *ToolContext, raw string) (*ToolResult, error) 
 		}
 		return NewResult(fmt.Sprintf("Updated %s from %s to %s", params.Key, prev, params.Value)), nil
 
+	case "reload_plugins":
+		if ctx.PluginReloader == nil {
+			return nil, fmt.Errorf("config: plugin reload is not available (plugin system not enabled)")
+		}
+		if err := ctx.PluginReloader(); err != nil {
+			return nil, fmt.Errorf("config: reload_plugins failed: %w", err)
+		}
+		return NewResult("All plugins reloaded successfully"), nil
+
+	case "reload_hooks":
+		if ctx.HooksReloader == nil {
+			return nil, fmt.Errorf("config: hooks reload is not available")
+		}
+		if err := ctx.HooksReloader(); err != nil {
+			return nil, fmt.Errorf("config: reload_hooks failed: %w", err)
+		}
+		return NewResult("Hooks configuration reloaded successfully"), nil
+
 	default:
-		return nil, fmt.Errorf("config: unknown action: %s (valid: list, get, set, subscriptions)", params.Action)
+		return nil, fmt.Errorf("config: unknown action: %s (valid: list, get, set, subscriptions, reload_plugins, reload_hooks)", params.Action)
 	}
 }

--- a/tools/interface.go
+++ b/tools/interface.go
@@ -113,6 +113,11 @@ type ToolContext struct {
 	ConfigGet func(key string) (string, error)
 
 	// ConfigSet writes a configuration value and returns the previous value (for config tool).
+	// The implementation routes to the correct backend based on SettingDef.Source:
+	//   SourceUserDB        → user_settings DB (via SettingsSvc)
+	//   SourceConfigJSON    → config.json (via SaveToFile)
+	// Subscription-scoped keys (llm_model, max_output_tokens, etc.) are written via
+	// the subscription manager to the user_llm_subscriptions DB.
 	ConfigSet func(key, value string) (string, error)
 
 	// ChatRename renames the current chat session (for config tool's session_name key).

--- a/tools/tui_control.go
+++ b/tools/tui_control.go
@@ -31,17 +31,15 @@ func (t *TuiControlTool) Description() string {
 		"To create a custom theme, use FileCreate to write a JSON file to ~/.xbot/themes/<name>.json then switch via set_theme. Activate the ai-config skill for the JSON format template. " +
 		"Use send_slash ONLY for pure-TUI operations (/palette, /settings, /rewind, /tasks, /clear, etc.). " +
 		"DO NOT use send_slash for /usage, /set-llm, /set-model, /models, /new, /compress, /context — these are agent-level commands handled natively. " +
+		"For all configuration management (LLM models, subscriptions, settings, plugins, hooks), use the config tool instead. " +
 		"Actions: switch_session(chat_id), close_session(chat_id, params.confirm=true), " +
-		"set_layout(key=\"sidebar_width\"|..., value), set_theme(theme_name), send_slash(command=\"/palette\"), " +
-		"reload_plugins(), reload_hooks(). " +
-		"Use reload_plugins after creating or modifying plugin files to hot-reload all plugins. " +
-		"Use reload_hooks after modifying hooks.json to reload hook configuration without restart. " +
+		"set_layout(key=\"sidebar_width\"|..., value), set_theme(theme_name), send_slash(command=\"/palette\"). " +
 		"To find available sessions to switch to, look at the sessions listed in the sidebar."
 }
 
 func (t *TuiControlTool) Parameters() []llm.ToolParam {
 	return []llm.ToolParam{
-		{Name: "action", Type: "string", Description: "Action: switch_session, close_session, set_layout, set_theme, send_slash, reload_plugins, reload_hooks", Required: true},
+		{Name: "action", Type: "string", Description: "Action: switch_session, close_session, set_layout, set_theme, send_slash. For config changes use config tool.", Required: true},
 		{Name: "chat_id", Type: "string", Description: "Target session chatID (for switch/close)", Required: false},
 		{Name: "key", Type: "string", Description: "Layout key: sidebar_width, sidebar_enabled, etc.", Required: false},
 		{Name: "value", Type: "string", Description: "New value for layout key or theme name", Required: false},
@@ -133,24 +131,6 @@ func (t *TuiControlTool) Execute(ctx *ToolContext, raw string) (*ToolResult, err
 		}
 		_ = res
 		return NewResult(fmt.Sprintf("Slash command sent: %s", cmd)), nil
-
-	case "reload_plugins":
-		if ctx.PluginReloader == nil {
-			return nil, fmt.Errorf("tui_control: plugin reload is not available (plugin system not enabled)")
-		}
-		if err := ctx.PluginReloader(); err != nil {
-			return nil, fmt.Errorf("tui_control: reload_plugins failed: %w", err)
-		}
-		return NewResult("All plugins reloaded successfully"), nil
-
-	case "reload_hooks":
-		if ctx.HooksReloader == nil {
-			return nil, fmt.Errorf("tui_control: hooks reload is not available")
-		}
-		if err := ctx.HooksReloader(); err != nil {
-			return nil, fmt.Errorf("tui_control: reload_hooks failed: %w", err)
-		}
-		return NewResult("Hooks configuration reloaded successfully"), nil
 
 	default:
 		if params.Action == "new_session" || params.Action == "create_session" {


### PR DESCRIPTION
## Summary

This PR refactors the config and tui_control tools with clear boundaries: config handles ALL configuration (subscriptions, models, settings, plugins, hooks), while tui_control is pure TUI (sessions, sidebar, theme).

## Key Changes

### config tool
- Route subscription-scoped writes to subscription manager (DB), fixing previously-broken set path
- Add reload_plugins and reload_hooks actions (moved from tui_control)
- Remove /set-model guide — AI can now set models directly: config set llm_model gpt-4
- Update description to reflect new boundaries

### tui_control tool  
- Remove reload_plugins and reload_hooks (moved to config)
- Update description: For all config management, use config tool
- Keep: switch_session, close_session, set_layout, set_theme, send_slash

### AllSettingDefs
- LLM subscription keys: SourceLLMConfig→SourceUserDB, PermManual→PermPersistent/Transient
- Tier model keys: PermManual→PermPersistent

### Engine + Agent
- Add GetActiveSubFieldFn/UpdateActiveSubFn callbacks for subscription read/write
- ConfigGet reads subscription-scoped keys from active subscription
- ConfigSet writes subscription-scoped keys to subscription manager
- Inject callbacks in both main and SubAgent config paths

## Testing
Pre-commit: gofmt ✅ golangci-lint (0 issues) ✅ go build ✅ go test (all packages) ✅