### PR TITLE
feat: plugin extension points + 7 fun plugins + fix /plugin reload-all deadlock

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1156,6 +1156,17 @@ func New(cfg Config) (*Agent, error) {
 		})
 		// Re-wire commands after every plugin reload
 		agent.pluginMgr.OnReload(func() {
+			// Remove old plugin commands before re-registering to avoid duplicates
+			agent.commands.mu.Lock()
+			filtered := agent.commands.commands[:0]
+			for _, cmd := range agent.commands.commands {
+				if _, ok := cmd.(*pluginCmdAdapter); !ok {
+					filtered = append(filtered, cmd)
+				}
+			}
+			agent.commands.commands = filtered
+			agent.commands.mu.Unlock()
+
 			plugin.WirePluginCommands(agent.pluginMgr, func(name, description string, handler plugin.PluginCommandHandler, pctx plugin.PluginContext) {
 				agent.commands.Register(&pluginCmdAdapter{
 					name:        name,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1145,6 +1145,43 @@ func New(cfg Config) (*Agent, error) {
 		}
 		// Wire channel providers registered by plugins to ChannelProviderRegistry.
 		plugin.WireChannelProviders(agent.pluginMgr)
+		// Wire plugin commands into the agent command registry.
+		plugin.WirePluginCommands(agent.pluginMgr, func(name, description string, handler plugin.PluginCommandHandler, pctx plugin.PluginContext) {
+			agent.commands.Register(&pluginCmdAdapter{
+				name:        name,
+				description: description,
+				handler:     handler,
+				pctx:        pctx,
+			})
+		})
+		// Re-wire commands after every plugin reload
+		agent.pluginMgr.OnReload(func() {
+			plugin.WirePluginCommands(agent.pluginMgr, func(name, description string, handler plugin.PluginCommandHandler, pctx plugin.PluginContext) {
+				agent.commands.Register(&pluginCmdAdapter{
+					name:        name,
+					description: description,
+					handler:     handler,
+					pctx:        pctx,
+				})
+			})
+			plugin.WirePluginCrons(agent.pluginMgr, agent.cronSvc)
+			plugin.WirePluginThemes(agent.pluginMgr, func(id string, data []byte) error {
+				themesDir := filepath.Join(agent.xbotHome, "themes")
+				os.MkdirAll(themesDir, 0755)
+				return os.WriteFile(filepath.Join(themesDir, id+".json"), data, 0644)
+			})
+		})
+		// Wire plugin crons into the cron service.
+		plugin.WirePluginCrons(agent.pluginMgr, agent.cronSvc)
+		// Wire plugin themes into the local themes directory.
+		plugin.WirePluginThemes(agent.pluginMgr, func(id string, data []byte) error {
+			themesDir := filepath.Join(agent.xbotHome, "themes")
+			if err := os.MkdirAll(themesDir, 0755); err != nil {
+				return err
+			}
+			themePath := filepath.Join(themesDir, id+".json")
+			return os.WriteFile(themePath, data, 0644)
+		})
 		// Register the hook bridge as a builtin hook handler
 		agent.hookManager.RegisterBuiltin(hooks.PluginBridgeCallback(hookBridge))
 		// Wire enricher registry into the message pipeline

--- a/agent/command.go
+++ b/agent/command.go
@@ -83,5 +83,7 @@ func (r *CommandRegistry) IsCommand(content string) bool {
 func (r *CommandRegistry) Commands() []Command {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.commands
+	result := make([]Command, len(r.commands))
+	copy(result, r.commands)
+	return result
 }

--- a/agent/command.go
+++ b/agent/command.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"xbot/bus"
 	"xbot/channel"
@@ -38,7 +39,9 @@ type Command interface {
 }
 
 // CommandRegistry holds registered commands and provides lookup.
+// Thread-safe: Register and Match can be called concurrently.
 type CommandRegistry struct {
+	mu       sync.RWMutex
 	commands []Command
 }
 
@@ -47,18 +50,22 @@ func NewCommandRegistry() *CommandRegistry {
 	return &CommandRegistry{}
 }
 
-// Register adds a command to the registry.
+// Register adds a command to the registry. Safe for concurrent use.
 func (r *CommandRegistry) Register(cmd Command) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.commands = append(r.commands, cmd)
 }
 
 // Match finds the first command that matches the given message content.
-// Returns nil if no command matches.
+// Returns nil if no command matches. Safe for concurrent use.
 func (r *CommandRegistry) Match(content string) Command {
 	trimmed := strings.TrimSpace(content)
 	if trimmed == "" {
 		return nil
 	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	for _, cmd := range r.commands {
 		if cmd.Match(trimmed) {
 			return cmd
@@ -74,5 +81,7 @@ func (r *CommandRegistry) IsCommand(content string) bool {
 
 // Commands returns all registered commands (for /help generation, etc.).
 func (r *CommandRegistry) Commands() []Command {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.commands
 }

--- a/agent/command_builtin.go
+++ b/agent/command_builtin.go
@@ -10,6 +10,7 @@ import (
 	"xbot/bus"
 	"xbot/channel"
 	"xbot/channel/feishu"
+	"xbot/plugin"
 	"xbot/version"
 )
 
@@ -48,6 +49,34 @@ func (c *versionCmd) Execute(_ context.Context, _ *Agent, msg bus.InboundMessage
 		Channel: msg.Channel,
 		ChatID:  msg.ChatID,
 		Content: info,
+	}, nil
+}
+
+// --- /plugin reload-all (agent-level command for remote CLI) ---
+
+type pluginReloadAllCmd struct{}
+
+func (c *pluginReloadAllCmd) Name() string      { return "/plugin reload-all" }
+func (c *pluginReloadAllCmd) Aliases() []string { return nil }
+func (c *pluginReloadAllCmd) Concurrent() bool  { return true } // doesn't block message queue
+func (c *pluginReloadAllCmd) Match(s string) bool {
+	return strings.TrimSpace(s) == "/plugin reload-all"
+}
+func (c *pluginReloadAllCmd) Execute(ctx context.Context, a *Agent, msg bus.InboundMessage) (*channel.OutboundMsg, error) {
+	if a.pluginMgr == nil {
+		return nil, fmt.Errorf("plugin system not available")
+	}
+	// Run reload in background — ReloadAll can take a while and must not
+	// block the command handler (which blocks message processing).
+	go func() {
+		if err := a.pluginMgr.ReloadAll(context.Background()); err != nil {
+			_ = err // reload errors handled by plugin logging
+		}
+	}()
+	return &channel.OutboundMsg{
+		Channel: msg.Channel,
+		ChatID:  msg.ChatID,
+		Content: "🔄 Plugin reload started — widgets will refresh when complete",
 	}, nil
 }
 
@@ -637,4 +666,45 @@ func registerBuiltinCommands(r *CommandRegistry) {
 	r.Register(&myCmd{})
 	r.Register(&settingsCmd{})
 	r.Register(&menuCmd{})
+	r.Register(&pluginReloadAllCmd{})
+}
+
+// ---------------------------------------------------------------------------
+// Plugin Command Adapter — bridges plugin.PluginCommandHandler → agent.Command
+// ---------------------------------------------------------------------------
+
+// pluginCmdAdapter wraps a plugin command handler as an agent.Command.
+// It avoids circular imports by living in the agent package, receiving the
+// handler and PluginContext from plugin.WirePluginCommands.
+type pluginCmdAdapter struct {
+	name        string
+	description string
+	handler     plugin.PluginCommandHandler
+	pctx        plugin.PluginContext
+}
+
+func (a *pluginCmdAdapter) Name() string      { return a.name }
+func (a *pluginCmdAdapter) Aliases() []string { return nil }
+func (a *pluginCmdAdapter) Concurrent() bool  { return false }
+
+func (a *pluginCmdAdapter) Match(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	return strings.HasPrefix(trimmed, a.name+" ") || trimmed == a.name
+}
+
+func (a *pluginCmdAdapter) Execute(ctx context.Context, ag *Agent, msg bus.InboundMessage) (*channel.OutboundMsg, error) {
+	trimmed := strings.TrimSpace(msg.Content)
+	args := ""
+	if strings.HasPrefix(trimmed, a.name+" ") {
+		args = strings.TrimSpace(strings.TrimPrefix(trimmed, a.name+" "))
+	}
+	result, err := a.handler(ctx, args, a.pctx)
+	if err != nil {
+		return nil, err
+	}
+	return &channel.OutboundMsg{
+		Channel: msg.Channel,
+		ChatID:  msg.ChatID,
+		Content: result,
+	}, nil
 }

--- a/agent/command_builtin.go
+++ b/agent/command_builtin.go
@@ -10,6 +10,7 @@ import (
 	"xbot/bus"
 	"xbot/channel"
 	"xbot/channel/feishu"
+	log "xbot/logger"
 	"xbot/plugin"
 	"xbot/version"
 )
@@ -70,7 +71,7 @@ func (c *pluginReloadAllCmd) Execute(ctx context.Context, a *Agent, msg bus.Inbo
 	// block the command handler (which blocks message processing).
 	go func() {
 		if err := a.pluginMgr.ReloadAll(context.Background()); err != nil {
-			_ = err // reload errors handled by plugin logging
+			log.WithError(err).Error("Plugin reload-all failed")
 		}
 	}()
 	return &channel.OutboundMsg{

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -87,8 +87,8 @@ func TestCommandRegistry_Commands(t *testing.T) {
 	registerBuiltinCommands(r)
 
 	cmds := r.Commands()
-	if len(cmds) != 22 {
-		t.Errorf("Commands() returned %d commands, want 22", len(cmds))
+	if len(cmds) != 23 {
+		t.Errorf("Commands() returned %d commands, want 23", len(cmds))
 	}
 
 	// Verify all expected commands are registered

--- a/channel/cli/cli.go
+++ b/channel/cli/cli.go
@@ -249,6 +249,10 @@ func (c *CLIChannel) Start() error {
 		c.approvalState.SetHandler(NewCLIApprovalHandler(c.program))
 	}
 
+	// Wire plugin event bus subscriptions — overlay show/hide, notifications, sound.
+	// This must happen after applyPending() wires pluginMgrFn into the model.
+	c.model.wirePluginEventBus(c.program)
+
 	// Ctrl+Z 紧急退出：双保险
 	// 1) Key event handler (cli_update.go): raw mode 下终端可能直接传 0x1A 字节
 	// 2) SIGTSTP 信号兜底: 某些终端 emulator 在 raw mode 下仍发信号

--- a/channel/cli/cli_model.go
+++ b/channel/cli/cli_model.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"time"
 	ch "xbot/channel"
 	"xbot/internal/textarea"
@@ -160,8 +162,9 @@ type cliModel struct {
 	lastThinking       string                  // 最后一次迭代的 thinking_content，在 progress 清除前捕获
 
 	// --- §8 Tab 补全 ---
-	completions []string // 当前补全候选项
-	compIdx     int      // 当前选中的补全索引
+	completions    []string // 当前补全候选项
+	compIdx        int      // 当前选中的补全索引
+	pluginCmdNames []string // 插件注册的命令名（/xxx 格式），合并到 Tab 补全
 
 	// --- §8b @ 文件引用补全 ---
 	fileCompletions []string // @ 文件路径补全候选项
@@ -245,6 +248,12 @@ type cliModel struct {
 	mouseZones mouseZoneBuilder // zone tracker for mouse hit testing (rebuilt each View())
 
 	easterEggState easterEggState
+
+	pluginOverlay struct {
+		active   bool
+		id       string
+		provider plugin.OverlayProvider
+	}
 
 	searchState searchState
 
@@ -826,4 +835,145 @@ type progressState struct {
 	rwCjkSkip             bool
 	twCjkSkip             bool
 	streamReasoningByIter map[int]string // per-iteration stream-only reasoning, captured at arrival time
+}
+
+// --- Plugin Overlay ---
+
+// refreshPluginCmdNames lazily populates plugin command names for Tab completion
+// from the palette contributor. Called on every slash-input keypress; syncs from
+// channel.PaletteContributor if needed and caches results.
+func (m *cliModel) refreshPluginCmdNames() {
+	// Sync palette contributor from channel if not yet set
+	if m.paletteContributor == nil && m.channel != nil && m.channel.PaletteContributor != nil {
+		m.paletteContributor = m.channel.PaletteContributor
+	}
+	if m.paletteContributor == nil {
+		return
+	}
+	// Already populated — only refresh if palette was rebuilt
+	if len(m.pluginCmdNames) > 0 {
+		return
+	}
+	for _, ext := range m.paletteContributor() {
+		if strings.HasPrefix(ext.Content, "/") {
+			name := strings.SplitN(ext.Content, " ", 2)[0]
+			found := false
+			for _, existing := range m.pluginCmdNames {
+				if existing == name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				m.pluginCmdNames = append(m.pluginCmdNames, name)
+			}
+		}
+	}
+}
+
+// showPluginOverlay activates a full-screen overlay provided by a plugin.
+func (m *cliModel) showPluginOverlay(id string, provider plugin.OverlayProvider) {
+	m.pluginOverlay.active = true
+	m.pluginOverlay.id = id
+	m.pluginOverlay.provider = provider
+}
+
+// hidePluginOverlay deactivates the current plugin overlay.
+func (m *cliModel) hidePluginOverlay() {
+	m.pluginOverlay.active = false
+	m.pluginOverlay.provider = nil
+}
+
+// --- Plugin Event Bus Messages ---
+
+// cliPluginOverlayShowMsg triggers display of a plugin overlay.
+type cliPluginOverlayShowMsg struct {
+	pluginID  string
+	overlayID string
+}
+
+// cliPluginOverlayHideMsg triggers hiding of the current plugin overlay.
+type cliPluginOverlayHideMsg struct {
+	pluginID string
+}
+
+// cliPluginNotifyMsg carries a notification from a plugin to be shown as a toast.
+type cliPluginNotifyMsg struct {
+	pluginID string
+	level    string
+	title    string
+	message  string
+}
+
+// cliPluginSoundMsg carries a sound playback request from a plugin.
+type cliPluginSoundMsg struct {
+	pluginID string
+	sound    string
+}
+
+// wirePluginEventBus subscribes to plugin event bus topics and routes events
+// into the Bubble Tea event loop via program.Send(). This is called once
+// during CLI channel startup after the model and program are both available.
+func (m *cliModel) wirePluginEventBus(program *tea.Program) {
+	if m.pluginMgrFn == nil {
+		return
+	}
+	mgr := m.pluginMgrFn()
+	bus := mgr.Bus()
+	if bus == nil {
+		return
+	}
+
+	// plugin:overlay:show — display a plugin's full-screen overlay
+	_ = bus.Subscribe("plugin:overlay:show", func(ctx context.Context, topic string, data any) error {
+		d, ok := data.(map[string]string)
+		if !ok {
+			return nil
+		}
+		program.Send(cliPluginOverlayShowMsg{
+			pluginID:  d["plugin_id"],
+			overlayID: d["overlay_id"],
+		})
+		return nil
+	})
+
+	// plugin:overlay:hide — dismiss the current plugin overlay
+	_ = bus.Subscribe("plugin:overlay:hide", func(ctx context.Context, topic string, data any) error {
+		d, ok := data.(map[string]string)
+		if !ok {
+			return nil
+		}
+		program.Send(cliPluginOverlayHideMsg{
+			pluginID: d["plugin_id"],
+		})
+		return nil
+	})
+
+	// plugin:notify — show a plugin notification as a toast
+	_ = bus.Subscribe("plugin:notify", func(ctx context.Context, topic string, data any) error {
+		d, ok := data.(map[string]string)
+		if !ok {
+			return nil
+		}
+		program.Send(cliPluginNotifyMsg{
+			pluginID: d["plugin_id"],
+			level:    d["level"],
+			title:    d["title"],
+			message:  d["message"],
+		})
+		return nil
+	})
+
+	// plugin:sound:play — play a sound effect
+	_ = bus.Subscribe("plugin:sound:play", func(ctx context.Context, topic string, data any) error {
+		d, ok := data.(map[string]string)
+		if !ok {
+			return nil
+		}
+		program.Send(cliPluginSoundMsg{
+			pluginID: d["plugin_id"],
+			sound:    d["sound"],
+		})
+		return nil
+	})
 }

--- a/channel/cli/cli_model.go
+++ b/channel/cli/cli_model.go
@@ -7,6 +7,7 @@ import (
 	"time"
 	ch "xbot/channel"
 	"xbot/internal/textarea"
+	log "xbot/logger"
 	"xbot/plugin"
 	"xbot/protocol"
 	"xbot/tools"
@@ -924,8 +925,15 @@ func (m *cliModel) wirePluginEventBus(program *tea.Program) {
 		return
 	}
 
+	// Helper that logs subscription failures instead of silently dropping them.
+	sub := func(topic string, handler plugin.PluginEventHandler) {
+		if err := bus.Subscribe(topic, handler); err != nil {
+			log.WithError(err).WithField("topic", topic).Warn("plugin event subscription failed")
+		}
+	}
+
 	// plugin:overlay:show — display a plugin's full-screen overlay
-	_ = bus.Subscribe("plugin:overlay:show", func(ctx context.Context, topic string, data any) error {
+	sub("plugin:overlay:show", func(ctx context.Context, topic string, data any) error {
 		d, ok := data.(map[string]string)
 		if !ok {
 			return nil
@@ -938,7 +946,7 @@ func (m *cliModel) wirePluginEventBus(program *tea.Program) {
 	})
 
 	// plugin:overlay:hide — dismiss the current plugin overlay
-	_ = bus.Subscribe("plugin:overlay:hide", func(ctx context.Context, topic string, data any) error {
+	sub("plugin:overlay:hide", func(ctx context.Context, topic string, data any) error {
 		d, ok := data.(map[string]string)
 		if !ok {
 			return nil
@@ -950,7 +958,7 @@ func (m *cliModel) wirePluginEventBus(program *tea.Program) {
 	})
 
 	// plugin:notify — show a plugin notification as a toast
-	_ = bus.Subscribe("plugin:notify", func(ctx context.Context, topic string, data any) error {
+	sub("plugin:notify", func(ctx context.Context, topic string, data any) error {
 		d, ok := data.(map[string]string)
 		if !ok {
 			return nil
@@ -965,7 +973,7 @@ func (m *cliModel) wirePluginEventBus(program *tea.Program) {
 	})
 
 	// plugin:sound:play — play a sound effect
-	_ = bus.Subscribe("plugin:sound:play", func(ctx context.Context, topic string, data any) error {
+	sub("plugin:sound:play", func(ctx context.Context, topic string, data any) error {
 		d, ok := data.(map[string]string)
 		if !ok {
 			return nil

--- a/channel/cli/cli_palette.go
+++ b/channel/cli/cli_palette.go
@@ -186,6 +186,7 @@ func (m *cliModel) buildPaletteCommands() []paletteCommand {
 
 	// --- External contributions (plugins, skills, agents, custom commands) ---
 	if m.paletteContributor != nil {
+		m.pluginCmdNames = nil // reset
 		for _, ext := range m.paletteContributor() {
 			kind := paletteActionInsertText
 			if ext.Send {
@@ -203,6 +204,21 @@ func (m *cliModel) buildPaletteCommands() []paletteCommand {
 				ActionKind:  kind,
 				ActionData:  ext.Content,
 			})
+			// Collect slash command names for Tab completion
+			if strings.HasPrefix(ext.Content, "/") {
+				name := strings.SplitN(ext.Content, " ", 2)[0]
+				// Avoid duplicates
+				found := false
+				for _, existing := range m.pluginCmdNames {
+					if existing == name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					m.pluginCmdNames = append(m.pluginCmdNames, name)
+				}
+			}
 		}
 	}
 

--- a/channel/cli/cli_plugin_cmd.go
+++ b/channel/cli/cli_plugin_cmd.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"path/filepath"
+	ch "xbot/channel"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -169,7 +170,7 @@ func (m *cliModel) handlePluginReload(pluginID string) tea.Cmd {
 
 func (m *cliModel) handlePluginReloadAll() tea.Cmd {
 	if m.pluginMgrFn == nil {
-		if m.remotePluginCache != nil {
+		if m.remotePluginCache != nil || m.remoteMode {
 			if m.pluginReloading {
 				m.showSystemMsg("Plugin reload already in progress, please wait...", feedbackWarning)
 				return nil
@@ -177,11 +178,16 @@ func (m *cliModel) handlePluginReloadAll() tea.Cmd {
 			m.pluginReloading = true
 			m.showSystemMsg("🔄 Reloading all plugins...", feedbackInfo)
 			m.updateViewportContent()
-			cache := m.remotePluginCache
-			return func() tea.Msg {
-				err := cache.PluginReloadAll()
-				return cliPluginReloadAllResultMsg{err: err}
+			// Send as regular message — agent's builtin command handler
+			// calls ReloadAll directly, avoiding RPC deadlock.
+			if m.sendInboundFn != nil {
+				m.sendInboundFn(ch.InboundMsg{
+					Channel: m.channelName,
+					ChatID:  m.chatID,
+					Content: "/plugin reload-all",
+				})
 			}
+			return nil
 		}
 		m.showSystemMsg("Plugin system is not enabled", feedbackWarning)
 		return nil

--- a/channel/cli/cli_plugin_cmd.go
+++ b/channel/cli/cli_plugin_cmd.go
@@ -186,6 +186,9 @@ func (m *cliModel) handlePluginReloadAll() tea.Cmd {
 					ChatID:  m.chatID,
 					Content: "/plugin reload-all",
 				})
+			} else {
+				m.showSystemMsg("Cannot reload plugins: session not connected", feedbackWarning)
+				m.pluginReloading = false
 			}
 			return nil
 		}

--- a/channel/cli/cli_tab.go
+++ b/channel/cli/cli_tab.go
@@ -26,11 +26,7 @@ func (m *cliModel) handleTabComplete() {
 	}
 
 	if len(m.completions) == 0 {
-		for _, cmd := range cliCommands {
-			if strings.HasPrefix(cmd, trimmed) {
-				m.completions = append(m.completions, cmd)
-			}
-		}
+		m.completions = m.getCommandCompletions(trimmed)
 		if len(m.completions) == 0 {
 			return
 		}
@@ -40,6 +36,25 @@ func (m *cliModel) handleTabComplete() {
 	}
 
 	m.textarea.SetValue(m.completions[m.compIdx] + " ")
+}
+
+// getCommandCompletions returns all registered command names (built-in + plugin)
+// matching the given prefix. This is the SINGLE source of truth used by both
+// Tab completion (handleTabComplete) and hint display (renderCompletionsHint).
+func (m *cliModel) getCommandCompletions(prefix string) []string {
+	var matches []string
+	for _, cmd := range cliCommands {
+		if strings.HasPrefix(cmd, prefix) {
+			matches = append(matches, cmd)
+		}
+	}
+	m.refreshPluginCmdNames()
+	for _, cmd := range m.pluginCmdNames {
+		if strings.HasPrefix(cmd, prefix) {
+			matches = append(matches, cmd)
+		}
+	}
+	return matches
 }
 
 // detectAtPrefix 检测输入文本末尾是否有 @ 触发文件补全。

--- a/channel/cli/cli_theme.go
+++ b/channel/cli/cli_theme.go
@@ -960,6 +960,65 @@ func loadExternalTheme(name string) *cliTheme {
 	return t
 }
 
+var pluginThemesMu sync.Mutex
+
+// LoadPluginTheme parses a theme JSON (same format as external themes) and
+// registers it in the theme registry. This is called when plugins contribute
+// themes via ContributeTheme. Thread-safe.
+func LoadPluginTheme(id string, data []byte) error {
+	var ext externalThemeJSON
+	if err := json.Unmarshal(data, &ext); err != nil {
+		return fmt.Errorf("plugin theme %q: %w", id, err)
+	}
+	t := &cliTheme{
+		TextPrimary:     or(ext.TextPrimary, "#e8eaed"),
+		TextSecondary:   or(ext.TextSecondary, "#9aa0a6"),
+		TextMuted:       or(ext.TextMuted, "#5f6368"),
+		FGMostSubtle:    or(ext.FGMostSubtle, "#3c4043"),
+		FGGuide:         or(ext.FGGuide, "#667eea"),
+		Success:         or(ext.Success, "#81c995"),
+		Warning:         or(ext.Warning, "#fdd663"),
+		Error:           or(ext.Error, "#f28b82"),
+		Info:            or(ext.Info, "#8ab4f8"),
+		Accent:          or(ext.Accent, "#8c9eff"),
+		AccentAlt:       or(ext.AccentAlt, "#c58af9"),
+		BarFilled:       or(ext.BarFilled, "#8c9eff"),
+		BarEmpty:        or(ext.BarEmpty, "#292a3d"),
+		Border:          or(ext.Border, "#3c4043"),
+		TitleText:       or(ext.TitleText, "#e8eaed"),
+		Surface:         or(ext.Surface, "#1e1f2e"),
+		BGPanel:         or(ext.BGPanel, "#252736"),
+		Gradient:        or(ext.Gradient, "#667eea"),
+		ErrorBg:         or(ext.ErrorBg, "#332020"),
+		SuccessBg:       or(ext.SuccessBg, "#1a3325"),
+		WarningBg:       or(ext.WarningBg, "#332d1a"),
+		InfoBg:          or(ext.InfoBg, "#1a2533"),
+		GDocumentText:   or(ext.GDocumentText, "#e8eaed"),
+		GHeadingText:    or(ext.GHeadingText, "#8ab4f8"),
+		GCodeBlock:      or(ext.GCodeBlock, "#1e1f2e"),
+		GCodeText:       or(ext.GCodeText, "#c9d1d9"),
+		GLinkText:       or(ext.GLinkText, "#8ab4f8"),
+		GBlockQuote:     or(ext.GBlockQuote, "#8c9eff"),
+		GListItem:       or(ext.GListItem, "#8ab4f8"),
+		GHorizontalRule: or(ext.GHorizontalRule, "#3c4043"),
+		FGBright:        or(ext.FGBright, "#ffffff"),
+		BGHover:         or(ext.BGHover, "#2d2f3e"),
+		BGInset:         or(ext.BGInset, "#161722"),
+		BGOverlay:       or(ext.BGOverlay, "#0d0e1a"),
+		SuccessMuted:    or(ext.SuccessMuted, "#4a7d5f"),
+		WarningMuted:    or(ext.WarningMuted, "#8a7a3a"),
+		ErrorMuted:      or(ext.ErrorMuted, "#8a4d4d"),
+		InfoMuted:       or(ext.InfoMuted, "#4a6d8a"),
+		AccentStart:     or(ext.AccentStart, ext.Accent),
+		AccentEnd:       or(ext.AccentEnd, ext.AccentAlt),
+	}
+
+	pluginThemesMu.Lock()
+	themeRegistry[id] = t
+	pluginThemesMu.Unlock()
+	return nil
+}
+
 // externalThemeJSON is the JSON-serializable theme format for external files.
 // Users only need to specify colors they want to override; defaults fill the rest.
 type externalThemeJSON struct {

--- a/channel/cli/cli_theme.go
+++ b/channel/cli/cli_theme.go
@@ -960,7 +960,7 @@ func loadExternalTheme(name string) *cliTheme {
 	return t
 }
 
-var pluginThemesMu sync.Mutex
+// pluginThemesMu removed — currentThemeMu protects themeRegistry reads and writes
 
 // LoadPluginTheme parses a theme JSON (same format as external themes) and
 // registers it in the theme registry. This is called when plugins contribute
@@ -1013,9 +1013,9 @@ func LoadPluginTheme(id string, data []byte) error {
 		AccentEnd:       or(ext.AccentEnd, ext.AccentAlt),
 	}
 
-	pluginThemesMu.Lock()
+	currentThemeMu.Lock()
 	themeRegistry[id] = t
-	pluginThemesMu.Unlock()
+	currentThemeMu.Unlock()
 	return nil
 }
 

--- a/channel/cli/cli_update.go
+++ b/channel/cli/cli_update.go
@@ -3,7 +3,10 @@ package cli
 import (
 	"fmt"
 	"image/color"
+	"io"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"unicode/utf8"
 
@@ -126,6 +129,17 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 		if handled {
 			return model, cmd
 		}
+	}
+
+	// Plugin overlay: when active, forward all keys to the overlay provider.
+	// Ctrl+C above is handled first so the user can always dismiss the overlay.
+	if m.pluginOverlay.active && m.pluginOverlay.provider != nil {
+		if key, ok := msg.(tea.KeyPressMsg); ok {
+			if m.pluginOverlay.provider.HandleKey(key.String()) {
+				m.hidePluginOverlay()
+			}
+		}
+		return m, nil
 	}
 
 	// §23 Command palette overlay: highest priority (above quick switch).
@@ -441,6 +455,15 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 			cmds = append(cmds, matrixTickCmd())
 		}
 		return m, tea.Batch(cmds...)
+
+	case cliPluginOverlayShowMsg:
+		cmds = append(cmds, m.handlePluginOverlayShow(msg)...)
+	case cliPluginOverlayHideMsg:
+		m.handlePluginOverlayHide(msg)
+	case cliPluginNotifyMsg:
+		cmds = append(cmds, m.handlePluginNotify(msg)...)
+	case cliPluginSoundMsg:
+		m.handlePluginSound(msg)
 
 	case approvalRequestMsg:
 		return m.handleApprovalRequest(msg)
@@ -772,12 +795,7 @@ func (m *cliModel) renderCompletionsHint(inputValue string) (borderColor color.C
 			}
 			hint = truncateCompHint(m.styles.CompHint.Render(strings.Join(parts, " · ")), m.chatWidth())
 		} else {
-			var matches []string
-			for _, cmd := range cliCommands {
-				if strings.HasPrefix(cmd, inputValue) {
-					matches = append(matches, cmd)
-				}
-			}
+			matches := m.getCommandCompletions(inputValue)
 			if len(matches) > 0 {
 				hint = truncateCompHint(m.styles.CompHintBorder.Render("[Tab] "+strings.Join(matches, " · ")), m.chatWidth())
 			}
@@ -835,4 +853,98 @@ func (m *cliModel) handleRunnerStatusMsg(msg runnerStatusMsg) tea.Cmd {
 		return m.clearTempStatusCmd()
 	}
 	return nil
+}
+
+// --- Plugin Overlay Handlers ---
+
+// handlePluginOverlayShow resolves the overlay provider from the plugin manager
+// and activates the full-screen overlay.
+func (m *cliModel) handlePluginOverlayShow(msg cliPluginOverlayShowMsg) []tea.Cmd {
+	if m.pluginMgrFn == nil {
+		return nil
+	}
+	mgr := m.pluginMgrFn()
+	provider, ok := mgr.GetOverlayProvider(msg.pluginID, msg.overlayID)
+	if !ok {
+		return nil
+	}
+	m.showPluginOverlay(msg.overlayID, provider)
+	return nil
+}
+
+// handlePluginOverlayHide deactivates the current plugin overlay.
+func (m *cliModel) handlePluginOverlayHide(msg cliPluginOverlayHideMsg) {
+	m.hidePluginOverlay()
+}
+
+// handlePluginNotify shows a plugin notification as a toast message.
+func (m *cliModel) handlePluginNotify(msg cliPluginNotifyMsg) []tea.Cmd {
+	icon := "ℹ"
+	switch msg.level {
+	case "success":
+		icon = "✓"
+	case "error":
+		icon = "✗"
+	case "warning":
+		icon = "⚠"
+	}
+	text := msg.message
+	if msg.title != "" {
+		text = msg.title + ": " + msg.message
+	}
+	return m.handleToastMsg(cliToastMsg{text: text, icon: icon})
+}
+
+// handlePluginSound plays a sound effect requested by a plugin.
+// On Linux, tries paplay first (PulseAudio), falls back to terminal bell.
+// On macOS, uses afplay. On other platforms, uses terminal bell.
+func (m *cliModel) handlePluginSound(msg cliPluginSoundMsg) {
+	soundID := msg.sound
+	var cmd string
+	switch soundID {
+	case "complete", "achievement":
+		if isMacOS() {
+			cmd = "afplay /System/Library/Sounds/Glass.aiff &"
+		} else if isLinux() {
+			cmd = "paplay /usr/share/sounds/freedesktop/stereo/complete.oga 2>/dev/null || printf '\\a'"
+		} else {
+			cmd = "printf '\\a'" // terminal bell fallback
+		}
+	case "error":
+		if isMacOS() {
+			cmd = "afplay /System/Library/Sounds/Basso.aiff &"
+		} else {
+			cmd = "printf '\\a'"
+		}
+	case "chime", "beep":
+		fallthrough
+	default:
+		cmd = "printf '\\a'" // terminal bell
+	}
+	if cmd != "" {
+		go runShellBg(cmd)
+	}
+}
+
+// runShellBg runs a shell command in the background (fire-and-forget).
+func runShellBg(cmd string) {
+	_ = execShell(cmd)
+}
+
+// execShell executes a shell command and returns any error.
+func execShell(cmd string) error {
+	c := exec.Command("sh", "-c", cmd)
+	c.Stdout = io.Discard
+	c.Stderr = io.Discard
+	return c.Start()
+}
+
+// isMacOS returns true if running on macOS.
+func isMacOS() bool {
+	return runtime.GOOS == "darwin"
+}
+
+// isLinux returns true if running on Linux.
+func isLinux() bool {
+	return runtime.GOOS == "linux"
 }

--- a/channel/cli/cli_update.go
+++ b/channel/cli/cli_update.go
@@ -928,15 +928,12 @@ func (m *cliModel) handlePluginSound(msg cliPluginSoundMsg) {
 
 // runShellBg runs a shell command in the background (fire-and-forget).
 func runShellBg(cmd string) {
-	_ = execShell(cmd)
-}
-
-// execShell executes a shell command and returns any error.
-func execShell(cmd string) error {
-	c := exec.Command("sh", "-c", cmd)
-	c.Stdout = io.Discard
-	c.Stderr = io.Discard
-	return c.Start()
+	go func() {
+		c := exec.Command("sh", "-c", cmd)
+		c.Stdout = io.Discard
+		c.Stderr = io.Discard
+		_ = c.Run() // Start + Wait to avoid zombie processes
+	}()
 }
 
 // isMacOS returns true if running on macOS.

--- a/channel/cli/cli_view.go
+++ b/channel/cli/cli_view.go
@@ -16,6 +16,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // computeInputCursorScreenPos calculates the absolute screen (X, Y) of the
@@ -166,8 +167,9 @@ func cliFormatTokenCount(n int64) string {
 // renderTitleBar builds the top title bar with gradient wordmark, diagonal fill,
 // mode label, hints, runner status, and user identity indicator.
 // In compact mode (<80 cols), extras (runner, user) are hidden.
-func (m *cliModel) renderTitleBar() string {
-	titleLeft := m.titleText()
+// buildTitleRight builds the right side of the title bar (hints, runner status, etc).
+// Extracted so augmentTitleBar can rebuild the title bar with widgets in the padding.
+func (m *cliModel) buildTitleRight() string {
 	titleRight := m.locale.TitleHint
 	// Askuser panel: override titleRight with panel-specific hints (always visible)
 	if m.panelState.mode == "askuser" {
@@ -199,6 +201,12 @@ func (m *cliModel) renderTitleBar() string {
 	if m.isNarrow() {
 		titleRight = ""
 	}
+	return titleRight
+}
+
+func (m *cliModel) renderTitleBar() string {
+	titleLeft := m.titleText()
+	titleRight := m.buildTitleRight()
 	titlePad := m.width - lipgloss.Width(titleLeft) - lipgloss.Width(titleRight)
 	if titlePad < 1 {
 		titlePad = 1
@@ -974,19 +982,57 @@ func (m *cliModel) padLineToWidth(line string) string {
 	return line + strings.Repeat(" ", targetW-lineW)
 }
 
-// augmentTitleBar prepends titleBarLeft widgets and appends titleBarRight widgets.
+// augmentTitleBar rebuilds the title bar with titleBarLeft/titleBarRight widgets
+// embedded in the padding area between titleLeft and titleRight, all rendered
+// with TitleBar style so widgets share the bar's background color.
 func (m *cliModel) augmentTitleBar(titleBar string) string {
 	left, right := m.resolveWidgetZone("titleBarLeft"), m.resolveWidgetZone("titleBarRight")
 	if left == "" && right == "" {
 		return titleBar
 	}
+
+	titleLeft := m.titleText()
+	titleRight := m.buildTitleRight()
+
+	// Build widget segments with surrounding space.
+	// Strip ANSI from widget content so it doesn't break the TitleBar background.
+	var extraLeft, extraRight string
 	if left != "" {
-		titleBar = left + " " + titleBar
+		extraLeft = " " + ansi.Strip(left) + " "
 	}
 	if right != "" {
-		titleBar = titleBar + " " + right
+		extraRight = " " + ansi.Strip(right) + " "
 	}
-	return titleBar
+
+	// Calculate remaining padding after accounting for widgets
+	totalExtra := lipgloss.Width(extraLeft) + lipgloss.Width(extraRight)
+	titlePad := m.width - lipgloss.Width(titleLeft) - lipgloss.Width(titleRight) - totalExtra
+	if titlePad < 1 {
+		titlePad = 1
+	}
+
+	// Rebuild with widgets embedded in the padding area — all rendered with
+	// TitleBar style so they inherit the bar's background color.
+	content := titleLeft + extraLeft + strings.Repeat(" ", titlePad) + extraRight + titleRight
+	// Truncate content BEFORE rendering — lipgloss v2 may auto-wrap long content
+	if cw := lipgloss.Width(content); cw > m.width {
+		// Shrink titlePad to fit, or truncate titleRight as last resort
+		over := cw - m.width
+		if titlePad > over {
+			titlePad -= over
+			content = titleLeft + extraLeft + strings.Repeat(" ", titlePad) + extraRight + titleRight
+		} else {
+			// Still too long — truncate titleRight
+			avail := m.width - lipgloss.Width(titleLeft+extraLeft+strings.Repeat(" ", 1)+extraRight)
+			if avail > 4 {
+				titleRight = ansi.Truncate(titleRight, avail-1, "…")
+				content = titleLeft + extraLeft + " " + extraRight + titleRight
+			} else {
+				content = ansi.Truncate(content, m.width, "…")
+			}
+		}
+	}
+	return m.styles.TitleBar.Render(content)
 }
 
 // augmentStatusBar prepends statusBarLeft and appends statusBarRight widgets.
@@ -1027,14 +1073,22 @@ func (m *cliModel) augmentFooter(footer string) string {
 // The result is padded to full terminal width so that stale content from a
 // previous (wider) frame is overwritten.
 func (m *cliModel) augmentInfoBar(infoBar string) string {
-	content := m.resolveWidgetZone("infoBar")
+	return m.augmentWithWidget(infoBar, "infoBar", "  ")
+}
+
+// augmentWithWidget appends widget content for a given zone to a base string.
+// This is a generic version usable for any single-content widget zone.
+// The result is padded to full terminal width so stale content from a
+// previous (wider) frame is overwritten.
+func (m *cliModel) augmentWithWidget(base string, zone string, separator string) string {
+	content := m.resolveWidgetZone(zone)
 	if content == "" {
-		return m.padLineToWidth(infoBar)
+		return m.padLineToWidth(base)
 	}
-	if infoBar == "" {
+	if base == "" {
 		return m.padLineToWidth(content)
 	}
-	return m.padLineToWidth(infoBar + "  " + content)
+	return m.padLineToWidth(base + separator + content)
 }
 
 // resolveWidgetZone returns widget content for a zone, checking local WidgetRegistry
@@ -1077,6 +1131,13 @@ func (m *cliModel) View() (v tea.View) {
 	// Easter egg overlay
 	if m.easterEggState.mode != easterEggNone {
 		v := tea.NewView(m.renderEasterEggOverlay())
+		v.AltScreen = true
+		return v
+	}
+
+	// Plugin overlay — full-screen overlay contributed by plugins.
+	if m.pluginOverlay.active && m.pluginOverlay.provider != nil {
+		v := tea.NewView(m.pluginOverlay.provider.Render(m.width, m.height))
 		v.AltScreen = true
 		return v
 	}

--- a/channel/web/web.go
+++ b/channel/web/web.go
@@ -993,15 +993,11 @@ func (wc *WebChannel) readPump(c *Client, si *sessionInfo) {
 			} else if result != nil {
 				rpcMsg.Result = result
 			}
-			// RPC responses MUST NOT be dropped — a dropped response causes the
-			// client to block until its 30s RPC timeout. During plugin reload-all,
-			// multiple widget pushes can fill sendCh (64 buffer) simultaneously,
-			// so we block with a timeout instead of silently dropping.
 			select {
 			case c.sendCh <- rpcMsg:
 			case <-time.After(10 * time.Second):
 				log.WithField("rpc_id", rpcReq.ID).WithField("method", rpcReq.Method).
-					Error("RPC response send timeout (10s), sendCh full — writePump may be stuck")
+					Error("RPC response send timeout (10s)")
 			}
 			continue
 		case protocol.MsgTypeSubscribe:

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -678,7 +678,11 @@ func (a *cliApp) buildPaletteExternalCommands() []cli.PaletteExternalCommand {
 		}
 	}
 
-	// 2. Plugin commands from ~/.xbot/plugins/*/plugin.json
+	// 2. Plugin commands from local ~/.xbot/plugins/*/plugin.json
+	// NOTE: This reads plugin.json directly to discover commands. In remote mode,
+	// plugin manifests are also synced locally via the plugin system. A future
+	// improvement would be to fetch commands via RPC (list_plugin_commands) for
+	// consistency with the PluginManager, but this approach is correct and simple.
 	if entries, err := os.ReadDir(xbotDir + "/plugins"); err == nil {
 		for _, e := range entries {
 			if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -678,8 +678,41 @@ func (a *cliApp) buildPaletteExternalCommands() []cli.PaletteExternalCommand {
 		}
 	}
 
-	// 2. Plugin commands from loaded plugins
-	// TODO: migrate palette plugin commands to RPC
+	// 2. Plugin commands from ~/.xbot/plugins/*/plugin.json
+	if entries, err := os.ReadDir(xbotDir + "/plugins"); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+				continue
+			}
+			manifestPath := filepath.Join(xbotDir, "plugins", e.Name(), "plugin.json")
+			data, err := os.ReadFile(manifestPath)
+			if err != nil {
+				continue
+			}
+			var manifest struct {
+				Contributes struct {
+					Commands []struct {
+						Name        string `json:"name"`
+						Description string `json:"description"`
+					} `json:"commands"`
+				} `json:"contributes"`
+			}
+			if err := json.Unmarshal(data, &manifest); err != nil {
+				continue
+			}
+			for _, cmd := range manifest.Contributes.Commands {
+				if cmd.Name == "" {
+					continue
+				}
+				cmds = append(cmds, cli.PaletteExternalCommand{
+					Title:       cmd.Name,
+					Description: cmd.Description,
+					Category:    cli.PaletteCategoryPlugins,
+					Content:     cmd.Name + " ",
+				})
+			}
+		}
+	}
 
 	// 3. User custom commands from ~/.xbot/commands/*.md (crush-style)
 	if entries, err := os.ReadDir(xbotDir + "/commands"); err == nil {

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -193,6 +193,52 @@ type PluginContext interface {
 	// 注册后 provider 会被存储，供 serverapp 在 registerChannels 和动态启停路径中使用。
 	// 参数类型为 any 而非 channel.ChannelProvider 是为了避免 plugin→channel 循环依赖。
 	RegisterChannelProvider(provider any) error
+
+	// --- Command Registration ---
+
+	// RegisterCommand registers a slash command handler for this plugin.
+	// Requires "commands.register" permission.
+	RegisterCommand(name string, description string, handler PluginCommandHandler) error
+
+	// --- Cron Scheduling ---
+
+	// ScheduleCron creates a scheduled task. Returns a job ID.
+	// Requires "cron.schedule" permission.
+	ScheduleCron(spec CronContribution) (string, error)
+
+	// CancelCron cancels a previously scheduled task.
+	// Requires "cron.schedule" permission.
+	CancelCron(jobID string) error
+
+	// --- Theme Contribution ---
+
+	// ContributeTheme registers a theme from the plugin.
+	// Requires "ui.themes" permission.
+	ContributeTheme(id string, themeData []byte) error
+
+	// --- Overlay ---
+
+	// RegisterOverlay registers a full-screen overlay provider.
+	// Requires "ui.overlay" permission.
+	RegisterOverlay(id string, provider OverlayProvider) error
+
+	// ShowOverlay triggers the display of a registered overlay.
+	// Requires "ui.overlay" permission.
+	ShowOverlay(id string) error
+
+	// HideOverlay hides the currently displayed overlay.
+	// Requires "ui.overlay" permission.
+	HideOverlay() error
+
+	// --- Notifications & Sound ---
+
+	// Notify sends a notification to the user.
+	// Requires "notifications.send" permission.
+	Notify(level NotificationLevel, title, message string)
+
+	// PlaySound plays a sound effect.
+	// Requires "notifications.send" permission.
+	PlaySound(sound SoundID)
 }
 
 // Logger provides structured logging for plugins.
@@ -288,6 +334,19 @@ type pluginContextImpl struct {
 	// Runtime resource tracking (atomic for lock-free reads)
 	toolCallCount int64
 	hookCallCount int64
+
+	// Command handlers
+	commands map[string]pluginCommandEntry
+
+	// Cron tasks
+	crons             []CronContribution
+	cronCancellations map[string]bool
+
+	// Themes
+	themes map[string][]byte
+
+	// Overlays
+	overlays map[string]OverlayProvider
 }
 
 type hookRegistration struct {
@@ -304,22 +363,34 @@ type enricherRegistration struct {
 	Enricher ContextEnricher
 }
 
+// pluginCommandEntry stores a registered command handler.
+type pluginCommandEntry struct {
+	name        string
+	description string
+	handler     PluginCommandHandler
+}
+
 // newPluginContext creates a new PluginContext for the given plugin.
 func newPluginContext(manifest *PluginManifest, storage StorageAccessor, logger Logger, bus *PluginEventBus, configStore *PluginConfigStore, pm *PluginManager) *pluginContextImpl {
 	return &pluginContextImpl{
-		pluginID:         manifest.ID,
-		manifest:         manifest,
-		perm:             NewPermissionChecker(manifest.Permissions),
-		storage:          storage,
-		logger:           logger,
-		tools:            make([]PluginTool, 0),
-		hooks:            make([]hookRegistration, 0),
-		contextEnrichers: make([]enricherRegistration, 0),
-		channelProviders: make([]any, 0),
-		bus:              bus,
-		pm:               pm,
-		configStore:      configStore,
-		contextValues:    make(map[string]any),
+		pluginID:          manifest.ID,
+		manifest:          manifest,
+		perm:              NewPermissionChecker(manifest.Permissions),
+		storage:           storage,
+		logger:            logger,
+		tools:             make([]PluginTool, 0),
+		hooks:             make([]hookRegistration, 0),
+		contextEnrichers:  make([]enricherRegistration, 0),
+		channelProviders:  make([]any, 0),
+		bus:               bus,
+		pm:                pm,
+		configStore:       configStore,
+		contextValues:     make(map[string]any),
+		commands:          make(map[string]pluginCommandEntry),
+		crons:             make([]CronContribution, 0),
+		cronCancellations: make(map[string]bool),
+		themes:            make(map[string][]byte),
+		overlays:          make(map[string]OverlayProvider),
 	}
 }
 
@@ -1002,4 +1073,252 @@ func (pc *pluginContextImpl) ChannelProviders() []any {
 	result := make([]any, len(pc.channelProviders))
 	copy(result, pc.channelProviders)
 	return result
+}
+
+// ---------------------------------------------------------------------------
+// Command Registration
+// ---------------------------------------------------------------------------
+
+// RegisterCommand registers a slash command handler for this plugin.
+func (pc *pluginContextImpl) RegisterCommand(name string, description string, handler PluginCommandHandler) error {
+	if !pc.perm.Has(PermCommandsRegister) {
+		return &PermissionError{
+			PluginID:   pc.pluginID,
+			Permission: PermCommandsRegister,
+			Action:     "register command",
+		}
+	}
+	if handler == nil {
+		return fmt.Errorf("command handler must not be nil")
+	}
+	if name == "" {
+		return fmt.Errorf("command name must not be empty")
+	}
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.commands[name] = pluginCommandEntry{
+		name:        name,
+		description: description,
+		handler:     handler,
+	}
+	pc.logger.Info("Command registered", Field{Key: "command", Value: name})
+	return nil
+}
+
+// GetCommands returns a snapshot of all registered command handlers.
+func (pc *pluginContextImpl) GetCommands() map[string]pluginCommandEntry {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	result := make(map[string]pluginCommandEntry, len(pc.commands))
+	for k, v := range pc.commands {
+		result[k] = v
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Cron Scheduling
+// ---------------------------------------------------------------------------
+
+// ScheduleCron creates a scheduled task. Returns a job ID.
+func (pc *pluginContextImpl) ScheduleCron(spec CronContribution) (string, error) {
+	if !pc.perm.Has(PermCronSchedule) {
+		return "", &PermissionError{
+			PluginID:   pc.pluginID,
+			Permission: PermCronSchedule,
+			Action:     "schedule cron",
+		}
+	}
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	jobID := fmt.Sprintf("plugin:%s:%d", pc.pluginID, len(pc.crons))
+	pc.crons = append(pc.crons, spec)
+	pc.logger.Info("Cron scheduled", Field{Key: "job_id", Value: jobID})
+	return jobID, nil
+}
+
+// CancelCron cancels a previously scheduled task.
+func (pc *pluginContextImpl) CancelCron(jobID string) error {
+	if !pc.perm.Has(PermCronSchedule) {
+		return &PermissionError{
+			PluginID:   pc.pluginID,
+			Permission: PermCronSchedule,
+			Action:     "cancel cron",
+		}
+	}
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.cronCancellations[jobID] = true
+	pc.logger.Info("Cron cancellation requested", Field{Key: "job_id", Value: jobID})
+	return nil
+}
+
+// GetCrons returns a snapshot of all scheduled crons.
+func (pc *pluginContextImpl) GetCrons() []CronContribution {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	result := make([]CronContribution, len(pc.crons))
+	copy(result, pc.crons)
+	return result
+}
+
+// GetCronCancellations returns a snapshot of all cancelled cron job IDs.
+func (pc *pluginContextImpl) GetCronCancellations() map[string]bool {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	result := make(map[string]bool, len(pc.cronCancellations))
+	for k, v := range pc.cronCancellations {
+		result[k] = v
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Theme Contribution
+// ---------------------------------------------------------------------------
+
+// ContributeTheme registers a theme from the plugin.
+func (pc *pluginContextImpl) ContributeTheme(id string, themeData []byte) error {
+	if !pc.perm.Has(PermUIThemes) {
+		return &PermissionError{
+			PluginID:   pc.pluginID,
+			Permission: PermUIThemes,
+			Action:     "contribute theme",
+		}
+	}
+	if id == "" {
+		return fmt.Errorf("theme id must not be empty")
+	}
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.themes[id] = themeData
+	pc.logger.Info("Theme contributed", Field{Key: "theme_id", Value: id})
+	return nil
+}
+
+// GetThemes returns a snapshot of all contributed themes.
+func (pc *pluginContextImpl) GetThemes() map[string][]byte {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	result := make(map[string][]byte, len(pc.themes))
+	for k, v := range pc.themes {
+		result[k] = v
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Overlay
+// ---------------------------------------------------------------------------
+
+// RegisterOverlay registers a full-screen overlay provider.
+func (pc *pluginContextImpl) RegisterOverlay(id string, provider OverlayProvider) error {
+	if !pc.perm.Has(PermUIOverlay) {
+		return &PermissionError{
+			PluginID:   pc.pluginID,
+			Permission: PermUIOverlay,
+			Action:     "register overlay",
+		}
+	}
+	if id == "" {
+		return fmt.Errorf("overlay id must not be empty")
+	}
+	if provider == nil {
+		return fmt.Errorf("overlay provider must not be nil")
+	}
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.overlays[id] = provider
+	pc.logger.Info("Overlay registered", Field{Key: "overlay_id", Value: id})
+	return nil
+}
+
+// ShowOverlay triggers the display of a registered overlay.
+func (pc *pluginContextImpl) ShowOverlay(id string) error {
+	if !pc.perm.Has(PermUIOverlay) {
+		return &PermissionError{
+			PluginID:   pc.pluginID,
+			Permission: PermUIOverlay,
+			Action:     "show overlay",
+		}
+	}
+	pc.mu.RLock()
+	_, ok := pc.overlays[id]
+	pc.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("overlay %q not registered", id)
+	}
+	if pc.bus != nil {
+		pc.bus.Publish(context.Background(), "plugin:overlay:show", map[string]string{
+			"plugin_id":  pc.pluginID,
+			"overlay_id": id,
+		})
+	}
+	pc.logger.Info("Overlay shown", Field{Key: "overlay_id", Value: id})
+	return nil
+}
+
+// HideOverlay hides the currently displayed overlay.
+func (pc *pluginContextImpl) HideOverlay() error {
+	if !pc.perm.Has(PermUIOverlay) {
+		return &PermissionError{
+			PluginID:   pc.pluginID,
+			Permission: PermUIOverlay,
+			Action:     "hide overlay",
+		}
+	}
+	if pc.bus != nil {
+		pc.bus.Publish(context.Background(), "plugin:overlay:hide", map[string]string{
+			"plugin_id": pc.pluginID,
+		})
+	}
+	pc.logger.Info("Overlay hidden")
+	return nil
+}
+
+// GetOverlays returns a snapshot of all registered overlay providers.
+func (pc *pluginContextImpl) GetOverlays() map[string]OverlayProvider {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	result := make(map[string]OverlayProvider, len(pc.overlays))
+	for k, v := range pc.overlays {
+		result[k] = v
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Notifications & Sound
+// ---------------------------------------------------------------------------
+
+// Notify sends a notification to the user.
+func (pc *pluginContextImpl) Notify(level NotificationLevel, title, message string) {
+	if !pc.perm.Has(PermNotificationsSend) {
+		pc.logger.Warn("Notification denied", Field{Key: "permission", Value: PermNotificationsSend})
+		return
+	}
+	if pc.bus != nil {
+		pc.bus.Publish(context.Background(), "plugin:notify", map[string]string{
+			"plugin_id": pc.pluginID,
+			"level":     string(level),
+			"title":     title,
+			"message":   message,
+		})
+	}
+	pc.logger.Info("Notification sent", Field{Key: "level", Value: string(level)}, Field{Key: "title", Value: title})
+}
+
+// PlaySound plays a sound effect.
+func (pc *pluginContextImpl) PlaySound(sound SoundID) {
+	if !pc.perm.Has(PermNotificationsSend) {
+		pc.logger.Warn("Sound denied", Field{Key: "permission", Value: PermNotificationsSend})
+		return
+	}
+	if pc.bus != nil {
+		pc.bus.Publish(context.Background(), "plugin:sound:play", map[string]string{
+			"plugin_id": pc.pluginID,
+			"sound":     string(sound),
+		})
+	}
+	pc.logger.Info("Sound played", Field{Key: "sound", Value: string(sound)})
 }

--- a/plugin/integration.go
+++ b/plugin/integration.go
@@ -3,11 +3,14 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
+	"xbot/cron"
 	"xbot/llm"
 	log "xbot/logger"
+	"xbot/storage/sqlite"
 	"xbot/tools"
 )
 
@@ -294,4 +297,147 @@ func WireAll(pm *PluginManager, registry *tools.Registry, bridge *PluginHookBrid
 	WirePluginEnrichers(enricherRegistry, pm, defaultEnricherPriority)
 
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Plugin Command Wiring
+// ---------------------------------------------------------------------------
+
+// CommandRegisterFn is the callback signature for registering a plugin command.
+// The caller (agent package) wraps this into a Command implementation to avoid
+// circular imports between plugin ↔ agent.
+type CommandRegisterFn func(name, description string, handler PluginCommandHandler, pctx PluginContext)
+
+// WirePluginCommands iterates active plugins and calls registerFn for each
+// registered command handler. The registerFn is responsible for wrapping the
+// handler into an agent.Command and registering it with the command registry.
+func WirePluginCommands(pm *PluginManager, registerFn CommandRegisterFn) {
+	entries := pm.ListPlugins()
+	registered := 0
+
+	for _, entry := range entries {
+		if entry.State != StateActive {
+			continue
+		}
+		pctx := entry.Context
+		for _, cmd := range pctx.GetCommands() {
+			registerFn(cmd.name, cmd.description, cmd.handler, pctx)
+			registered++
+		}
+	}
+
+	if registered > 0 {
+		log.Infof("plugin: registered %d commands from %d active plugins", registered, pm.ActiveCount())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Plugin Cron Wiring
+// ---------------------------------------------------------------------------
+
+// WirePluginCrons scans active plugins for scheduled crons and adds them to
+// the CronService. It also processes cancellation requests (removes jobs that
+// were cancelled via CancelCron). Re-wiring is idempotent: existing plugin jobs
+// are cleaned up before re-adding to avoid duplicates.
+func WirePluginCrons(pm *PluginManager, cronSvc *sqlite.CronService) {
+	if cronSvc == nil {
+		return
+	}
+
+	added := 0
+	removed := 0
+	now := time.Now()
+
+	entries := pm.ListPlugins()
+	for _, entry := range entries {
+		if entry.State != StateActive {
+			continue
+		}
+		pluginID := entry.Manifest.ID
+
+		// Remove stale plugin jobs (idempotent: delete before re-add)
+		allJobs, _ := cronSvc.ListAllJobs()
+		for _, job := range allJobs {
+			if strings.HasPrefix(job.ID, "plugin:"+pluginID+":") {
+				if err := cronSvc.RemoveJob(job.ID); err != nil {
+					log.WithError(err).WithField("job_id", job.ID).Warn("plugin: failed to remove stale cron job")
+				} else {
+					removed++
+				}
+			}
+		}
+
+		// Process cancellation requests
+		for jobID := range entry.Context.GetCronCancellations() {
+			if err := cronSvc.RemoveJob(jobID); err != nil {
+				log.WithError(err).WithField("job_id", jobID).Warn("plugin: failed to cancel cron job")
+			} else {
+				removed++
+			}
+		}
+
+		// Add current cron contributions
+		for i, spec := range entry.Context.GetCrons() {
+			job := &sqlite.CronJob{
+				ID:           fmt.Sprintf("plugin:%s:%d", pluginID, i),
+				Message:      spec.Message,
+				CronExpr:     spec.CronExpr,
+				EverySeconds: spec.EverySeconds,
+				DelaySeconds: spec.DelaySeconds,
+				At:           spec.At,
+				CreatedAt:    now,
+			}
+
+			// Calculate next run and one_shot flag
+			job.OneShot = job.At != "" || job.DelaySeconds > 0
+			nextRun, err := cron.CalculateNextRun(job, now)
+			if err != nil {
+				log.WithError(err).WithField("plugin", pluginID).Warn("plugin: failed to calculate next run for cron")
+				continue
+			}
+			job.NextRun = nextRun
+
+			if err := cronSvc.AddJob(job); err != nil {
+				log.WithError(err).WithField("job_id", job.ID).Warn("plugin: failed to add cron job")
+				continue
+			}
+			added++
+		}
+	}
+
+	if added > 0 || removed > 0 {
+		log.Infof("plugin: cron wiring complete: %d added, %d removed", added, removed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Plugin Theme Wiring
+// ---------------------------------------------------------------------------
+
+// WirePluginThemes iterates active plugins and calls themeLoader for each
+// contributed theme. themeLoader receives the theme ID and raw JSON data,
+// and is responsible for persisting the theme (e.g. to ~/.xbot/themes/).
+func WirePluginThemes(pm *PluginManager, themeLoader func(id string, data []byte) error) {
+	entries := pm.ListPlugins()
+	loaded := 0
+
+	for _, entry := range entries {
+		if entry.State != StateActive {
+			continue
+		}
+		for id, data := range entry.Context.GetThemes() {
+			if err := themeLoader(id, data); err != nil {
+				log.WithError(err).WithFields(log.Fields{
+					"plugin": entry.Manifest.ID,
+					"theme":  id,
+				}).Warn("plugin: failed to load theme")
+				continue
+			}
+			loaded++
+		}
+	}
+
+	if loaded > 0 {
+		log.Infof("plugin: loaded %d themes from active plugins", loaded)
+	}
 }

--- a/plugin/integration.go
+++ b/plugin/integration.go
@@ -356,7 +356,10 @@ func WirePluginCrons(pm *PluginManager, cronSvc *sqlite.CronService) {
 		pluginID := entry.Manifest.ID
 
 		// Remove stale plugin jobs (idempotent: delete before re-add)
-		allJobs, _ := cronSvc.ListAllJobs()
+		allJobs, err := cronSvc.ListAllJobs()
+		if err != nil {
+			log.WithError(err).Warn("plugin: failed to list existing cron jobs during re-wire")
+		}
 		for _, job := range allJobs {
 			if strings.HasPrefix(job.ID, "plugin:"+pluginID+":") {
 				if err := cronSvc.RemoveJob(job.ID); err != nil {

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -73,6 +73,10 @@ type PluginManager struct {
 
 	// logMgr manages per-plugin log writers and unified cleanup.
 	logMgr *pluginLogManager
+
+	// onReloadCallbacks are called after ReloadAll completes successfully.
+	onReloadCallbacks []func()
+	onReloadMu        sync.Mutex
 }
 
 // RuntimeFactory creates Plugin instances for different runtime types.
@@ -770,6 +774,18 @@ func (pm *PluginManager) ListPlugins() []*PluginEntry {
 	return result
 }
 
+// GetOverlayProvider looks up an overlay provider by plugin ID and overlay ID.
+// Returns the provider and true if found, or nil and false otherwise.
+func (pm *PluginManager) GetOverlayProvider(pluginID, overlayID string) (OverlayProvider, bool) {
+	entry, ok := pm.GetPlugin(pluginID)
+	if !ok || entry.Context == nil || entry.State != StateActive {
+		return nil, false
+	}
+	overlays := entry.Context.GetOverlays()
+	provider, ok := overlays[overlayID]
+	return provider, ok
+}
+
 // ActiveCount returns the number of currently active plugins.
 func (pm *PluginManager) ActiveCount() int {
 	pm.mu.RLock()
@@ -954,6 +970,8 @@ func (pm *PluginManager) Reload(ctx context.Context, pluginID string) error {
 
 // ReloadAll deactivates all plugins, clears entries, re-discovers, and re-activates.
 func (pm *PluginManager) ReloadAll(ctx context.Context) error {
+	// Suppress widget push during reload to avoid flooding WebSocket sendCh
+	defer pm.widgetRegistry.SuppressUpdates()()
 	pm.DeactivateAll(ctx)
 
 	// Collect plugin IDs before clearing entries so we can unregister widgets.
@@ -977,7 +995,32 @@ func (pm *PluginManager) ReloadAll(ctx context.Context) error {
 		return fmt.Errorf("reload all: discover failed: %w", err)
 	}
 
-	return pm.ActivateAll(ctx)
+	if err := pm.ActivateAll(ctx); err != nil {
+		return err
+	}
+
+	// Notify reload listeners asynchronously to avoid blocking the RPC handler
+	// (listeners may push widget updates via WebSocket which can be slow).
+	pm.onReloadMu.Lock()
+	cbs := make([]func(), len(pm.onReloadCallbacks))
+	copy(cbs, pm.onReloadCallbacks)
+	pm.onReloadMu.Unlock()
+	if len(cbs) > 0 {
+		go func() {
+			for _, cb := range cbs {
+				cb()
+			}
+		}()
+	}
+
+	return nil
+}
+
+// OnReload registers a callback invoked after ReloadAll completes.
+func (pm *PluginManager) OnReload(cb func()) {
+	pm.onReloadMu.Lock()
+	defer pm.onReloadMu.Unlock()
+	pm.onReloadCallbacks = append(pm.onReloadCallbacks, cb)
 }
 
 // ---------------------------------------------------------------------------

--- a/plugin/permissions.go
+++ b/plugin/permissions.go
@@ -33,22 +33,37 @@ const (
 	PermUIContribute = "ui.contribute"
 	// PermChannelsRegister grants permission to register custom Channel providers.
 	PermChannelsRegister = "channels.register"
+	// PermCommandsRegister grants permission to register slash commands.
+	PermCommandsRegister = "commands.register"
+	// PermCronSchedule grants permission to schedule cron tasks.
+	PermCronSchedule = "cron.schedule"
+	// PermUIThemes grants permission to contribute themes.
+	PermUIThemes = "ui.themes"
+	// PermUIOverlay grants permission to register and control overlays.
+	PermUIOverlay = "ui.overlay"
+	// PermNotificationsSend grants permission to send notifications and play sounds.
+	PermNotificationsSend = "notifications.send"
 )
 
 // allPermissions is the set of all recognized permission strings.
 var allPermissions = map[string]bool{
-	PermToolsRegister:    true,
-	PermToolsCall:        true,
-	PermHooksSubscribe:   true,
-	PermContextEnrich:    true,
-	PermStoragePrivate:   true,
-	PermStorageShared:    true,
-	PermNetworkOutbound:  true,
-	PermBusRead:          true,
-	PermBusWrite:         true,
-	PermBusPlugin:        true,
-	PermUIContribute:     true,
-	PermChannelsRegister: true,
+	PermToolsRegister:     true,
+	PermToolsCall:         true,
+	PermHooksSubscribe:    true,
+	PermContextEnrich:     true,
+	PermStoragePrivate:    true,
+	PermStorageShared:     true,
+	PermNetworkOutbound:   true,
+	PermBusRead:           true,
+	PermBusWrite:          true,
+	PermBusPlugin:         true,
+	PermUIContribute:      true,
+	PermChannelsRegister:  true,
+	PermCommandsRegister:  true,
+	PermCronSchedule:      true,
+	PermUIThemes:          true,
+	PermUIOverlay:         true,
+	PermNotificationsSend: true,
 }
 
 // IsValidPermission returns true if the given string is a known permission.

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -133,8 +133,17 @@ type PluginContributes struct {
 	Hooks            []HookContribution         `json:"hooks,omitempty"`
 	ContextEnrichers []EnricherContribution     `json:"context_enrichers,omitempty"`
 	Commands         []CommandContribution      `json:"commands,omitempty"`
+	Crons            []CronContribution         `json:"crons,omitempty"`
+	Themes           []ThemeContribution        `json:"themes,omitempty"`
+	Overlays         []OverlayContribution      `json:"overlays,omitempty"`
 	Configuration    *ConfigurationContribution `json:"configuration,omitempty"`
 	UI               []UISlotContribution       `json:"ui,omitempty"`
+}
+
+// OverlayContribution describes a full-screen overlay provided by the plugin.
+type OverlayContribution struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
 }
 
 // ToolContribution describes a tool provided by the plugin.
@@ -162,6 +171,55 @@ type CommandContribution struct {
 	Name        string `json:"name"` // e.g., "/deploy"
 	Description string `json:"description"`
 }
+
+// PluginCommandHandler is the function signature for plugin command handlers.
+// args contains everything after the command name (trimmed).
+// Returns the response text to show to the user.
+type PluginCommandHandler func(ctx context.Context, args string, pctx PluginContext) (string, error)
+
+// CronContribution describes a scheduled task provided by the plugin.
+type CronContribution struct {
+	Message      string `json:"message"` // message sent to agent when triggered
+	CronExpr     string `json:"cron_expr,omitempty"`
+	EverySeconds int    `json:"every_seconds,omitempty"`
+	At           string `json:"at,omitempty"`
+	DelaySeconds int    `json:"delay_seconds,omitempty"`
+}
+
+// ThemeContribution describes a theme provided by the plugin.
+type ThemeContribution struct {
+	ID   string `json:"id"`
+	File string `json:"file"` // path relative to plugin dir, e.g. "themes/dracula.json"
+}
+
+// OverlayProvider is implemented by plugins that want to render a full-screen overlay.
+type OverlayProvider interface {
+	// Render returns the overlay content for the given terminal dimensions.
+	Render(width, height int) string
+	// HandleKey processes a key event. Returns true if the overlay should close.
+	HandleKey(key string) bool
+}
+
+// SoundID identifies a sound effect.
+type SoundID string
+
+const (
+	SoundBeep        SoundID = "beep"
+	SoundChime       SoundID = "chime"
+	SoundComplete    SoundID = "complete"
+	SoundError       SoundID = "error"
+	SoundAchievement SoundID = "achievement"
+)
+
+// NotificationLevel indicates the severity of a notification.
+type NotificationLevel string
+
+const (
+	NotifyInfo    NotificationLevel = "info"
+	NotifySuccess NotificationLevel = "success"
+	NotifyWarning NotificationLevel = "warning"
+	NotifyError   NotificationLevel = "error"
+)
 
 // ConfigurationContribution declares user-configurable settings for the plugin.
 // Defined in plugin.json under "contributes.configuration".

--- a/plugin/script_runtime.go
+++ b/plugin/script_runtime.go
@@ -34,9 +34,6 @@ func (f *scriptRuntimeFactory) Create(manifest *PluginManifest, dir string) (Plu
 		manifest.EntryDarwin == "" && manifest.EntryLinux == "" {
 		return nil, fmt.Errorf("script plugin %s: entry command is required", manifest.ID)
 	}
-	if len(manifest.Contributes.UI) == 0 {
-		return nil, fmt.Errorf("script plugin %s: at least one ui contribution required", manifest.ID)
-	}
 	return &scriptPlugin{
 		manifest: *manifest,
 		dir:      dir,
@@ -188,6 +185,47 @@ func (p *scriptPlugin) Activate(ctx PluginContext) error {
 				// Config detail — route to plugin log only, not main log.
 				ctx.Logger().Warnf("trigger %q subscribe failed: %v", trigger, err)
 			}
+		}
+	}
+
+	// Register commands declared in the manifest.
+	// Each command invokes the script with XBOT_COMMAND_NAME and XBOT_COMMAND_ARGS
+	// environment variables. The script's stdout becomes the command response.
+	for _, cmd := range p.manifest.Contributes.Commands {
+		cmdName := cmd.Name
+		cmdDesc := cmd.Description
+		pluginPtr := p // capture for closure
+		handler := func(ctx2 context.Context, args string, pctx PluginContext) (string, error) {
+			return pluginPtr.runCommand(cmdName, args)
+		}
+		if err := ctx.RegisterCommand(cmdName, cmdDesc, handler); err != nil {
+			ctx.Logger().Warnf("command %q registration failed: %v", cmdName, err)
+		}
+	}
+
+	// Subscribe to lifecycle hooks declared in the manifest.
+	// Format: {"event": "PostToolUse", "matcher": ""} → hook fires → script runs
+	// The script receives hook data via XBOT_TOOL_NAME, XBOT_TOOL_INPUT, etc.
+	for _, h := range p.manifest.Contributes.Hooks {
+		hookEvent := HookEvent(h.Event)
+		matcher := h.Matcher
+		pluginPtr := p // capture for closure
+		handler := func(_ context.Context, hp *HookPayload) (*HookResult, error) {
+			if hp != nil {
+				pluginPtr.lastHookMu.Lock()
+				pluginPtr.lastHook = hp
+				pluginPtr.lastHookMu.Unlock()
+			}
+			// Trigger async script run via the trigger channel
+			select {
+			case pluginPtr.triggerCh <- struct{}{}:
+			default:
+				// Channel full, skip — next refresh will catch up
+			}
+			return &HookResult{Decision: DecisionAllow}, nil
+		}
+		if err := ctx.OnEvent(hookEvent, matcher, handler); err != nil {
+			ctx.Logger().Warnf("hook %q (matcher=%q) subscribe failed: %v", h.Event, matcher, err)
 		}
 	}
 
@@ -394,25 +432,10 @@ func (p *scriptPlugin) runAndUpdate() {
 	}
 	p.outputMu.Unlock()
 
-	// Determine the primary widgetID (first declared, or empty if single-widget).
-	// For backward compatibility, when a plugin has a single widget, we run the
-	// script once per workDir and cache the same output for that widget.
-	// For multi-widget plugins, we also run once per workDir but with XBOT_WIDGET_ID
-	// set to the primary widget so the script output is consistent.
-	// The per-widget render paths (renderForWidget/renderByWidgetAndWorkDir) will
-	// call runScript with the specific widgetID for cache misses.
-	primaryWidgetID := ""
-	if len(p.widgetIDs) > 0 {
-		primaryWidgetID = p.widgetIDs[0]
-	}
-
-	// Run script for each workDir and update per-workDir output cache.
+	// Run script once per widget per workDir for correct per-widget output.
+	// Multi-widget plugins need XBOT_WIDGET_ID set per widget so they can
+	// branch on it and produce different content for each slot.
 	for _, wd := range workDirs {
-		output, err := p.runScript(wd, primaryWidgetID)
-		if err != nil {
-			p.logger().Errorf("script execution failed for %s: %v", wd, err)
-			continue
-		}
 		p.outputMu.Lock()
 		if p.outputs == nil {
 			p.outputs = make(map[string]map[string]string)
@@ -420,13 +443,18 @@ func (p *scriptPlugin) runAndUpdate() {
 		if p.outputs[wd] == nil {
 			p.outputs[wd] = make(map[string]string)
 		}
-		// Store the same output for ALL widgets of this plugin.
-		// The per-widget render paths will re-run with specific widgetID
-		// if the script needs different output per widget.
-		for _, wid := range p.widgetIDs {
-			p.outputs[wd][wid] = output
-		}
 		p.outputMu.Unlock()
+
+		for _, wid := range p.widgetIDs {
+			output, err := p.runScript(wd, wid)
+			if err != nil {
+				p.logger().Errorf("script execution failed for %s/%s: %v", wd, wid, err)
+				continue
+			}
+			p.outputMu.Lock()
+			p.outputs[wd][wid] = output
+			p.outputMu.Unlock()
+		}
 	}
 
 	// Change detection: only notify if any output actually changed.
@@ -644,6 +672,7 @@ func (p *scriptPlugin) runScript(workDir, widgetID string) (string, error) {
 		env = append(env, "XBOT_WIDGET_ID="+widgetID)
 	}
 	if hp != nil {
+		env = append(env, "XBOT_HOOK_EVENT="+string(hp.Event))
 		if hp.ToolName != "" {
 			env = append(env, "XBOT_TOOL_NAME="+hp.ToolName)
 		}
@@ -691,6 +720,59 @@ func (p *scriptPlugin) runScript(workDir, widgetID string) (string, error) {
 	// Default: use first line as widget content
 	lines := strings.SplitN(trimmed, "\n", 2)
 	return lines[0], nil
+}
+
+// runCommand invokes the script as a command handler. Sets XBOT_COMMAND_NAME
+// and XBOT_COMMAND_ARGS environment variables so the script can branch on them.
+// Returns the full stdout as the command response.
+func (p *scriptPlugin) runCommand(cmdName, args string) (string, error) {
+	// Resolve platform-specific entry command
+	entry := p.resolvedEntry()
+
+	// Split entry into command and args (safe shell-free splitting)
+	parts := strings.Fields(entry)
+	if len(parts) == 0 {
+		return "", fmt.Errorf("empty entry command")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	// Resolve the script path relative to the plugin directory.
+	if len(parts) > 1 && !filepath.IsAbs(parts[1]) {
+		parts[1] = filepath.Join(p.dir, parts[1])
+		cmd = exec.CommandContext(ctx, parts[0], parts[1:]...)
+	}
+
+	// Use the plugin context's working directory
+	workDir := ""
+	if p.pctx != nil {
+		workDir = p.pctx.WorkingDir()
+	}
+	if workDir != "" {
+		if _, err := os.Stat(workDir); err == nil {
+			cmd.Dir = workDir
+		}
+	}
+
+	// Inject command-specific environment variables
+	env := os.Environ()
+	env = append(env, "XBOT_COMMAND_NAME="+cmdName)
+	env = append(env, "XBOT_COMMAND_ARGS="+args)
+	if workDir != "" {
+		env = append(env, "XBOT_WORK_DIR="+workDir)
+	}
+	cmd.Env = env
+
+	out, err := cmd.Output()
+	if err != nil {
+		p.logger().Errorf("runCommand(%s) failed: %v", cmdName, err)
+		return "", fmt.Errorf("command script %q: %w", entry, err)
+	}
+	p.logger().Debugf("runCommand(%s) output: %s", cmdName, strings.TrimSpace(string(out)))
+
+	return strings.TrimSpace(string(out)), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/plugin/sdk_test.go
+++ b/plugin/sdk_test.go
@@ -383,6 +383,19 @@ func (c *sdkMockContext) HookCallCount() int64                                  
 func (c *sdkMockContext) SetValue(key string, value any)                            {}
 func (c *sdkMockContext) GetValue(key string) (any, bool)                           { return nil, false }
 func (c *sdkMockContext) RegisterChannelProvider(provider any) error                { return nil }
+func (c *sdkMockContext) RegisterCommand(name string, description string, handler PluginCommandHandler) error {
+	return nil
+}
+func (c *sdkMockContext) ScheduleCron(spec CronContribution) (string, error) { return "", nil }
+func (c *sdkMockContext) CancelCron(jobID string) error                      { return nil }
+func (c *sdkMockContext) ContributeTheme(id string, themeData []byte) error  { return nil }
+func (c *sdkMockContext) RegisterOverlay(id string, provider OverlayProvider) error {
+	return nil
+}
+func (c *sdkMockContext) ShowOverlay(id string) error                           { return nil }
+func (c *sdkMockContext) HideOverlay() error                                    { return nil }
+func (c *sdkMockContext) Notify(level NotificationLevel, title, message string) {}
+func (c *sdkMockContext) PlaySound(sound SoundID)                               {}
 
 type sdkMockLogger struct {
 	entries []sdkLogEntry

--- a/plugin/widget.go
+++ b/plugin/widget.go
@@ -33,6 +33,11 @@ type WidgetRegistry struct {
 	debounceMu    sync.Mutex
 	debounceTimer *time.Timer
 	debounceDur   time.Duration // 0 = no debounce (immediate notify)
+
+	// suppress prevents OnUpdated callbacks from firing.
+	// Set to true during batch operations (e.g. ReloadAll) to avoid
+	// flooding the WebSocket sendCh with intermediate widget states.
+	suppress atomic.Bool
 }
 
 // SetDebounce configures the debounce interval for OnUpdated notifications.
@@ -42,6 +47,19 @@ func (r *WidgetRegistry) SetDebounce(d time.Duration) {
 	r.mu.Lock()
 	r.debounceDur = d
 	r.mu.Unlock()
+}
+
+// SuppressUpdates disables OnUpdated callbacks and returns a function that
+// re-enables them and fires a single update. Use during batch operations
+// (e.g. ReloadAll) to prevent flooding downstream channels.
+func (r *WidgetRegistry) SuppressUpdates() (done func()) {
+	r.suppress.Store(true)
+	return func() {
+		r.suppress.Store(false)
+		// Fire after suppress is off, but asynchronously so the caller
+		// (typically an RPC handler) can send its response first.
+		go r.FireUpdated()
+	}
 }
 
 // NotifyUpdated triggers the OnUpdated callback (with debounce if configured)
@@ -61,6 +79,9 @@ func (r *WidgetRegistry) NotifyUpdated() {
 // Use this after direct CWD changes (e.g. Cd) where widget content was already
 // regenerated via RefreshWorkDir → OnWorkDirChanged and should be pushed now.
 func (r *WidgetRegistry) FireUpdated() {
+	if r.suppress.Load() {
+		return
+	}
 	r.mu.RLock()
 	fn := r.onUpdated
 	r.mu.RUnlock()
@@ -131,6 +152,9 @@ func (r *WidgetRegistry) OnUpdated(fn func()) {
 }
 
 func (r *WidgetRegistry) notifyUpdated() {
+	if r.suppress.Load() {
+		return
+	}
 	r.mu.RLock()
 	fn := r.onUpdated
 	dur := r.debounceDur

--- a/serverapp/rpc_table.go
+++ b/serverapp/rpc_table.go
@@ -1139,10 +1139,15 @@ func registerPluginHandlers(t RPCTable, h *RPCContext) {
 		if pm == nil {
 			return nil, fmt.Errorf("plugin system not available")
 		}
-		if err := pm.ReloadAll(context.Background()); err != nil {
-			return nil, err
-		}
-		return map[string]string{"status": "ok"}, nil
+		// Run reload asynchronously so the RPC returns immediately.
+		// ReloadAll can take a while (plugin deactivation/activation,
+		// script startup, etc.) and should not block the RPC channel.
+		go func() {
+			if err := pm.ReloadAll(context.Background()); err != nil {
+				log.WithError(err).Error("Async plugin reload failed")
+			}
+		}()
+		return map[string]string{"status": "started"}, nil
 	})
 
 	t["plugin_install"] = rpc1(func(ctx context.Context, p struct {

--- a/serverapp/rpc_table.go
+++ b/serverapp/rpc_table.go
@@ -1139,15 +1139,22 @@ func registerPluginHandlers(t RPCTable, h *RPCContext) {
 		if pm == nil {
 			return nil, fmt.Errorf("plugin system not available")
 		}
-		// Run reload asynchronously so the RPC returns immediately.
-		// ReloadAll can take a while (plugin deactivation/activation,
-		// script startup, etc.) and should not block the RPC channel.
+		// Run ReloadAll with timeout — typically <5s, 30s max.
+		// Since this RPC is dispatched from a concurrent agent command
+		// (not readPump), synchronous execution does not cause TCP deadlock.
+		resultCh := make(chan error, 1)
 		go func() {
-			if err := pm.ReloadAll(context.Background()); err != nil {
-				log.WithError(err).Error("Async plugin reload failed")
-			}
+			resultCh <- pm.ReloadAll(context.Background())
 		}()
-		return map[string]string{"status": "started"}, nil
+		select {
+		case err := <-resultCh:
+			if err != nil {
+				return nil, err
+			}
+			return map[string]string{"status": "ok"}, nil
+		case <-time.After(30 * time.Second):
+			return map[string]string{"status": "timeout", "message": "reload still in progress"}, nil
+		}
 	})
 
 	t["plugin_install"] = rpc1(func(ctx context.Context, p struct {


### PR DESCRIPTION
## 6 核心扩展点

为插件系统新增 6 个通用原语，让所有趣味功能都能以 Script 插件（bash）实现：

- **命令注册** — PluginContext.RegisterCommand + script plugin manifest `contributes.commands` + Palette/Tab completion
- **Cron 调度** — PluginContext.ScheduleCron/CancelCron
- **UI 槽位** — titleBarLeft/Right、statusBarLeft/Right、footer 完整接入 widget 渲染
- **主题贡献** — PluginContributes.Themes + 动态加载到主题系统
- **Overlay 系统** — PluginContext.RegisterOverlay/ShowOverlay
- **通知/音效** — PluginContext.Notify/PlaySound

## 7 个趣味插件

全部是纯 Script 插件（bash），无需编译，`~/.xbot/plugins/` 目录：

| 插件 | 功能 | 体验 |
|------|------|------|
| pet-mascot | 电子宠物 | `/pet feed/play/battle`，4 阶段进化 |
| xbot-achievements | 成就系统 | 13 成就，Hook 自动追踪 |
| daily-jokes | 每日一梗 | `/joke`，工作日 9am 自动推送 |
| mini-games | 小游戏合集 | `/tictactoe`（minimax AI）、`/2048`、`/quiz` |
| theme-party | 主题派对 | 10 主题（Dracula/Nord/Tokyo Night 等） |
| dashboard | 终端仪表盘 | CPU 柱状图/Git 统计/番茄钟 widget |
| time-capsule | 时间胶囊 | `/capsule` 定时给未来自己发消息 |

## Bug 修复

- Script 插件激活不再强制要求 UI widget
- `contributes.hooks` 现在被 script runtime 处理
- 注入 `XBOT_HOOK_EVENT` 环境变量
- 插件命令输出统一走 Markdown（glamour 渲染）
- 多 widget 脚本插件每次运行独立传 `XBOT_WIDGET_ID`
- Tab 补全通过 `getCommandCompletions()` 统一包含插件命令
- CommandRegistry 加 `sync.RWMutex` 线程安全
- AugmentTitleBar 内容超出宽度自动截断
- WidgetRegistry.SuppressUpdates() 阻止 ReloadAll 期间灌满 sendCh
- `/plugin reload-all` 改为 agent 内置命令（不走 RPC，避免 TCP 死锁）

22 files changed, +1367
