### PR TITLE
feat(cli): add model tier settings to /settings panel

### DIFF
--- a/channel/cli/cli_panel_settings.go
+++ b/channel/cli/cli_panel_settings.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 	ch "xbot/channel"
+	"xbot/protocol"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
@@ -68,6 +69,21 @@ func (m *cliModel) openSettingsPanel(schema []ch.SettingDefinition, values map[s
 			def.ReadOnly = true
 		}
 	}
+
+	// Inject cross-subscription model options for tier selectors.
+	// Tier values are stored as "subID|model" — options must match this format
+	// so the combo dropdown can pre-select the current value.
+	if m.channel != nil && m.channel.modelLister != nil {
+		entries := m.channel.modelLister.ListAllModelEntries()
+		tierKeys := map[string]bool{"tier_vanguard": true, "tier_balance": true, "tier_swift": true}
+		for i := range m.panelState.schemaFull {
+			def := &m.panelState.schemaFull[i]
+			if !tierKeys[def.Key] {
+				continue
+			}
+			def.Options = tierModelOptions(entries)
+		}
+	}
 	// Auto-fill base_url on panel open if provider has a known default
 	// and base_url is currently empty (typical for setup wizard).
 	if provider := m.panelState.values["llm_provider"]; provider != "" {
@@ -96,6 +112,25 @@ func (m *cliModel) openSettingsPanel(schema []ch.SettingDefinition, values map[s
 	ta.SetHeight(1)
 	ta.CharLimit = 200
 	m.panelState.editTA = ta
+}
+
+// tierModelOptions builds SettingOption list for tier selectors.
+// Values are encoded as "subID|model" (or plain "model" when SubID is empty)
+// to match the tier value format stored in DB.
+func tierModelOptions(entries []protocol.ModelEntry) []ch.SettingOption {
+	opts := make([]ch.SettingOption, 0, len(entries))
+	for _, e := range entries {
+		val := e.Model
+		if e.SubID != "" {
+			val = e.SubID + "|" + e.Model
+		}
+		label := e.Model
+		if e.SubName != "" {
+			label = e.Model + " (" + e.SubName + ")"
+		}
+		opts = append(opts, ch.SettingOption{Label: label, Value: val})
+	}
+	return opts
 }
 
 // rebuildVisibleSchema rebuilds panelSchema from panelSchemaFull,
@@ -689,7 +724,15 @@ func (m *cliModel) viewSettingsPanel() string {
 			if cur == "" {
 				displayVal = descStyle.Render(m.locale.PanelNotSet)
 			} else {
+				// Look up label from options for nicer display (e.g. tier selectors
+				// store "subID|model" but should show "model (subname)")
 				displayVal = valueSt.Render(cur)
+				for _, opt := range def.Options {
+					if opt.Value == cur {
+						displayVal = valueSt.Render(opt.Label)
+						break
+					}
+				}
 			}
 			if !def.ReadOnly && len(def.Options) > 0 {
 				displayVal += descStyle.Render(" ▾")

--- a/channel/cli/cli_settings.go
+++ b/channel/cli/cli_settings.go
@@ -21,6 +21,18 @@ import (
 // saveSettings:  dispatches each key to its scope's writer.
 // maxContext:    resolves from subscription.PerModelConfigs[model].MaxContext.
 
+// isTierSettingKey returns true if the key is one of the tier_* settings.
+// Tier settings are registered in AllSettingDefs with ScopeUser but are
+// persisted to DB only — no runtime handler needed. They are stripped from
+// runtimeValues in saveSettings to avoid redundant DB writes in ApplySettings.
+func isTierSettingKey(key string) bool {
+	switch key {
+	case "tier_vanguard", "tier_balance", "tier_swift":
+		return true
+	}
+	return false
+}
+
 // ── read ─────────────────────────────────────────────────────────────
 
 // readSettings returns the current settings values for the /settings panel.
@@ -325,6 +337,11 @@ func (m *cliModel) saveSettings(values map[string]string) {
 			// above via UpdatePerModelConfig. Never pass it to ApplySettings —
 			// that would call SetMaxContextTokens globally and contaminate all models.
 			if k == "max_context_tokens" {
+				continue
+			}
+			// Tier settings already persisted above via settingsSvc. Strip them
+			// to avoid redundant DB write in main.go's ApplySettings loop.
+			if isTierSettingKey(k) {
 				continue
 			}
 			runtimeValues[k] = v

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -551,6 +551,11 @@ func LocaleZH() *UILocale {
 			// Subscription management entry (display-only, triggers quick switch)
 			{Key: "subscription_manage", Label: "📦 订阅管理", Type: SettingTypeText, Category: "模型与推理"},
 
+			// ── 模型等级（SubAgent 全局设置，跨订阅生效）──
+			{Key: "tier_vanguard", Label: "Vanguard（强）", Description: "SubAgent 指定 vanguard 等级时使用的模型，跨所有订阅选择", Type: SettingTypeCombo, Category: "模型等级 (SubAgent)"},
+			{Key: "tier_balance", Label: "Balance（中）", Description: "SubAgent 指定 balance 等级时使用的模型，跨所有订阅选择", Type: SettingTypeCombo, Category: "模型等级 (SubAgent)"},
+			{Key: "tier_swift", Label: "Swift（弱）", Description: "SubAgent 指定 swift 等级时使用的模型，跨所有订阅选择", Type: SettingTypeCombo, Category: "模型等级 (SubAgent)"},
+
 			// ── Agent 行为（用户级）──
 			{
 				Key: "enable_stream", Label: "流式输出", Description: "使用流式 API 调用 LLM（默认开启）",
@@ -955,6 +960,11 @@ func localeEN() *UILocale {
 			// Subscription management entry (display-only, triggers quick switch)
 			{Key: "subscription_manage", Label: "📦 Subscriptions", Type: SettingTypeText, Category: "Model & Reasoning"},
 
+			// ── Model tiers (SubAgent global, cross-subscription) ──
+			{Key: "tier_vanguard", Label: "Vanguard (strong)", Description: "Model used when SubAgent specifies vanguard tier, selected across all subscriptions", Type: SettingTypeCombo, Category: "Model Tiers (SubAgent)"},
+			{Key: "tier_balance", Label: "Balance (medium)", Description: "Model used when SubAgent specifies balance tier, selected across all subscriptions", Type: SettingTypeCombo, Category: "Model Tiers (SubAgent)"},
+			{Key: "tier_swift", Label: "Swift (weak)", Description: "Model used when SubAgent specifies swift tier, selected across all subscriptions", Type: SettingTypeCombo, Category: "Model Tiers (SubAgent)"},
+
 			// ── Agent behavior (user-level) ──
 			{
 				Key: "enable_stream", Label: "Stream Output", Description: "Use streaming API for LLM calls (on by default)",
@@ -1358,6 +1368,11 @@ func localeJA() *UILocale {
 			},
 			// Subscription management entry (display-only, triggers quick switch)
 			{Key: "subscription_manage", Label: "📦 サブスクリプション管理", Type: SettingTypeText, Category: "モデルと推論"},
+
+			// ── モデルティア（SubAgent グローバル設定、サブスクリプション横断）──
+			{Key: "tier_vanguard", Label: "Vanguard（強）", Description: "SubAgent が vanguard ティアを指定した場合に使用するモデル、全サブスクリプションから選択", Type: SettingTypeCombo, Category: "モデルティア (SubAgent)"},
+			{Key: "tier_balance", Label: "Balance（中）", Description: "SubAgent が balance ティアを指定した場合に使用するモデル、全サブスクリプションから選択", Type: SettingTypeCombo, Category: "モデルティア (SubAgent)"},
+			{Key: "tier_swift", Label: "Swift（弱）", Description: "SubAgent が swift ティアを指定した場合に使用するモデル、全サブスクリプションから選択", Type: SettingTypeCombo, Category: "モデルティア (SubAgent)"},
 
 			// ── Agent 動作（ユーザーレベル）──
 			{

--- a/channel/setting_keys.go
+++ b/channel/setting_keys.go
@@ -88,6 +88,14 @@ var AllSettingDefs = []SettingDef{
 	{Key: "thinking_mode", Scope: ScopeUser, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Enable thinking/reasoning mode (global toggle)", ValidValues: "|enabled|disabled", DefaultValue: ""},
 	{Key: "api_type", Scope: ScopeSubscription, Source: SourceLLMConfig, Permission: PermPersistent, AIDescription: "OpenAI API endpoint type: chat_completions or responses", ValidValues: "chat_completions|responses", DefaultValue: "chat_completions"},
 
+	// ── Model tier settings (user_settings DB, consumed by agent tier resolver) ──
+	// Stored under the "cli" channel. Values use "subID|model" format. Not Runtime
+	// (no.ApplyConfig/ApplyAgent handler needed — the agent reads them lazily via
+	// getSetting at SubAgent invocation time).
+	{Key: "tier_vanguard", Scope: ScopeUser, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Model used for SubAgent vanguard tier (cross-subscription)", ValidValues: "subID|model or plain model name", DefaultValue: ""},
+	{Key: "tier_balance", Scope: ScopeUser, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Model used for SubAgent balance tier (cross-subscription)", ValidValues: "subID|model or plain model name", DefaultValue: ""},
+	{Key: "tier_swift", Scope: ScopeUser, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Model used for SubAgent swift tier (cross-subscription)", ValidValues: "subID|model or plain model name", DefaultValue: ""},
+
 	// ── User-scoped settings (user_settings DB) ──
 	{Key: "enable_stream", Scope: ScopeUser, Source: SourceUserDB, Permission: PermTransient, AIDescription: "Show LLM output token-by-token", ValidValues: "true|false", DefaultValue: "true"},
 	{Key: "enable_masking", Scope: ScopeUser, Source: SourceUserDB, Permission: PermPersistent, AIDescription: "Hide old tool results behind 📂 markers", ValidValues: "true|false", DefaultValue: "true"},
@@ -218,12 +226,17 @@ func IsUserScopedSettingKey(key string) bool {
 }
 
 // IsKnownNonRuntimeKey returns true for keys that don't need runtime handling
-// (UI-only, persistence-only, or action keys). These are keys NOT registered
-// in AllSettingDefs. Both CLI and Server use this to avoid warning logs for
-// known harmless keys.
+// (UI-only, persistence-only, action keys, or registered keys with Runtime=false).
+// Keys NOT registered in AllSettingDefs are treated as known non-runtime.
+// Keys registered with Runtime=false also don't need a handler.
+// Both CLI and Server use this to avoid warning logs for known harmless keys.
 func IsKnownNonRuntimeKey(key string) bool {
-	_, inDefs := allSettingDefsMap[key]
-	return !inDefs
+	d, ok := allSettingDefsMap[key]
+	if !ok {
+		return true // Not in defs at all — known harmless (UI-only, action, etc.)
+	}
+	// In defs but Runtime=false — doesn't need runtime handling (DB persistence only)
+	return !d.Runtime
 }
 
 // IsGlobalScopedSettingKey returns true if the key has ScopeGlobal.


### PR DESCRIPTION
## Summary

CLI settings panel (`/settings`) was missing model tier configuration (Vanguard/Balance/Swift) — only Feishu had it. This PR adds 3 combo fields under a new **Model Tiers (SubAgent)** category, with cross-subscription model options injected dynamically.

## Changes

| File | Change |
|------|--------|
| `channel/i18n.go` | Add `tier_vanguard`/`tier_balance`/`tier_swift` SettingTypeCombo fields to all 3 locales (zh/en/ja) |
| `channel/setting_keys.go` | Register tier keys in `AllSettingDefs` as `ScopeUser` (`Runtime=false`) + fix `IsKnownNonRuntimeKey` to return true for `Runtime=false` keys |
| `channel/cli/cli_panel_settings.go` | Inject dynamic combo options from `ListAllModelEntries()` + improve Combo display to show label instead of raw value |
| `channel/cli/cli_settings.go` | Add `isTierSettingKey` filter to strip tier keys from `runtimeValues` (avoids redundant DB write) |

## How it works

1. **Schema**: 3 combo fields added under "模型等级 (SubAgent)" category in all locales
2. **Options injection**: `openSettingsPanel` calls `modelLister.ListAllModelEntries()` to populate combo options with `subID|model` values and `model (subname)` labels — same format as the Feishu tier selectors
3. **Read**: `readSettings` step 2 automatically picks up tier keys from `GetSettings` since they are now `ScopeUser` in `AllSettingDefs`
4. **Write**: `saveSettings` step 3 automatically persists tier keys via `settingsSvc.SetSetting` (same path as `thinking_mode`)
5. **Runtime**: Tier keys are stripped from `runtimeValues` (step 4) to avoid redundant DB write in `main.go` ApplySettings — the agent reads them lazily via `getSetting()` at SubAgent invocation time

## No new interfaces needed

The existing `settingsSvc` + `modelLister` wiring handles everything. Tier values are stored in the same `user_settings` DB table under the same `"cli"` channel that the agent tier resolver reads (`agent/llm_factory.go:resolveTierModel`).

## Bonus fix

`IsKnownNonRuntimeKey` previously returned `false` for any key in `AllSettingDefs`, causing spurious "unhandled setting key" warnings in `ApplyRuntimeSettings` for `Runtime=false` keys. Fixed to return `true` when `!d.Runtime`.

## Test

- `go build ./...` — pass
- `go test ./...` — all packages pass
- `TestCLISettingScope_SettingsSchemaKeysAreClassified` — pass (tier keys now classified as ScopeUser)
