### PR TITLE
fix(tui): stream ChatID mismatch + tool stuck yellow + context bar stale on switch

### DIFF
--- a/agent/engine_run_tools.go
+++ b/agent/engine_run_tools.go
@@ -113,6 +113,18 @@ func (s *runState) execOneTool(ctx context.Context, entry toolCallEntry, batch *
 	batch.results[entry.index] = toolExecResult{err: execErr, result: result, elapsed: elapsed}
 	s.updateToolResultProgress(ctx, entry, batch, result, execErr, elapsed)
 	s.updateToolResultLine(ctx, entry, batch, tc, result, execErr, elapsed)
+	// Notify immediately so the TUI sees the done/error status BEFORE
+	// snapshotCompletedIteration clears ActiveTools and prepareForIteration
+	// starts the next iteration. Without this, for fast tools (e.g. config,
+	// Read), the done status is set but not pushed until the dispatcher's
+	// notifyProgress — which fires synchronously right before snapshot and
+	// next-iteration-thinking. The progressSlot drain goroutine doesn't get
+	// a chance to run between them, so only the final "thinking, everything
+	// cleared" event survives → tool goes from yellow(running) straight to
+	// snapshot, never showing green(done).
+	if s.autoNotify {
+		s.notifyProgress("")
+	}
 }
 
 // updateToolResultProgress updates the structured progress entry for a completed tool.

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -2004,34 +2004,40 @@ func (a *Agent) buildStreamCallbacks(chatID, channel string, progressSeq *atomic
 	progressKey := qualifyChatID(channel, chatID)
 
 	// broadcast pushes to all ProgressSender channels uniformly.
-	broadcastStream := func(content, reasoning string) {
-		for _, s := range senders {
-			s.SendStreamContent(progressKey, content, reasoning)
-		}
-	}
+	// chatID (raw) is the routing key for SendProgress's first parameter.
+	// payload.ChatID (qualified progressKey) is the session identity for
+	// the TUI's handleProgressMsg filter. These are two different semantics —
+	// never mix them.
 	broadcastProgress := func(payload *protocol.ProgressEvent) {
+		if payload.ChatID == "" {
+			payload.ChatID = progressKey
+		}
 		for _, s := range senders {
 			s.SendProgress(chatID, payload)
 		}
 	}
 
-	// No throttle: every callback pushes immediately. Backlog is prevented
-	// by catch-up drain in handleAsyncDrain (coalesces all pending progress
-	// events into one before Send). Throttling caused content truncation:
-	// content callback was skipped (60ms), then unthrottled toolCallFunc
-	// pushed with empty StreamContent → coalescing preserved stale incomplete
-	// content from the last throttled push.
+	// All stream callbacks go through broadcastProgress with a qualified
+	// ChatID. This replaces the old SendStreamContent path which had
+	// inconsistent ChatID qualification across implementations (CLIChannel
+	// used raw, RemoteCLI/Web qualified manually).
 	streamContentFunc = func(content string) {
 		a.updateStreamState(progressKey, func(s *protocol.ProgressEvent) {
 			s.StreamContent = content
 		})
-		broadcastStream(content, "")
+		broadcastProgress(&protocol.ProgressEvent{
+			ChatID:        progressKey,
+			StreamContent: content,
+		})
 	}
 	streamReasoningFunc = func(content string) {
 		a.updateStreamState(progressKey, func(s *protocol.ProgressEvent) {
 			s.ReasoningStreamContent = content
 		})
-		broadcastStream("", content)
+		broadcastProgress(&protocol.ProgressEvent{
+			ChatID:                 progressKey,
+			ReasoningStreamContent: content,
+		})
 	}
 	streamToolCallFunc = func(toolCalls []llm.ToolCallDelta) {
 		tools := make([]protocol.ToolProgress, 0, len(toolCalls))

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -2006,7 +2006,7 @@ func (a *Agent) buildStreamCallbacks(chatID, channel string, progressSeq *atomic
 	// broadcast pushes to all ProgressSender channels uniformly.
 	broadcastStream := func(content, reasoning string) {
 		for _, s := range senders {
-			s.SendStreamContent(chatID, content, reasoning)
+			s.SendStreamContent(progressKey, content, reasoning)
 		}
 	}
 	broadcastProgress := func(payload *protocol.ProgressEvent) {

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -327,10 +327,10 @@ func (a *Agent) wireSubAgentCLIProgress(key, originChatID string, cfg *RunConfig
 		a.lastProgressSnapshot.Store(agentProgressKey, cliPayload)
 	}
 
-	// Wire stream callbacks — capability-based push via ProgressSender interface.
-	// No throttle: catch-up drain in handleAsyncDrain prevents backlog.
-	// Throttling caused content truncation (content callback skipped →
-	// next unthrottled toolCallFunc push carried empty StreamContent).
+	// Wire stream callbacks — unified SendProgress path with qualified ChatID.
+	// No SendStreamContent: all stream events go through SendProgress with
+	// payload.ChatID = agentProgressKey (qualified). This ensures consistent
+	// ChatID semantics across all ProgressSender implementations.
 	cfg.Stream = true
 	var subAgentProgressSeq atomic.Uint64
 	cfg.ProgressSeq = &subAgentProgressSeq
@@ -338,13 +338,19 @@ func (a *Agent) wireSubAgentCLIProgress(key, originChatID string, cfg *RunConfig
 		a.updateStreamState(agentProgressKey, func(s *protocol.ProgressEvent) {
 			s.StreamContent = content
 		})
-		sender.SendStreamContent(agentProgressKey, content, "")
+		sender.SendProgress(key, &protocol.ProgressEvent{
+			ChatID:        agentProgressKey,
+			StreamContent: content,
+		})
 	}
 	cfg.StreamReasoningFunc = func(content string) {
 		a.updateStreamState(agentProgressKey, func(s *protocol.ProgressEvent) {
 			s.ReasoningStreamContent = content
 		})
-		sender.SendStreamContent(agentProgressKey, "", content)
+		sender.SendProgress(key, &protocol.ProgressEvent{
+			ChatID:                 agentProgressKey,
+			ReasoningStreamContent: content,
+		})
 	}
 	cfg.StreamUsageFunc = func(usage *llm.TokenUsage) {
 		if usage == nil || usage.CompletionTokens == 0 {

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -338,13 +338,13 @@ func (a *Agent) wireSubAgentCLIProgress(key, originChatID string, cfg *RunConfig
 		a.updateStreamState(agentProgressKey, func(s *protocol.ProgressEvent) {
 			s.StreamContent = content
 		})
-		sender.SendStreamContent(key, content, "")
+		sender.SendStreamContent(agentProgressKey, content, "")
 	}
 	cfg.StreamReasoningFunc = func(content string) {
 		a.updateStreamState(agentProgressKey, func(s *protocol.ProgressEvent) {
 			s.ReasoningStreamContent = content
 		})
-		sender.SendStreamContent(key, "", content)
+		sender.SendStreamContent(agentProgressKey, "", content)
 	}
 	cfg.StreamUsageFunc = func(usage *llm.TokenUsage) {
 		if usage == nil || usage.CompletionTokens == 0 {

--- a/channel/cli/cli_agent_msg.go
+++ b/channel/cli/cli_agent_msg.go
@@ -174,11 +174,15 @@ func (m *cliModel) handleAgentMessage(msg ch.OutboundMsg) {
 						finalTools = append(finalTools, t)
 					}
 				}
+				// Include ALL active tools — turn is ending, so running/pending
+				// tools have completed. Mark them as done (done event may have
+				// been lost in progressSlot coalescing).
 				for _, t := range m.progressState.current.ActiveTools {
-					if t.Status == "done" || t.Status == "error" {
-						if (t.Iteration == 0 || t.Iteration == iterNum) && !containsToolProgress(finalTools, t) {
-							finalTools = append(finalTools, t)
-						}
+					if t.Status == "running" || t.Status == "pending" || t.Status == "" {
+						t.Status = "done"
+					}
+					if (t.Iteration == 0 || t.Iteration == iterNum) && !containsToolProgress(finalTools, t) {
+						finalTools = append(finalTools, t)
 					}
 				}
 				reasoning := m.progressState.current.Reasoning

--- a/channel/cli/cli_model_session.go
+++ b/channel/cli/cli_model_session.go
@@ -455,73 +455,56 @@ func (m *cliModel) postRestoreSessionSetup() []tea.Cmd {
 	m.splashState.compReloading = false
 
 	// ── Session LLM state restoration ──────────────────────────
-	// Only when in-memory caches are empty (new session or TUI restart).
-	// Uses unified LoadSessionLLMState + applySessionLLMState to ensure
-	// activeSubID, cachedModelName, cachedMaxContextTokens, cachedMaxOutputTokens
-	// are ALWAYS consistent. No scattered field-by-field assignments.
-	if m.activeSubID == "" && m.cachedModelName == "" {
-		// Agent sessions: skip default subscription fallback — the model name,
-		// context limits, and token usage come from the SubAgent's config via
-		// handleSuHistoryLoad (AgentSessionLLMStateFn). Setting the default
-		// subscription here would show the parent agent's model name instead.
-		if m.channelName == "agent" {
-			// No-op: model name will be populated by handleSuHistoryLoad
-		} else {
-			state := LoadSessionLLMState(m.workDir, m.chatID)
-			if !state.IsZero() {
-				// Found persisted LLM state on disk — apply to caches atomically
-				m.applySessionLLMState(state)
-				// Refresh values cache so GetCurrentValues() reflects the session's
-				// per-session subscription, not the previous session's or the startup default.
-				if m.channel != nil && m.channel.config.RefreshValuesCache != nil && state.SubscriptionID != "" {
-					m.channel.config.RefreshValuesCache(state.SubscriptionID)
-				}
-				// Restore the actual LLM client via SwitchLLM (creates new client)
-				if state.SubscriptionID != "" && m.subscriptionMgr != nil {
-					if subs, err := m.subscriptionMgr.List(""); err == nil {
-						for i := range subs {
-							if subs[i].ID == state.SubscriptionID {
-								if m.channel != nil && m.channel.config.SwitchLLM != nil {
-									switchFn := m.channel.config.SwitchLLM
-									target := subs[i]
-									m.pendingCmds = append(m.pendingCmds, func() tea.Msg {
-										err := switchFn(target.Provider, target.BaseURL, target.APIKey, target.Model)
-										return cliSwitchLLMDoneMsg{
-											err:       err,
-											subID:     target.ID,
-											subName:   target.Name,
-											subModel:  target.Model,
-											maxCtx:    resolveSubMaxContext(&target),
-											maxOutTok: resolveSubMaxOutputTokens(&target),
-											mgr:       m.subscriptionMgr,
-										}
-									})
-								}
-								break
+	// ALWAYS re-resolve from DB on session switch. The in-memory savedSessions
+	// cache may have stale max_context values (user changed per-model config
+	// in another window, or session was never visited before). DB is authoritative.
+	// Agent sessions are excluded — their LLM state comes from handleSuHistoryLoad.
+	if m.channelName != "agent" {
+		state := LoadSessionLLMState(m.workDir, m.chatID)
+		if !state.IsZero() {
+			m.applySessionLLMState(state)
+			if m.channel != nil && m.channel.config.RefreshValuesCache != nil && state.SubscriptionID != "" {
+				m.channel.config.RefreshValuesCache(state.SubscriptionID)
+			}
+			if state.SubscriptionID != "" && m.subscriptionMgr != nil {
+				if subs, err := m.subscriptionMgr.List(""); err == nil {
+					for i := range subs {
+						if subs[i].ID == state.SubscriptionID {
+							if m.channel != nil && m.channel.config.SwitchLLM != nil {
+								switchFn := m.channel.config.SwitchLLM
+								target := subs[i]
+								m.pendingCmds = append(m.pendingCmds, func() tea.Msg {
+									err := switchFn(target.Provider, target.BaseURL, target.APIKey, target.Model)
+									return cliSwitchLLMDoneMsg{
+										err:       err,
+										subID:     target.ID,
+										subName:   target.Name,
+										subModel:  target.Model,
+										maxCtx:    resolveSubMaxContext(&target),
+										maxOutTok: resolveSubMaxOutputTokens(&target),
+										mgr:       m.subscriptionMgr,
+									}
+								})
 							}
+							break
 						}
 					}
 				}
-			} else {
-				// No per-session override on disk — load global default subscription
-				if m.subscriptionMgr != nil {
-					if defSub, err := m.subscriptionMgr.GetDefault(""); err == nil && defSub != nil {
-						m.activeSubID = defSub.ID
-						m.cachedModelName = defSub.Model
-						m.cachedMaxContextTokens = resolveSubMaxContext(defSub)
-						m.cachedMaxOutputTokens = int64(resolveSubMaxOutputTokens(defSub))
-					}
+			}
+		} else {
+			if m.subscriptionMgr != nil {
+				if defSub, err := m.subscriptionMgr.GetDefault(""); err == nil && defSub != nil {
+					m.activeSubID = defSub.ID
+					m.cachedModelName = defSub.Model
+					m.cachedMaxContextTokens = resolveSubMaxContext(defSub)
+					m.cachedMaxOutputTokens = int64(resolveSubMaxOutputTokens(defSub))
 				}
-				// Resolve cachedMaxContextTokens if still zero (e.g. default sub
-				// had no per-model config and resolveSubMaxContext returned 0).
-				// Without this, the context bar stays as a white line until
-				// the first progress event triggers the lazy resolve.
-				if m.cachedMaxContextTokens == 0 {
-					m.cachedMaxContextTokens = m.resolveMaxContextTokens()
-				}
-				if m.cachedMaxOutputTokens == 0 {
-					m.cachedMaxOutputTokens = m.resolveMaxOutputTokens()
-				}
+			}
+			if m.cachedMaxContextTokens == 0 {
+				m.cachedMaxContextTokens = m.resolveMaxContextTokens()
+			}
+			if m.cachedMaxOutputTokens == 0 {
+				m.cachedMaxOutputTokens = m.resolveMaxOutputTokens()
 			}
 		}
 	}

--- a/channel/cli/cli_pull.go
+++ b/channel/cli/cli_pull.go
@@ -185,10 +185,19 @@ func (m *cliModel) snapshotIterationLocal(prev *protocol.ProgressEvent) {
 			return
 		}
 	}
-	tools := prev.CompletedTools
-	// Include ALL active tools — when iteration changes, active tools
-	// belong to the completed iteration (engine transitions them to done).
-	tools = append(tools, prev.ActiveTools...)
+	// When we snapshot an iteration, it means the iteration has ENDED.
+	// All tools that were "running" or "pending" have completed — the done
+	// event may have been lost in progressSlot coalescing (drain goroutine
+	// didn't wake between the done push and the next-iteration thinking push).
+	// Mark them as "done" — otherwise they stay yellow forever in the history.
+	tools := make([]protocol.ToolProgress, 0, len(prev.CompletedTools)+len(prev.ActiveTools))
+	tools = append(tools, prev.CompletedTools...)
+	for _, t := range prev.ActiveTools {
+		if t.Status == "running" || t.Status == "pending" || t.Status == "" {
+			t.Status = "done"
+		}
+		tools = append(tools, t)
+	}
 	reasoning := prev.Reasoning
 	if reasoning == "" {
 		reasoning = prev.ReasoningStreamContent
@@ -304,10 +313,14 @@ func (m *cliModel) finalizeTurnFromSnapshot(snapshot *protocol.ProgressEvent) {
 			finalTools := snapshot.CompletedTools
 			if len(finalTools) == 0 && cur != nil {
 				finalTools = cur.CompletedTools
+				// Include ALL active tools — the iteration is ending, so all
+				// running/pending tools have completed. Mark them as done
+				// (the done event may have been lost in progressSlot coalescing).
 				for _, t := range cur.ActiveTools {
-					if t.Status == "done" || t.Status == "error" {
-						finalTools = append(finalTools, t)
+					if t.Status == "running" || t.Status == "pending" || t.Status == "" {
+						t.Status = "done"
 					}
+					finalTools = append(finalTools, t)
 				}
 			}
 			// Filter by iteration to prevent cross-iteration tool contamination.

--- a/channel/cli/cli_regression_test.go
+++ b/channel/cli/cli_regression_test.go
@@ -395,3 +395,49 @@ func TestRegression_CoalesceDropsContentOnToolEvent(t *testing.T) {
 		t.Errorf("StreamingTools lost: got %d tools", len(merged.payload.StreamingTools))
 	}
 }
+
+// ── Bug: stream content events have unqualified ChatID → TUI discards ──
+// Root cause: SendStreamContent implementations had inconsistent ChatID
+// qualification. Stream callbacks now go through SendProgress with
+// qualified payload.ChatID — this test verifies the TUI accepts them.
+func TestRegression_StreamContentChatIDQualified(t *testing.T) {
+	model := initTestModel()
+	model.startAgentTurn()
+
+	// Stream content event with QUALIFIED ChatID (what stream callbacks now send)
+	sendProgress(model, &protocol.ProgressEvent{
+		ChatID:        "cli:/test",
+		StreamContent: "content via qualified ChatID",
+	})
+
+	if model.progressState.current == nil {
+		t.Fatal("stream content event with qualified ChatID was discarded by session filter")
+	}
+	if model.progressState.current.StreamContent != "content via qualified ChatID" {
+		t.Errorf("StreamContent not applied: got %q",
+			model.progressState.current.StreamContent)
+	}
+}
+
+// ── Bug: raw ChatID stream event must be rejected by session filter ──
+// This is the negative test — verifies that unqualified ChatID events
+// are still filtered out (the original bug scenario).
+func TestRegression_RawChatIDStreamEventRejected(t *testing.T) {
+	model := initTestModel()
+	model.startAgentTurn()
+	// initTestModel sets chatID="/test", channelName="cli"
+	// currentKey = "cli:/test"
+
+	// Send event with RAW ChatID (the old bug)
+	model.handleProgressMsg(cliProgressMsg{
+		payload: &protocol.ProgressEvent{
+			ChatID:        "/test", // raw, unqualified
+			StreamContent: "should be rejected",
+		},
+	})
+
+	if model.progressState.current != nil &&
+		model.progressState.current.StreamContent == "should be rejected" {
+		t.Error("raw ChatID event was accepted — session filter broken")
+	}
+}

--- a/channel/cli/cli_regression_test.go
+++ b/channel/cli/cli_regression_test.go
@@ -441,3 +441,52 @@ func TestRegression_RawChatIDStreamEventRejected(t *testing.T) {
 		t.Error("raw ChatID event was accepted — session filter broken")
 	}
 }
+
+// ── Bug: tool stays yellow (running) forever in iteration history ──
+// Root cause: when done event is lost in progressSlot coalescing (drain
+// goroutine doesn't wake between done push and next-iteration thinking
+// push), snapshotIterationLocal captured the tool with Status="running"
+// in the iteration snapshot → stays yellow forever.
+//
+// Fix: when snapshotting an iteration, mark all running/pending tools
+// as "done". An iteration snapshot means the iteration has ended —
+// any tool that was running has completed.
+func TestRegression_ToolStuckRunningInSnapshot(t *testing.T) {
+	model := initTestModel()
+	model.startAgentTurn()
+
+	// Iteration 0: tool running (done event was lost)
+	sendProgress(model, &protocol.ProgressEvent{
+		ChatID:      "cli:/test",
+		Seq:         1,
+		Phase:       "tool_exec",
+		Iteration:   0,
+		ActiveTools: []protocol.ToolProgress{{Name: "config", Status: "running", Iteration: 0}},
+	})
+
+	// Iteration changes to 1 (thinking) — done event was lost
+	sendProgress(model, &protocol.ProgressEvent{
+		ChatID:    "cli:/test",
+		Seq:       2,
+		Phase:     "thinking",
+		Iteration: 1,
+	})
+
+	// Check iteration 0 snapshot — tool must NOT be "running"
+	if len(model.progressState.iterations) == 0 {
+		t.Fatal("no iteration snapshot created")
+	}
+	iter0 := model.progressState.iterations[0]
+	if iter0.Iteration != 0 {
+		t.Fatalf("expected iteration 0, got %d", iter0.Iteration)
+	}
+	if len(iter0.Tools) == 0 {
+		t.Fatal("no tools in iteration 0 snapshot")
+	}
+	for _, tool := range iter0.Tools {
+		if tool.Status == "running" || tool.Status == "pending" {
+			t.Errorf("tool %q stuck as %q in snapshot — should be done",
+				tool.Name, tool.Status)
+		}
+	}
+}


### PR DESCRIPTION
## 3 个 TUI bug 修复

### 1. Stream content 在 tool generating 阶段显示不全

**根因**：`SendStreamContent` 各实现处理 ChatID 限定不一致——CLIChannel 用 raw，RemoteCLI/Web 手动限定。stream content 事件成为 progressSlot 后被 TUI session filter 丢弃。

**修复**：stream 回调统一走 `SendProgress`，payload 内设限定 ChatID。

### 2. Tool 完成后保持黄色（running）不变成绿色（done）

**根因**：done 事件在 progressSlot coalescing 中丢失（drain goroutine 来不及醒来），`snapshotIterationLocal` 捕获了 `Status="running"` 的工具到迭代历史 → 永久黄色。

**修复**：迭代快照时，所有 running/pending 工具标记为 done。迭代快照意味着迭代已结束——工具必然已完成。

### 3. Session 切换后 context usage bar 显示旧 session 的 max_context

**根因**：`postRestoreSessionSetup` 只在 `activeSubID == ""` 时从 DB 重新解析 LLM 状态。但 `restoreSession()` 从内存 savedSessions 恢复了 activeSubID → 条件不满足 → 跳过 DB 解析 → `cachedMaxContextTokens` 保持旧值。

**修复**：去掉条件判断，每次 session 切换都从 DB 重新解析。

## 测试

- 全部现有测试通过
- 3 个新回归测试：
  - `StreamContentChatIDQualified` + `RawChatIDStreamEventRejected`
  - `ToolStuckRunningInSnapshot`