### PR TITLE
fix(cli): prevent cross-iteration reasoning merge causing double render

### DIFF
--- a/channel/cli/cli.go
+++ b/channel/cli/cli.go
@@ -550,8 +550,13 @@ func (c *CLIChannel) SendProgress(chatID string, payload *protocol.ProgressEvent
 			// snapshotted by snapshotIterationChange). Merging it
 			// into the new payload causes reasoning to render twice —
 			// once in completed iterations, once in live.
-			sameIter := payload.Iteration == old.Iteration || payload.Iteration == 0
-			if sameIter {
+			//
+			// payload.Iteration==0 branch: payload's iteration is
+			// unknown (stream-only or edge-case structured event with
+			// Iteration==0). Conservatively allow merge — the stream
+			// content is presumed to belong to the same logical turn.
+			sameOrUnknownIter := payload.Iteration == old.Iteration || payload.Iteration == 0
+			if sameOrUnknownIter {
 				if payload.StreamContent == "" && old.StreamContent != "" {
 					payload.StreamContent = old.StreamContent
 				}
@@ -560,7 +565,7 @@ func (c *CLIChannel) SendProgress(chatID string, payload *protocol.ProgressEvent
 				}
 			}
 			// StreamingTools follow the same rule.
-			if sameIter && len(payload.StreamingTools) == 0 && len(old.StreamingTools) > 0 {
+			if sameOrUnknownIter && len(payload.StreamingTools) == 0 && len(old.StreamingTools) > 0 {
 				payload.StreamingTools = old.StreamingTools
 			}
 			// Merge TokenUsage and CWD regardless of old event type —

--- a/channel/cli/cli.go
+++ b/channel/cli/cli.go
@@ -541,13 +541,26 @@ func (c *CLIChannel) SendProgress(chatID string, payload *protocol.ProgressEvent
 			// eviction; Phase=="" && Iteration==0) or structured
 			// (chained eviction where structured accumulated stream
 			// fields from prior merges). Both need the same merge.
-			if payload.StreamContent == "" && old.StreamContent != "" {
-				payload.StreamContent = old.StreamContent
+			//
+			// Guard: only merge stream fields when old and payload
+			// belong to the same iteration. Stream-only events have
+			// Iteration==0 (unknown). If payload has a structured
+			// iteration (>0) and old is stream-only, the old content
+			// likely belongs to the previous iteration (already
+			// snapshotted by snapshotIterationChange). Merging it
+			// into the new payload causes reasoning to render twice —
+			// once in completed iterations, once in live.
+			sameIter := payload.Iteration == old.Iteration || payload.Iteration == 0
+			if sameIter {
+				if payload.StreamContent == "" && old.StreamContent != "" {
+					payload.StreamContent = old.StreamContent
+				}
+				if payload.ReasoningStreamContent == "" && old.ReasoningStreamContent != "" {
+					payload.ReasoningStreamContent = old.ReasoningStreamContent
+				}
 			}
-			if payload.ReasoningStreamContent == "" && old.ReasoningStreamContent != "" {
-				payload.ReasoningStreamContent = old.ReasoningStreamContent
-			}
-			if len(payload.StreamingTools) == 0 && len(old.StreamingTools) > 0 {
+			// StreamingTools follow the same rule.
+			if sameIter && len(payload.StreamingTools) == 0 && len(old.StreamingTools) > 0 {
 				payload.StreamingTools = old.StreamingTools
 			}
 			// Merge TokenUsage and CWD regardless of old event type —


### PR DESCRIPTION
## 修复

`progressPublishLoop` 在结构化事件驱逐旧 stream-only 事件时，无条件将 `old.ReasoningStreamContent` 合并到新 payload。当迭代 N 的流式 reasoning 被注入迭代 N+1 的结构化事件：

- `snapshotIterationChange` 将其捕获到 `progressState.iterations` → 已完成区渲染
- `progressState.current.ReasoningStreamContent` 也带着 → 实时区渲染
- `updateStreamingOnly` 两处都渲染 → **双重显示**

### 修复

添加 `sameIter` 守卫，仅在 `payload.Iteration == old.Iteration || payload.Iteration == 0` 时合并 stream 字段。

### 跨迭代安全性排查

所有 reasoning 跨迭代泄露路径已全部排查确认安全：

| 路径 | 守卫 | 结论 |
|---|---|---|
| `progressPublishLoop` merge | **新增 sameIter** | 🔴 已修复 |
| `carryForwardProgressState` | sameIter | ✅ |
| `snapshotIterationChange` | 仅迭代变化触发 | ✅ |
| `handleProgressDone` | pendingToolSummary 同 turn | ✅ |
| `handleAgentMessage` | 同 turn 来源 | ✅ |
| `reasoningByIter` | endAgentTurn 清空 | ✅ |
| `progressState.iterations` | endAgentTurn 清空 | ✅ |