### PR TITLE
feat: auto-discover skills from ~/.agents/skills and project .agents/skills

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -75,37 +75,46 @@ func resolveMemoryProvider(cfg string) string {
 	return cfg
 }
 
+// evalRealPath resolves a path to its real absolute path, following symlinks.
+// Falls back to filepath.Abs on error.
+func evalRealPath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return p
+	}
+	real, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return abs
+	}
+	return real
+}
+
 func resolveGlobalSkillsDirs(skillsDir string) []string {
 	var dirs []string
 
 	// 1. Add the configured/default xbot skills dir (~/.xbot/skills)
 	if skillsDir != "" {
-		abs, err := filepath.Abs(skillsDir)
-		if err == nil {
-			dirs = append(dirs, abs)
-		}
+		dirs = append(dirs, evalRealPath(skillsDir))
 	}
 
 	// 2. Auto-detect Codex/Cursor-compatible global skills dir: ~/.agents/skills
 	//    This allows xbot to automatically pick up skills installed by Codex, Cursor,
 	//    or other agents that follow the ~/.agents/ convention, without requiring symlinks.
-	//    Only add it if the directory actually exists.
+	//    Only add it if the directory actually exists, and deduplicate by real path
+	//    (in case skillsDir is a symlink pointing to ~/.agents/skills or vice versa).
 	if home, err := os.UserHomeDir(); err == nil {
 		agentsSkillsDir := filepath.Join(home, ".agents", "skills")
 		if info, err := os.Stat(agentsSkillsDir); err == nil && info.IsDir() {
-			abs, err := filepath.Abs(agentsSkillsDir)
-			if err == nil {
-				// Avoid duplicates if skillsDir already points here
-				alreadyIncluded := false
-				for _, d := range dirs {
-					if d == abs {
-						alreadyIncluded = true
-						break
-					}
+			real := evalRealPath(agentsSkillsDir)
+			alreadyIncluded := false
+			for _, d := range dirs {
+				if d == real {
+					alreadyIncluded = true
+					break
 				}
-				if !alreadyIncluded {
-					dirs = append(dirs, abs)
-				}
+			}
+			if !alreadyIncluded {
+				dirs = append(dirs, real)
 			}
 		}
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -76,14 +76,41 @@ func resolveMemoryProvider(cfg string) string {
 }
 
 func resolveGlobalSkillsDirs(skillsDir string) []string {
-	if skillsDir == "" {
-		return nil
+	var dirs []string
+
+	// 1. Add the configured/default xbot skills dir (~/.xbot/skills)
+	if skillsDir != "" {
+		abs, err := filepath.Abs(skillsDir)
+		if err == nil {
+			dirs = append(dirs, abs)
+		}
 	}
-	abs, err := filepath.Abs(skillsDir)
-	if err != nil {
-		return nil
+
+	// 2. Auto-detect Codex/Cursor-compatible global skills dir: ~/.agents/skills
+	//    This allows xbot to automatically pick up skills installed by Codex, Cursor,
+	//    or other agents that follow the ~/.agents/ convention, without requiring symlinks.
+	//    Only add it if the directory actually exists.
+	if home, err := os.UserHomeDir(); err == nil {
+		agentsSkillsDir := filepath.Join(home, ".agents", "skills")
+		if info, err := os.Stat(agentsSkillsDir); err == nil && info.IsDir() {
+			abs, err := filepath.Abs(agentsSkillsDir)
+			if err == nil {
+				// Avoid duplicates if skillsDir already points here
+				alreadyIncluded := false
+				for _, d := range dirs {
+					if d == abs {
+						alreadyIncluded = true
+						break
+					}
+				}
+				if !alreadyIncluded {
+					dirs = append(dirs, abs)
+				}
+			}
+		}
 	}
-	return []string{abs}
+
+	return dirs
 }
 
 // metaTools are tools that manage/search other tools — not useful to index.

--- a/agent/agent_helpers_test.go
+++ b/agent/agent_helpers_test.go
@@ -116,7 +116,14 @@ func TestResolveGlobalSkillsDirs(t *testing.T) {
 	// Use a temp HOME directory so tests are deterministic and don't depend on
 	// the host machine's ~/.agents/skills directory.
 	tmpHome := t.TempDir()
+	// Set HOME for Unix/macOS/Linux and USERPROFILE for Windows.
+	// os.UserHomeDir() on Windows checks USERPROFILE first, then HOMEDRIVE+HOMEPATH, then HOME.
+	// On Unix it only checks HOME. Setting both ensures cross-platform coverage.
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	// Also clear HOMEDRIVE/HOMEPATH to prevent them from interfering on Windows.
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
 
 	// Helper to build absolute paths inside tmpHome
 	homePath := func(parts ...string) string {

--- a/agent/agent_helpers_test.go
+++ b/agent/agent_helpers_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -112,40 +113,60 @@ func TestResolveMemoryProvider(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestResolveGlobalSkillsDirs(t *testing.T) {
+	// Detect if ~/.agents/skills exists on this machine (auto-detection target)
+	agentsSkillsExists := false
+	var agentsSkillsAbs string
+	if home, err := os.UserHomeDir(); err == nil {
+		dir := filepath.Join(home, ".agents", "skills")
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			agentsSkillsExists = true
+			agentsSkillsAbs, _ = filepath.Abs(dir)
+		}
+	}
+
 	tests := []struct {
 		name      string
 		skillsDir string
-		want      []string
+		wantLen   int
 	}{
 		{
-			name:      "empty returns nil",
+			name:      "empty returns at least auto-detected dirs",
 			skillsDir: "",
-			want:      nil,
+			wantLen:   map[bool]int{true: 1, false: 0}[agentsSkillsExists],
 		},
 		{
-			name:      "non-empty returns single-element slice",
+			name:      "non-empty includes configured dir plus auto-detected",
 			skillsDir: filepath.Join("path", "to", "skills"),
-			want:      []string{filepath.Join("path", "to", "skills")},
+			wantLen:   map[bool]int{true: 2, false: 1}[agentsSkillsExists],
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := resolveGlobalSkillsDirs(tc.skillsDir)
-			if tc.want == nil {
-				if got != nil {
-					t.Errorf("resolveGlobalSkillsDirs(%q) = %v, want nil", tc.skillsDir, got)
+			if len(got) != tc.wantLen {
+				t.Fatalf("length mismatch: got %d, want %d (got=%v)", len(got), tc.wantLen, got)
+			}
+
+			// If a skillsDir was provided, it should be first
+			if tc.skillsDir != "" && tc.wantLen > 0 {
+				wantAbs, _ := filepath.Abs(tc.skillsDir)
+				if got[0] != wantAbs {
+					t.Errorf("got[0] = %q, want %q", got[0], wantAbs)
 				}
-			} else {
-				if len(got) != len(tc.want) {
-					t.Fatalf("length mismatch: got %d, want %d", len(got), len(tc.want))
-				}
-				// resolveGlobalSkillsDirs calls filepath.Abs, so compare absolute paths
-				wantAbs, _ := filepath.Abs(tc.want[0])
-				for i := range got {
-					if got[i] != wantAbs {
-						t.Errorf("got[%d] = %q, want %q", i, got[i], wantAbs)
+			}
+
+			// If ~/.agents/skills exists, it should be in the result
+			if agentsSkillsExists {
+				found := false
+				for _, d := range got {
+					if d == agentsSkillsAbs {
+						found = true
+						break
 					}
+				}
+				if !found {
+					t.Errorf("expected ~/.agents/skills (%s) to be in result, got %v", agentsSkillsAbs, got)
 				}
 			}
 		})

--- a/agent/agent_helpers_test.go
+++ b/agent/agent_helpers_test.go
@@ -113,64 +113,89 @@ func TestResolveMemoryProvider(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestResolveGlobalSkillsDirs(t *testing.T) {
-	// Detect if ~/.agents/skills exists on this machine (auto-detection target)
-	agentsSkillsExists := false
-	var agentsSkillsAbs string
-	if home, err := os.UserHomeDir(); err == nil {
-		dir := filepath.Join(home, ".agents", "skills")
-		if info, err := os.Stat(dir); err == nil && info.IsDir() {
-			agentsSkillsExists = true
-			agentsSkillsAbs, _ = filepath.Abs(dir)
+	// Use a temp HOME directory so tests are deterministic and don't depend on
+	// the host machine's ~/.agents/skills directory.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// Helper to build absolute paths inside tmpHome
+	homePath := func(parts ...string) string {
+		all := append([]string{tmpHome}, parts...)
+		return filepath.Join(all...)
+	}
+
+	t.Run("empty skillsDir, no ~/.agents/skills → empty result", func(t *testing.T) {
+		got := resolveGlobalSkillsDirs("")
+		if len(got) != 0 {
+			t.Fatalf("expected empty slice, got %v", got)
 		}
-	}
+	})
 
-	tests := []struct {
-		name      string
-		skillsDir string
-		wantLen   int
-	}{
-		{
-			name:      "empty returns at least auto-detected dirs",
-			skillsDir: "",
-			wantLen:   map[bool]int{true: 1, false: 0}[agentsSkillsExists],
-		},
-		{
-			name:      "non-empty includes configured dir plus auto-detected",
-			skillsDir: filepath.Join("path", "to", "skills"),
-			wantLen:   map[bool]int{true: 2, false: 1}[agentsSkillsExists],
-		},
-	}
+	t.Run("non-empty skillsDir, no ~/.agents/skills → single entry", func(t *testing.T) {
+		fakeSkillsDir := homePath("xbot-skills")
+		os.MkdirAll(fakeSkillsDir, 0755)
+		got := resolveGlobalSkillsDirs(fakeSkillsDir)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 entry, got %d: %v", len(got), got)
+		}
+		want := evalRealPath(fakeSkillsDir)
+		if got[0] != want {
+			t.Errorf("got[0] = %q, want %q", got[0], want)
+		}
+	})
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := resolveGlobalSkillsDirs(tc.skillsDir)
-			if len(got) != tc.wantLen {
-				t.Fatalf("length mismatch: got %d, want %d (got=%v)", len(got), tc.wantLen, got)
-			}
+	t.Run("~/.agents/skills exists without skillsDir → auto-detected", func(t *testing.T) {
+		agentsDir := homePath(".agents", "skills")
+		os.MkdirAll(agentsDir, 0755)
+		defer os.RemoveAll(agentsDir)
+		got := resolveGlobalSkillsDirs("")
+		if len(got) != 1 {
+			t.Fatalf("expected 1 entry (auto-detected), got %d: %v", len(got), got)
+		}
+		want := evalRealPath(agentsDir)
+		if got[0] != want {
+			t.Errorf("got[0] = %q, want %q", got[0], want)
+		}
+	})
 
-			// If a skillsDir was provided, it should be first
-			if tc.skillsDir != "" && tc.wantLen > 0 {
-				wantAbs, _ := filepath.Abs(tc.skillsDir)
-				if got[0] != wantAbs {
-					t.Errorf("got[0] = %q, want %q", got[0], wantAbs)
-				}
-			}
+	t.Run("both dirs exist → two entries", func(t *testing.T) {
+		agentsDir := homePath(".agents", "skills")
+		os.MkdirAll(agentsDir, 0755)
+		defer os.RemoveAll(agentsDir)
+		fakeSkillsDir := homePath("xbot-skills-2")
+		os.MkdirAll(fakeSkillsDir, 0755)
+		got := resolveGlobalSkillsDirs(fakeSkillsDir)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 entries, got %d: %v", len(got), got)
+		}
+		// First entry should be the configured skillsDir
+		want0 := evalRealPath(fakeSkillsDir)
+		if got[0] != want0 {
+			t.Errorf("got[0] = %q, want %q", got[0], want0)
+		}
+		// Second entry should be ~/.agents/skills
+		want1 := evalRealPath(agentsDir)
+		if got[1] != want1 {
+			t.Errorf("got[1] = %q, want %q", got[1], want1)
+		}
+	})
 
-			// If ~/.agents/skills exists, it should be in the result
-			if agentsSkillsExists {
-				found := false
-				for _, d := range got {
-					if d == agentsSkillsAbs {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("expected ~/.agents/skills (%s) to be in result, got %v", agentsSkillsAbs, got)
-				}
-			}
-		})
-	}
+	t.Run("symlink deduplication: skillsDir symlinks to ~/.agents/skills", func(t *testing.T) {
+		agentsDir := homePath(".agents", "skills")
+		os.MkdirAll(agentsDir, 0755)
+		defer os.RemoveAll(agentsDir)
+		// Create a symlink that points to agentsDir
+		symlinkPath := homePath("skills-link")
+		if err := os.Symlink(agentsDir, symlinkPath); err != nil {
+			t.Skipf("symlink not supported on this platform: %v", err)
+		}
+		defer os.Remove(symlinkPath)
+		got := resolveGlobalSkillsDirs(symlinkPath)
+		// Should deduplicate to a single entry because symlink resolves to the same real path
+		if len(got) != 1 {
+			t.Fatalf("expected 1 entry after symlink dedup, got %d: %v", len(got), got)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/agent/skills.go
+++ b/agent/skills.go
@@ -201,10 +201,8 @@ func (s *SkillStore) GetSkillsCatalog(ctx context.Context, senderID string, proj
 	sb.WriteString("When a user's message starts with `/xxxx`, prioritize finding a matching skill name and activate it before processing the request.\n\n")
 
 	// 注入目录路径，供 skill-creator 参考新建位置
-	// Show all global dirs (xbot native + auto-detected Codex/Cursor compatible dirs)
 	if len(s.globalDirs) > 0 {
-		fmt.Fprintf(&sb, "**全局 Skills 目录**: %s\n", strings.Join(s.globalDirs, ", "))
-		fmt.Fprintf(&sb, "（自动识别 ~/.xbot/skills 和 ~/.agents/skills 两个全局目录）\n\n")
+		fmt.Fprintf(&sb, "**全局 Skills 目录**: %s\n\n", strings.Join(s.globalDirs, ", "))
 	}
 	// 注入项目本地目录提示
 	if pDir != "" {
@@ -241,16 +239,23 @@ func (s *SkillStore) scanProjectSkills(projectDir string, existing []SkillInfo) 
 
 	var result []SkillInfo
 
-	// Helper: scan a single skill directory and append new skills
+	// Helper: scan a single skill directory and append new skills.
+	// Uses evalRealPath to resolve symlinks for accurate deduplication.
 	scanDir := func(skillsDir string) {
 		abs, err := filepath.Abs(skillsDir)
 		if err != nil {
 			return
 		}
-		if seenPaths[abs] {
+		// Resolve symlinks for dedup — EvalSymlinks fails on non-existent dirs,
+		// which is fine because ReadDir will also fail on them below.
+		real := abs
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+			real = resolved
+		}
+		if seenPaths[real] {
 			return
 		}
-		seenPaths[abs] = true
+		seenPaths[real] = true
 
 		entries, err := os.ReadDir(abs)
 		if err != nil {

--- a/agent/skills.go
+++ b/agent/skills.go
@@ -201,12 +201,15 @@ func (s *SkillStore) GetSkillsCatalog(ctx context.Context, senderID string, proj
 	sb.WriteString("When a user's message starts with `/xxxx`, prioritize finding a matching skill name and activate it before processing the request.\n\n")
 
 	// 注入目录路径，供 skill-creator 参考新建位置
+	// Show all global dirs (xbot native + auto-detected Codex/Cursor compatible dirs)
 	if len(s.globalDirs) > 0 {
-		fmt.Fprintf(&sb, "**Skills 存储目录**: %s\n\n", s.globalDirs[0])
+		fmt.Fprintf(&sb, "**全局 Skills 目录**: %s\n", strings.Join(s.globalDirs, ", "))
+		fmt.Fprintf(&sb, "（自动识别 ~/.xbot/skills 和 ~/.agents/skills 两个全局目录）\n\n")
 	}
 	// 注入项目本地目录提示
 	if pDir != "" {
-		fmt.Fprintf(&sb, "**项目 Skills 目录**: %s\n\n", filepath.Join(pDir, ".xbot", "skills"))
+		fmt.Fprintf(&sb, "**项目 Skills 目录**: %s 或 %s/.agents/skills（自动向上递归查找）\n\n",
+			filepath.Join(pDir, ".xbot", "skills"), pDir)
 	}
 
 	sb.WriteString("<available_skills>\n")
@@ -221,50 +224,84 @@ func (s *SkillStore) GetSkillsCatalog(ctx context.Context, senderID string, proj
 	return sb.String()
 }
 
-// scanProjectSkills scans {projectDir}/.xbot/skills/ for project-local skills.
-// Returns skills that are NOT already present in the existing list (avoids duplicates).
+// scanProjectSkills scans project-local skills directories and returns skills
+// NOT already present in the existing list (avoids duplicates).
+// It scans two locations:
+//  1. {projectDir}/.xbot/skills/ (native xbot convention)
+//  2. {projectDir}/.agents/skills/ and all parent directories up to root
+//     (Codex/Cursor convention — walks up like git finds .git)
 func (s *SkillStore) scanProjectSkills(projectDir string, existing []SkillInfo) []SkillInfo {
-	projectSkillsDir := filepath.Join(projectDir, ".xbot", "skills")
-	entries, err := os.ReadDir(projectSkillsDir)
-	if err != nil {
-		return nil // directory doesn't exist — not an error
-	}
-
 	// Build set of existing names for dedup
 	existingNames := make(map[string]bool, len(existing))
 	for _, sk := range existing {
 		existingNames[sk.Name] = true
 	}
+	// Track visited dirs to avoid scanning same directory twice
+	seenPaths := make(map[string]bool)
 
 	var result []SkillInfo
-	for _, e := range entries {
-		skillDir := filepath.Join(projectSkillsDir, e.Name())
-		info, err := os.Stat(skillDir)
-		if err != nil || !info.IsDir() {
-			continue
-		}
-		skillFile := filepath.Join(skillDir, "SKILL.md")
-		if _, err := os.Stat(skillFile); err != nil {
-			continue
-		}
-		data, err := os.ReadFile(skillFile)
+
+	// Helper: scan a single skill directory and append new skills
+	scanDir := func(skillsDir string) {
+		abs, err := filepath.Abs(skillsDir)
 		if err != nil {
-			continue
+			return
 		}
-		name, description := parseSkillFrontmatter(data)
-		if name == "" {
-			name = e.Name()
+		if seenPaths[abs] {
+			return
 		}
-		// Skip if already present from global/embedded/user
-		if existingNames[name] {
-			continue
+		seenPaths[abs] = true
+
+		entries, err := os.ReadDir(abs)
+		if err != nil {
+			return // directory doesn't exist — not an error
 		}
-		result = append(result, SkillInfo{
-			Name:        name,
-			Description: description,
-			Path:        skillDir,
-		})
+		for _, e := range entries {
+			skillDir := filepath.Join(abs, e.Name())
+			info, err := os.Stat(skillDir)
+			if err != nil || !info.IsDir() {
+				continue
+			}
+			skillFile := filepath.Join(skillDir, "SKILL.md")
+			if _, err := os.Stat(skillFile); err != nil {
+				continue
+			}
+			data, err := os.ReadFile(skillFile)
+			if err != nil {
+				continue
+			}
+			name, description := parseSkillFrontmatter(data)
+			if name == "" {
+				name = e.Name()
+			}
+			// Skip if already present from global/embedded/user
+			if existingNames[name] {
+				continue
+			}
+			existingNames[name] = true // also dedup across multiple project dirs
+			result = append(result, SkillInfo{
+				Name:        name,
+				Description: description,
+				Path:        skillDir,
+			})
+		}
 	}
+
+	// 1. Scan native xbot project dir: {projectDir}/.xbot/skills
+	scanDir(filepath.Join(projectDir, ".xbot", "skills"))
+
+	// 2. Scan Codex/Cursor-compatible .agents/skills, walking up parent dirs
+	//    (like git walks up to find .git)
+	dir := projectDir
+	for {
+		scanDir(filepath.Join(dir, ".agents", "skills"))
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break // reached root
+		}
+		dir = parent
+	}
+
 	return result
 }
 


### PR DESCRIPTION
## Summary

Add native zero-config support for Codex/Cursor-compatible skill directories. Previously xbot only scanned `~/.xbot/skills/`, requiring manual symlinks to access skills installed by Codex/Cursor under `~/.agents/skills/`.

## Changes

- **`agent/agent.go`**: Extended `resolveGlobalSkillsDirs()` to automatically include `~/.agents/skills/` when the directory exists (with dedup and existence checks)
- **`agent/skills.go`**: Rewrote `scanProjectSkills()` to walk up parent directories (like git finds `.git`) and discover `.agents/skills/` project-local skill directories, in addition to the existing `.xbot/skills/` scan
- **`agent/agent_helpers_test.go`**: Updated test cases to account for new auto-detection behavior

## Features

- 🌍 **Global skills**: Automatically scans `~/.agents/skills/` — Codex/Cursor-compatible global skills load natively without symlinks
- 📁 **Project skills**: Walks up parent directories to find `.agents/skills/`, matching Codex/Cursor conventions
- 🛡️ **Safety**: Only scans existing directories, automatic deduplication, no impact on existing `.xbot/skills/` behavior
- ✅ **All tests pass** (`go test ./agent/...`)