### PR TITLE
chore: add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,69 @@
+---
+name: 🐛 Bug 报告 (Markdown)
+about: 通过 CLI / gh 命令行报告 bug
+title: "[Bug] "
+labels: ["bug"]
+---
+
+<!-- 请按以下模板填写，删除 <> 中的占位符提示。提交前先搜索已有 issue 确认未被重复报告。 -->
+
+## 受影响的组件
+
+<!-- 勾选 [x] 或列出具体模块 -->
+- [ ] 🖥️ CLI / TUI（终端界面）
+- [ ] 📱 Feishu（飞书）
+- [ ] 💬 QQ / NapCat
+- [ ] 🌐 Web
+- [ ] 🤖 LLM / 订阅系统（Subscription）
+- [ ] 🧠 Memory（记忆系统）
+- [ ] 🔌 Plugin（插件系统）
+- [ ] 🏗️ Runner / Sandbox（沙箱）
+- [ ] 🔄 SubAgent / Group Chat
+- [ ] 🔧 Tool（内置工具：Shell / Read / Edit / WebSearch 等）
+- [ ] ⏱️ Cron（定时任务）
+- [ ] 🪝 Hooks（钩子）
+- [ ] 📚 Documentation（文档）
+- [ ] ❓ 其他
+
+## 运行模式
+
+<!-- Standalone（CLI 本地模式） / Server（服务器模式） / 不确定 -->
+<mode>
+
+## Bug 描述
+
+<description>
+
+## 复现步骤
+
+1. <step 1>
+2. <step 2>
+3. <step 3>
+
+## 预期行为
+
+<expected>
+
+## 实际行为
+
+<actual>
+
+## 日志 / 错误信息
+
+<!-- CLI 按 Ctrl+L 查看日志路径；Server 模式查看 ~/.xbot/logs/ -->
+<logs>
+
+## 环境信息
+
+- **操作系统**: <os>
+- **xbot 版本**: <!-- 运行 `xbot version` 获取 --> <version>
+- **LLM 提供商和模型**: <!-- 可选 --> <provider/model>
+
+## 配置信息（可选）
+
+<!-- 相关的 ~/.xbot/config.json 片段，请移除 API key 和敏感信息 -->
+<config>
+
+## 补充信息
+
+<screenshots or other context>

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,134 @@
+name: 🐛 Bug 报告
+description: 报告一个 bug 或异常行为
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢你报告 bug！请尽量填写以下信息，帮助我们快速定位问题。
+
+        > 💡 提交前请先 [搜索已有 issues](https://github.com/ai-pivot/xbot/issues?q=is%3Aissue) 确认未被重复报告。
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: 受影响的组件
+      description: 选择出问题的功能模块（可多选）
+      multiple: true
+      options:
+        - 🖥️ CLI / TUI（终端界面）
+        - 📱 Feishu（飞书）
+        - 💬 QQ / NapCat
+        - 🌐 Web
+        - 🤖 LLM / 订阅系统（Subscription）
+        - 🧠 Memory（记忆系统）
+        - 🔌 Plugin（插件系统）
+        - 🏗️ Runner / Sandbox（沙箱）
+        - 🔄 SubAgent / Group Chat
+        - 🔧 Tool（内置工具：Shell / Read / Edit / WebSearch 等）
+        - ⏱️ Cron（定时任务）
+        - 🪝 Hooks（钩子）
+        - 📚 Documentation（文档）
+        - ❓ 其他
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: 运行模式
+      options:
+        - Standalone（CLI 本地模式）
+        - Server（服务器模式 — CLI 远程连接 / Feishu / QQ / Web）
+        - 不确定
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug 描述
+      description: 简要描述遇到了什么问题。
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: 复现步骤
+      description: 详细的重现步骤，帮助我们复现问题。
+      placeholder: |
+        1. 启动 xbot（'xbot-cli' 或 'xbot serve'）
+        2. ...
+        3. ...
+        4. 看到错误
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 预期行为
+      description: 你期望发生什么？
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际行为
+      description: 实际发生了什么？
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 日志 / 错误信息
+      description: 相关的日志输出或错误堆栈。CLI 模式按 `Ctrl+L` 可查看日志文件路径；Server 模式查看 `~/.xbot/logs/`。
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: 操作系统
+      placeholder: macOS 14.4 / Ubuntu 22.04 / Windows 11 / ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: xbot 版本
+      description: 运行 `xbot version` 或 `xbot-cli version` 获取版本号。
+      placeholder: v0.x.x
+    validations:
+      required: true
+
+  - type: input
+    id: llm-provider
+    attributes:
+      label: LLM 提供商和模型
+      placeholder: OpenAI / gpt-4o, DeepSeek / deepseek-chat, Anthropic / claude-3.5-sonnet, ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: 配置信息（可选）
+      description: 相关的 `~/.xbot/config.json` 配置片段（**请移除 API key 和敏感信息**）。
+      render: json
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 补充信息
+      description: 截图、相关的 config 片段、或任何其他有助于理解问题的信息。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Discussions 讨论区
+    url: https://github.com/ai-pivot/xbot/discussions
+    about: 提问、想法讨论、使用咨询请发到 Discussions 讨论区，而不是 Issue。
+  - name: 📖 文档站点
+    url: https://ai-pivot.github.io/xbot/
+    about: 查看完整文档（安装配置、渠道接入、插件开发等）。
+  - name: 🐛 已知问题列表
+    url: https://github.com/ai-pivot/xbot/issues?q=is%3Aopen+label%3Abug
+    about: 提交 Bug 前请先查看是否已有相同问题的 Issue。

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,45 @@
+---
+name: ✨ 功能请求 (Markdown)
+about: 通过 CLI / gh 命令行提出功能建议
+title: "[Feat] "
+labels: ["enhancement"]
+---
+
+<!-- 请按以下模板填写，删除 <> 中的占位符提示。提交前先搜索已有 issue 确认未被重复提议。 -->
+
+## 相关组件
+
+<!-- 勾选 [x] 或列出具体模块 -->
+- [ ] 🖥️ CLI / TUI（终端界面）
+- [ ] 📱 Feishu（飞书）
+- [ ] 💬 QQ / NapCat
+- [ ] 🌐 Web
+- [ ] 🤖 LLM / 订阅系统（Subscription）
+- [ ] 🧠 Memory（记忆系统）
+- [ ] 🔌 Plugin（插件系统）
+- [ ] 🏗️ Runner / Sandbox（沙箱）
+- [ ] 🔄 SubAgent / Group Chat
+- [ ] 🔧 Tool（内置工具）
+- [ ] ⏱️ Cron（定时任务）
+- [ ] 🪝 Hooks（钩子）
+- [ ] 📚 Documentation（文档）
+- [ ] ❓ 其他 / 全局
+
+## 问题背景
+
+<!-- 这个功能是为了解决什么问题？当前遇到的痛点或不便 -->
+<problem>
+
+## 期望的解决方案
+
+<solution>
+
+## 考虑过的替代方案
+
+<!-- 可选 -->
+<alternatives>
+
+## 补充信息
+
+<!-- 参考链接、截图等 -->
+<context>

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: ✨ 功能请求
+description: 提议一个新功能或改进
+title: "[Feat] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢你的功能建议！请描述你希望 xbot 新增或改进的功能。
+
+        > 💡 提交前请先 [搜索已有 issues](https://github.com/ai-pivot/xbot/issues?q=is%3Aissue+label%3Aenhancement) 确认未被重复提议。
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: 相关组件
+      description: 这个功能主要涉及哪个模块？（可多选）
+      multiple: true
+      options:
+        - 🖥️ CLI / TUI（终端界面）
+        - 📱 Feishu（飞书）
+        - 💬 QQ / NapCat
+        - 🌐 Web
+        - 🤖 LLM / 订阅系统（Subscription）
+        - 🧠 Memory（记忆系统）
+        - 🔌 Plugin（插件系统）
+        - 🏗️ Runner / Sandbox（沙箱）
+        - 🔄 SubAgent / Group Chat
+        - 🔧 Tool（内置工具）
+        - ⏱️ Cron（定时任务）
+        - 🪝 Hooks（钩子）
+        - 📚 Documentation（文档）
+        - ❓ 其他 / 全局
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 问题背景
+      description: 你的功能请求是为了解决什么问题？请描述当前遇到的痛点或不便。
+      placeholder: 我在使用 xbot 时，每次...都很麻烦，因为...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 期望的解决方案
+      description: 你希望 xbot 怎么做？请尽可能具体地描述。
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 考虑过的替代方案
+      description: 你是否考虑过其他实现方式或 workaround？为什么觉得它们不够好？
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 补充信息
+      description: 参考链接、截图、或任何其他有助于理解这个功能的信息。
+    validations:
+      required: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Config: `~/.xbot/config.json`, env var overrides
 - Subscriptions: `~/.xbot/config.json` (CLI) or DB `user_llm_subscriptions` (Server) — the single source of truth for LLM config
 - Pre-commit: gofmt → golangci-lint → go build → go test
+- Issue templates: `.github/ISSUE_TEMPLATE/` — YAML forms (`*.yml`) for web UI, Markdown templates (`*.md`) for CLI/AI use with `gh issue create --template`. AI agents MUST read and fill the `.md` templates (not `.yml`) since YAML Issue Forms are web-UI-only and cannot be submitted via `gh issue create --body`.
 
 ## Knowledge Files
 


### PR DESCRIPTION
## 概述

为项目添加结构化的 GitHub Issue 模板，帮助用户更规范地报告 bug 和提出功能建议。

## 新增内容

### 📋 
基于 GitHub Issue Forms 的结构化 Bug 报告表单，包含项目专属字段：

- **受影响的组件**（多选下拉）：CLI/TUI、Feishu、QQ/NapCat、Web、LLM/订阅系统、Memory、Plugin、Runner/Sandbox、SubAgent/Group Chat、Tool、Cron、Hooks、文档等 — 覆盖 xbot 所有功能模块
- **运行模式**：Standalone（CLI 本地）/ Server（服务器模式）
- Bug 描述、复现步骤、预期/实际行为
- 日志/错误信息（带 shell 语法高亮）
- 环境信息：操作系统、xbot 版本、LLM 提供商和模型
- 配置信息（JSON 高亮，提醒移除敏感信息）

### 💡 
功能请求表单，包含：

- 相关组件多选
- 问题背景、期望方案、替代方案

### ⚙️ 
Issue 选择器配置，提供引导链接：

- Discussions 讨论区（提问/讨论导向）
- 文档站点
- 已知 Bug 列表

## 设计考量

- 使用 **YAML Issue Forms**（而非 Markdown 模板），提供下拉选择、必填校验，降低用户填写门槛
- 组件选项根据 xbot 实际架构（多渠道 + 插件 + 沙箱 + SubAgent）定制，非通用模板
- 中文为主，匹配项目主要用户群体（飞书/QQ 渠道面向中文用户）
- Bug 模板要求版本号和操作系统必填，便于复现环境差异问题